### PR TITLE
Alphabetized and updated indexes

### DIFF
--- a/codes/index
+++ b/codes/index
@@ -1,3420 +1,3410 @@
-DSE/Unknown_G7659/0,-1.csv
-DSE/Unknown_G1605/5,-1.csv
-DSE/Unknown_G1928/0,-1.csv
-Salora/Unknown_SV6700/49,-1.csv
-AudioSource/Unknown_SS-Three/6,1.csv
-DLO/HomeDock/238,135.csv
-Norcent/Unknown_DP/0,-1.csv
-Telemann/PC HDTV Tuner Card/8,-1.csv
-Colorado Vnet/Music Server/110,146.csv
-Austar/Cable Box/32,224.csv
-Microsoft/Unknown_MCE/5,-1.csv
-Microsoft/DVD Player/5,-1.csv
-Microsoft/Unknown_XboxDVDDongle/None,None.csv
-Microsoft/Unknown_xbox/10,-1.csv
-Microsoft/Windows Media Center/4,15.csv
-Microsoft/Unknown_Xbox360/116,15.csv
-Microsoft/Game Console/5,-1.csv
-Microsoft/Game Console/116,15.csv
-Microsoft/Game Console/4,15.csv
-Microsoft/Home Media PC/4,15.csv
-Govideo/Unknown_GoVideoD2730/8,230.csv
-Kinergetics Research/Receiver/0,-1.csv
-Kinergetics Research/Surround Processor/7,-1.csv
-Kinergetics Research/Pre-Amplifier/28,-1.csv
-DK Digital/Unknown_Digital/0,-1.csv
-Russound/Music Server/10,-1.csv
-Cables to Go/VGA Switcher/0,191.csv
-Hirschmann/Satellite/32,255.csv
-Hirschmann/Unknown_RC426/54,-1.csv
-Creek/Line_Volume Control/16,-1.csv
-Foxtel/Unknown_Digital/0,0.csv
-Foxtel/Unknown_foxtel/33,160.csv
-Foxtel/Set Top Box/33,160.csv
-Radix/Unknown_DT-X1/0,127.csv
-Radix/Unknown_radix/138,245.csv
-Radix/Unknown_SAT/138,245.csv
-Radix/Unknown_DTR-9000-Twin/0,127.csv
-Radix/Unknown_lircd.conf/0,127.csv
-Radix/Unknown_Alpha/138,245.csv
-Marantz/Receiver/4,-1.csv
-Marantz/Receiver/39,-1.csv
-Marantz/Receiver/6,-1.csv
-Marantz/Receiver/23,-1.csv
-Marantz/Receiver/176,-1.csv
-Marantz/Receiver/12,-1.csv
-Marantz/Receiver/17,-1.csv
-Marantz/Receiver/5,-1.csv
-Marantz/Receiver/20,-1.csv
-Marantz/Receiver/7,-1.csv
-Marantz/Receiver/16,-1.csv
-Marantz/Receiver/21,-1.csv
-Marantz/Receiver/0,-1.csv
-Marantz/Receiver/26,-1.csv
-Marantz/Receiver/18,-1.csv
-Marantz/Receiver/8,-1.csv
-Marantz/Unknown_Marantz-RC-63CD/20,-1.csv
-Marantz/Unknown_RC-65CD/20,-1.csv
-Marantz/DVD Player/4,-1.csv
-Marantz/DVD Player/41,-1.csv
-Marantz/DVD Player/69,-1.csv
-Marantz/DVD Player/20,-1.csv
-Marantz/Unknown_RC1400-MD/255,255.csv
-Marantz/DVD/4,-1.csv
-Marantz/DVD/69,-1.csv
-Marantz/Video Projector/0,-1.csv
-Marantz/Video Projector/13,-1.csv
-Marantz/Unknown_RC-72CD/20,-1.csv
-Marantz/MP3 Player/14,-1.csv
-Marantz/MP3 Player/16,-1.csv
-Marantz/Projector/0,-1.csv
-Marantz/VCR/23,-1.csv
-Marantz/VCR/134,97.csv
-Marantz/VCR/5,-1.csv
-Marantz/Unknown_RC-1400/4,-1.csv
-Marantz/iPod Dock/14,-1.csv
-Marantz/iPod Dock/16,-1.csv
-Marantz/Amplifier/23,-1.csv
-Marantz/Amplifier/17,-1.csv
-Marantz/Amplifier/20,-1.csv
-Marantz/Amplifier/16,-1.csv
-Marantz/Amplifier/21,-1.csv
-Marantz/Amplifier/26,-1.csv
-Marantz/Amplifier/18,-1.csv
-Marantz/Unknown_RC4300CC/20,-1.csv
-Marantz/CD Player/20,-1.csv
-Marantz/Unknown_RC4000CD/20,-1.csv
-Marantz/Plasma Displays/24,-1.csv
-Marantz/Plasma Displays/24,24.csv
-Marantz/Cassette Tape/23,-1.csv
-Marantz/Cassette Tape/18,-1.csv
-Marantz/Tuner Section/17,-1.csv
-Marantz/CD Changer/20,-1.csv
-Marantz/Unknown_rc/4,-1.csv
-Marantz/AM-FM Tuner/17,-1.csv
-Marantz/AM-FM Tuner/16,-1.csv
-Marantz/Plasma/24,-1.csv
-Marantz/Plasma/80,-1.csv
-Marantz/Plasma/24,247.csv
-Marantz/Plasma/24,24.csv
-Marantz/Plasma/0,-1.csv
-Marantz/CD Jukebox/20,-1.csv
-Marantz/TV/144,0.csv
-Marantz/TV/24,-1.csv
-Marantz/TV/80,-1.csv
-Marantz/TV/24,247.csv
-Marantz/TV/24,24.csv
-Marantz/TV/0,-1.csv
-Marantz/Pre-Amplifier/23,-1.csv
-Marantz/Pre-Amplifier/17,-1.csv
-Marantz/Pre-Amplifier/11,-1.csv
-Marantz/Pre-Amplifier/0,-1.csv
-Marantz/Tuner/17,-1.csv
-Marantz/Tuner/20,-1.csv
-Marantz/Tuner/16,-1.csv
-Marantz/D-VHS/3,-1.csv
-Marantz/D-VHS/67,-1.csv
-Amstrad/Unknown_DX3070/0,-1.csv
-Amstrad/Unknown_srd650/128,105.csv
-Amstrad/Unknown_SRX340/128,105.csv
-Amstrad/Twin Receiver/128,105.csv
-Lumagen/Scaler/2,-1.csv
-AIM/RADIO/129,129.csv
-AIM/MCE_AIM-RC126/4,15.csv
-Elitron/Unknown_utk/7,-1.csv
-Phonotrend/Unknown_Prestige/4,-1.csv
-Aconatic/Unknown_AN-2121/2,-1.csv
-Curtis Mathes/VCR/144,1.csv
-Curtis Mathes/VCR/144,0.csv
-Epson/Unknown_ELPST12/131,85.csv
-Epson/Unknown_12807990/131,85.csv
-Epson/Video Projector/131,85.csv
-Epson/Projector/131,85.csv
-L+S/Unknown_30755/5,-1.csv
-L+S/Unknown_LS/164,164.csv
-Fortec/Unknown_Lifetime/32,-1.csv
-Fortec/Unknown_Mercury2/1,253.csv
-Melectronic/Unknown_PP3600/2,-1.csv
-PixelView/Unknown_2000/63,-1.csv
-PixelView/Unknown_PlayTV/134,107.csv
-Sky/Unknown_rev.4/0,0.csv
-Sky/Unknown_DVB-S/0,12.csv
-ADA/Millenium/27,-1.csv
-MGA/VCR/87,-1.csv
-Gradiente/Unknown_GSD-100/132,60.csv
-Gradiente/Unknown_D-10/5,-1.csv
-Fujtech/Unknown_DVB-T/3,-1.csv
-Multichoice/Unknown_DSD910/24,-1.csv
-Grundig/Satellite/2,-1.csv
-Grundig/Satellite/1,-1.csv
-Grundig/Satellite/8,-1.csv
-Grundig/Unknown_CDM700.cfg/162,162.csv
-Grundig/Unknown_RC8400CD/20,-1.csv
-Grundig/Unknown_84D/128,-1.csv
-Grundig/Unknown_Grundig-TP660/0,-1.csv
-Grundig/Unknown_UMS9V/162,162.csv
-Grundig/Unknown_Grundig/None,None.csv
-Grundig/Unknown_TP/0,-1.csv
-Grundig/Unknown_2500S/10,-1.csv
-Grundig/Video Recorder/127,-1.csv
-Grundig/Unknown_RP/5,-1.csv
-Grundig/Unknown_rp700/5,-1.csv
-Grundig/Unknown_tp621/1,-1.csv
-Grundig/Unknown_TP-750C/0,-1.csv
-Grundig/Unknown_RC-TP3/8,-1.csv
-Grundig/Unknown_RP25/None,None.csv
-Grundig/TV/0,-1.csv
-Dream Vision/DLP Projector/135,78.csv
-Electrocompaniet/Integrated Amplifier/16,-1.csv
-Electrocompaniet/CD Player/20,-1.csv
-Fujitsu/Monitor/132,139.csv
-Fujitsu/Monitor/132,138.csv
-Fujitsu/Monitor/132,140.csv
-Fujitsu/Monitor/132,-1.csv
-Fujitsu/Plasma/132,139.csv
-Fujitsu/Plasma/132,134.csv
-Fujitsu/Plasma/140,132.csv
-Fujitsu/Plasma/132,138.csv
-Fujitsu/Plasma/132,140.csv
-Fujitsu/Plasma/132,-1.csv
-Fujitsu/Plasma/132,129.csv
-Fujitsu/Plasma/132,141.csv
-Fujitsu/Plasma/132,130.csv
-Fujitsu/Plasma/132,136.csv
-Fujitsu/Unknown_CP300375-01/4,15.csv
-Fujitsu/TV/132,-1.csv
-WD/Unknown_TV/132,121.csv
-WD/Unknown_HDTVMediaPlayerV1/132,121.csv
-Lenovo/Unknown_Y530/4,69.csv
+2wire/Unknown_2wire/32,159.csv
+3M/Projector/134,-1.csv
+3M/Video Projector/134,-1.csv
+ABIT/DVD_WINDVD/1,-1.csv
+ABS/SAT_8776/8,0.csv
+AccessHD/CONVERTER_DTA1080U/0,191.csv
 AccessMedia/ThinBox/31,-1.csv
-Provideo/Unknown_PV951/134,107.csv
-Sherwood/Receiver/131,69.csv
-Sherwood/Unknown_Sherwood-S2770R-CP-II/129,123.csv
-Sherwood/Unknown_CD/255,255.csv
-Sherwood/Unknown_GC-1285/129,114.csv
-Sherwood/Unknown_GC-1285/255,255.csv
-Sherwood/Unknown_RM-636/131,68.csv
-Sherwood/Unknown_RM-RV-N25/131,68.csv
-Sherwood/Unknown_RM-101/69,131.csv
-Sherwood/Unknown_sherwood/129,122.csv
-Sherwood/Unknown_sherwood/131,69.csv
-Streamzap/Unknown_PC/35,-1.csv
-UEC/Unknown_DVB/24,-1.csv
-Viewsat/Unknown_VS2000/32,255.csv
-Viewsat/Unknown_SAT/32,255.csv
-NAD/Receiver/135,124.csv
-NAD/Monitor/64,-1.csv
-NAD/Surround Processor/93,-1.csv
-NAD/Surround Processor/135,124.csv
-NAD/Unknown_NAD/17,-1.csv
-NAD/Unknown_451/135,124.csv
-NAD/Amplifier/135,124.csv
-NAD/Unknown_SR712/135,124.csv
-NAD/CD Player/133,111.csv
-NAD/CD Player/42,-1.csv
-NAD/CD Player/135,124.csv
-NAD/Unknown_SR6/135,124.csv
-NAD/Unknown/135,124.csv
-NAD/Cassette Tape/135,124.csv
-NAD/Receiver_CD/135,124.csv
-NAD/Tuner/135,124.csv
-NAD/Unknown_RC512/135,124.csv
-ione/Unknown_remote/0,-1.csv
-Acesonic/Karaoke/77,-1.csv
+Accupel/Signal Generator/0,-1.csv
+Acer/Projector/8,19.csv
+Acer/Unknown_Aspire/4,15.csv
+Acer/Unknown_AT3201W/97,99.csv
+Acer/Unknown_RC-802/16,37.csv
 Acesonic/Karaoke/5,122.csv
-Pragmatic/Router/172,-1.csv
-ANITECH/TV/0,-1.csv
-Linn/Surround Processor/4,-1.csv
-Linn/Surround Processor/23,-1.csv
-Linn/Surround Processor/16,-1.csv
-Linn/CD Player/20,-1.csv
-Linn/Classic music/17,-1.csv
-Linn/Classic music/20,-1.csv
-Linn/Classic music/16,-1.csv
-ST/Unknown_DTTRC-4/1,-1.csv
-ST/Unknown_HMP/8,-1.csv
-General Instrument/Satellite/130,110.csv
-General Instrument/Satellite/1,-1.csv
-General Instrument/Cable Box/144,0.csv
-General Instrument/Cable Box/87,-1.csv
-General Instrument/Cable Box/122,-1.csv
-General Instrument/Cable Box/1,-1.csv
-General Instrument/Cable Box/15,-1.csv
-General Instrument/Cable Box/0,-1.csv
-General Instrument/Cable Box/64,-1.csv
-Panasonic/Unknown_EUR7617010/176,0.csv
-Panasonic/Unknown_VEQ1309/144,0.csv
-Panasonic/Receiver/160,4.csv
-Panasonic/Receiver/160,28.csv
-Panasonic/Receiver/160,0.csv
-Panasonic/Unknown_Panasonic-RAK-RX314W/160,194.csv
-Panasonic/Unknown_EUR7621010/176,0.csv
-Panasonic/Unknown_EUR7914Z20/128,72.csv
-Panasonic/Unknown_PANASONIC/0,-1.csv
-Panasonic/Unknown_PANASONIC/176,0.csv
-Panasonic/Unknown_RAK-RX309W/160,194.csv
-Panasonic/Unknown_TV/0,-1.csv
-Panasonic/Unknown_VEQ0910/144,0.csv
-Panasonic/DVD Player/160,4.csv
-Panasonic/DVD Player/128,0.csv
-Panasonic/DVD Player/160,16.csv
-Panasonic/DVD Player/160,28.csv
-Panasonic/DVD Player/160,18.csv
-Panasonic/DVD Player/160,0.csv
-Panasonic/DVD Player/176,0.csv
-Panasonic/DVD Player/160,34.csv
-Panasonic/Unknown_Panasonic-EUR571100/144,0.csv
-Panasonic/Unknown_EUR7631010/176,0.csv
-Panasonic/Unknown_vi/2,32.csv
-Panasonic/Laser Disc/144,64.csv
-Panasonic/Unknown_NV-F65/144,0.csv
-Panasonic/Unknown_VEQ2380/176,0.csv
-Panasonic/Unknown_EUR57510/144,0.csv
-Panasonic/Unknown_veq2249/176,0.csv
-Panasonic/Unknown_VEQ1697/112,8.csv
-Panasonic/Unknown_CARC60EX/129,106.csv
-Panasonic/Unknown_AMP/2,32.csv
-Panasonic/Unknown_N2QADC000006/128,72.csv
-Panasonic/Unknown_RC4346-01B/0,-1.csv
-Panasonic/VCR/144,1.csv
-Panasonic/VCR/144,0.csv
-Panasonic/VCR/144,5.csv
-Panasonic/VCR/2,-1.csv
-Panasonic/Unknown_N2QAYB000064/128,72.csv
-Panasonic/HDTV Tuner/128,2.csv
-Panasonic/Unknown_RX-ED70/160,194.csv
-Panasonic/Unknown_VSQS0531/2,-1.csv
-Panasonic/Unknown_N2QAHB0048/160,194.csv
-Panasonic/Unknown_panasonic.conf/144,0.csv
-Panasonic/Unknown_DSS/2,32.csv
-Panasonic/Unknown_panasonic-RAX-RX318W/160,194.csv
-Panasonic/Unknown_EUR642195/160,194.csv
-Panasonic/Unknown_VCR/144,1.csv
-Panasonic/Unknown_VCR/2,32.csv
-Panasonic/Plasma/128,0.csv
-Panasonic/Plasma/128,4.csv
-Panasonic/Unknown_DVD/2,32.csv
-Panasonic/Unknown_panas928/160,194.csv
-Panasonic/Unknown_EUR643820/160,194.csv
-Panasonic/TV/128,0.csv
-Panasonic/TV/128,4.csv
-Panasonic/Unknown_EUR642162/160,194.csv
-Panasonic/Unknown_EUR643826/160,194.csv
-Panasonic/Unknown_cd/160,194.csv
-Samy/Unknown_SDX1100/8,230.csv
-Samsung/Unknown_MF59/0,-1.csv
-Samsung/Unknown_SMT-1000T/64,64.csv
-Samsung/Unknown_VXK-336/5,5.csv
-Samsung/Unknown_BN59-00869A/7,7.csv
-Samsung/Unknown_TV/7,7.csv
-Samsung/Unknown_00092M/102,0.csv
-Samsung/Unknown_MF59-00291a/32,0.csv
-Samsung/Unknown_HLN507W/7,7.csv
-Samsung/Unknown_BN59-00538A/7,7.csv
-Samsung/Unknown_00104J/7,7.csv
-Samsung/Unknown_AA59-00332D/7,7.csv
-Samsung/Unknown_BN59-00634A/9,9.csv
-Samsung/Unknown_10107N/0,-1.csv
-Samsung/Unknown_BN59-00856A/7,7.csv
-Samsung/Unknown_SMT-H3050/27,-1.csv
-Samsung/Unknown_SV-DVD3E/5,5.csv
-Samsung/Unknown_BN59-00861A/7,7.csv
-Samsung/Unknown_AA59-00600A/7,7.csv
-Samsung/Unknown_10116A/0,-1.csv
-Samsung/Unknown_00225A/7,7.csv
-Samsung/Unknown_528Z/2,-1.csv
-Samsung/Unknown_00077A/7,7.csv
-Samsung/Unknown_test/0,-1.csv
-Samsung/VCR/5,5.csv
-Samsung/VCR/2,2.csv
-Samsung/Unknown_AH59-01527F/67,83.csv
-Samsung/Unknown_SAT/21,-1.csv
-Samsung/Unknown_BN59-00609A/7,7.csv
-Samsung/Unknown_BN59-00865A/7,7.csv
-Samsung/Unknown_hifi/0,1.csv
-Samsung/Unknown_PR3914/5,5.csv
-Samsung/Unknown_AA64-50236A/7,7.csv
-Samsung/Rear Projection DLP TV/7,7.csv
-Samsung/Unknown_BN59-00507A/7,7.csv
-Samsung/Unknown_SFT-702E/64,-1.csv
-Samsung/Unknown_BN59-00603A/7,7.csv
-Samsung/Unknown_AA59-10026E/5,5.csv
-Samsung/Unknown_SV-610X/5,5.csv
-Samsung/Unknown_00011k/102,0.csv
-Samsung/Unknown_00054d/102,0.csv
-Samsung/Unknown_SV-411X/5,5.csv
-Samsung/Unknown_BN59-00683A/7,7.csv
-Samsung/Unknown_AA59-00316b/7,7.csv
-Samsung/Unknown_SAMSUNG/7,7.csv
-Samsung/Unknown_SAMSUNG/5,5.csv
-Samsung/Unknown_SAMSUNG/102,0.csv
-Samsung/Unknown_01043A/102,0.csv
-Samsung/Unknown_BN59-00940A/7,7.csv
-Samsung/Unknown_samsung-10095T/7,7.csv
-Samsung/Unknown_RCD-M70/0,4.csv
-Samsung/Unknown_00056A/102,0.csv
-Samsung/Unknown_BRM-E1E/33,33.csv
-Samsung/Air Conditioner/1,8.csv
-Samsung/Unknown_MF59-00242B/9,9.csv
-Samsung/Unknown_BN59-00685A/7,7.csv
-Samsung/Unknown_00104K/7,7.csv
-Samsung/Unknown_AH59-02345A/7,7.csv
-Samsung/Unknown_VCR/5,5.csv
-Samsung/Unknown_AA59-00370A/7,7.csv
-Samsung/Unknown_00021c/5,5.csv
-Samsung/Unknown_AA59-00382A/7,7.csv
-Samsung/Unknown_00198f/7,7.csv
-Samsung/Unknown_BN59-00678A/7,7.csv
-Samsung/Unknown_SV-651B/5,5.csv
-Samsung/Unknown_10420A/5,5.csv
-Samsung/TV/7,7.csv
-Samsung/Unknown_AH59-00043E/67,83.csv
-Samsung/Unknown_00092b/102,0.csv
-Samsung/Unknown_ARH-700/1,8.csv
-GE/VCR_VKFS0938/14,-1.csv
-GE/VCR/14,-1.csv
-GE/VCR/11,-1.csv
-GE/VCR/26,73.csv
-GE/TV/15,-1.csv
-Sencor/Unknown_SFN9011SL/0,252.csv
-Antex Electronics/Satellite Radio/26,-1.csv
+Acesonic/Karaoke/77,-1.csv
+Aconatic/Unknown_AN-2121/2,-1.csv
+Acorp/Unknown_Acorp-878/134,107.csv
+ADA/Millenium/27,-1.csv
+ADB/SAT_ICAN3000/8,0.csv
+ADB/Set Top Box/42,17.csv
+Adcom/AV Preamplifier/26,-1.csv
+Adcom/CD Player/26,-1.csv
+Adcom/Pre-Amplifier/232,26.csv
+Adcom/Pre-Amplifier/26,-1.csv
+Adcom/Pre-Amplifier/26,232.csv
+Adcom/Pre-Amplifier/81,0.csv
+Adcom/Pre-Amplifier/88,23.csv
+Adcom/Receiver/26,-1.csv
+Adcom/Receiver/26,232.csv
+Adcom/Receiver/81,0.csv
+Adcom/Surround Processor/26,-1.csv
+Adcom/Tuner/26,-1.csv
+Adcom/Unknown/26,-1.csv
+Adcom/Unknown/81,0.csv
+Adelphia/Cable Box/0,-1.csv
+Adelphia/Cable Box/1,-1.csv
+Adelphia/Cable Box/27,-1.csv
+ADS/AUDIO_Tech/0,-1.csv
+ADS/TV_Instant/2,-1.csv
+Advanced Acoustics/Unknown_Acoustic/36,75.csv
+Aesthetix/Pre-Amplifier/16,-1.csv
+AIM/MCE_AIM-RC126/4,15.csv
+AIM/RADIO/129,129.csv
+Aiwa/Cassette Tape/115,0.csv
+Aiwa/CD Player/118,0.csv
+Aiwa/Mini System/110,0.csv
+Aiwa/Receiver/12,-1.csv
+Aiwa/Receiver/13,-1.csv
+Aiwa/Receiver/16,-1.csv
+Aiwa/Receiver/18,-1.csv
+Aiwa/Unknown/127,0.csv
+Aiwa/Unknown_AIWA/110,0.csv
+Aiwa/Unknown_AIWA/118,0.csv
+Aiwa/Unknown_AIWA/127,0.csv
+Aiwa/Unknown_AIWA/72,0.csv
+Aiwa/Unknown_AIWA-RC-5VP05/127,0.csv
+Aiwa/Unknown_AWIA-RC-ZVR04/128,123.csv
+Aiwa/Unknown_HIFI/112,0.csv
+Aiwa/Unknown_hu/112,0.csv
+Aiwa/Unknown_RC-6AS07/112,0.csv
+Aiwa/Unknown_rc6as14/110,0.csv
+Aiwa/Unknown_RC-7AS06/110,0.csv
+Aiwa/Unknown_RC-8AS04/110,0.csv
+Aiwa/Unknown_RC-8AT02/110,0.csv
+Aiwa/Unknown_RC-AVT02/123,0.csv
+Aiwa/Unknown_RC-BVR02/110,-1.csv
+Aiwa/Unknown_rc-c003/118,0.csv
+Aiwa/Unknown_RC-C105/118,0.csv
+Aiwa/Unknown_RC-CAS10/110,0.csv
+Aiwa/Unknown_RC-L01/112,0.csv
+Aiwa/Unknown_RC-L60E/110,0.csv
+Aiwa/Unknown_RC-T503/110,0.csv
+Aiwa/Unknown_RC-T504/110,0.csv
+Aiwa/Unknown_RC-TD3/112,0.csv
+Aiwa/Unknown_RC-TN320EX/110,0.csv
+Aiwa/Unknown_RC-TN330/110,0.csv
+Aiwa/Unknown_RC-TN360/110,0.csv
+Aiwa/Unknown_rc-tn380b/110,0.csv
+Aiwa/Unknown_RC-TN500EX/110,0.csv
+Aiwa/Unknown_RC-TN520EX/110,0.csv
+Aiwa/Unknown_rc-tz650/110,0.csv
+Aiwa/Unknown_RC-X97/134,19.csv
+Aiwa/Unknown_RC-XR-MD201/110,0.csv
+Aiwa/Unknown_RC-ZAS02/110,0.csv
+Aiwa/Unknown_RC-ZAS10/110,0.csv
+Aiwa/Unknown_RC-ZAT04/112,0.csv
+Aiwa/Unknown_RC-ZVR02/127,0.csv
+Aiwa/Unknown_S79/72,0.csv
+Aiwa/VCR/127,0.csv
+Aiwa/VCR/130,111.csv
+Akai/CD Player/141,-1.csv
+Akai/Unknown_akai/131,101.csv
+Akai/Unknown_akai/139,-1.csv
+Akai/Unknown_Akai-RC-61A/11,11.csv
+Akai/Unknown_AKAI-RC-AAV2100/160,160.csv
+Akai/Unknown_Akai-RC-V23E/137,119.csv
+Akai/Unknown_RC891/137,-1.csv
+Akai/Unknown_rc-c37/141,-1.csv
+Akai/Unknown_RC-C79/141,-1.csv
+Akai/Unknown_RC-W152E/137,119.csv
+Akai/Unknown_RC-W201G/137,119.csv
+Akai/Unknown_RC-W212F/137,119.csv
+Akai/Unknown_RC-X121E/137,119.csv
+Akai/Unknown_RC-Y121G/137,119.csv
+Akai/Unknown_TV/0,-1.csv
+Akai/Unknown_V425A/137,-1.csv
+Aki/Unknown_DVD-838W/0,-1.csv
+Allsat/Unknown_sat/8,-1.csv
+alpine/Unknown_rue-4185/134,114.csv
+alpine/Unknown_RUE-4187/134,114.csv
 AMC/CD Player/7,252.csv
 AMC/Input Selector/7,232.csv
 AMC/Pre-Amplifier/7,252.csv
 AMC/Tuner/145,145.csv
-No Brand/Unknown_YK-001/0,-1.csv
-Proton/TV/4,-1.csv
-Proton/TV/17,-1.csv
-Proton/TV/3,-1.csv
-Proton/TV/2,-1.csv
-Chaparral/Unknown_11-5315-1/128,103.csv
-Cambridge Audio/Receiver/192,192.csv
-Cambridge Audio/Receiver/16,-1.csv
-Cambridge Audio/Receiver/19,-1.csv
-Cambridge Audio/DVD Player/12,-1.csv
-Cambridge Audio/DVD Player/7,-1.csv
-Cambridge Audio/Amp_CD/16,-1.csv
-Cambridge Audio/Amp_CD/160,160.csv
-Cambridge Audio/Unknown_X40A/16,-1.csv
-Cambridge Audio/Unknown_Audio/192,192.csv
-Sharpsat/Unknown_T28/128,38.csv
-Myryad/Receiver/23,-1.csv
-Myryad/Receiver/17,-1.csv
-Myryad/Receiver/20,-1.csv
-Myryad/Receiver/16,-1.csv
-Myryad/Receiver/21,-1.csv
-Myryad/Receiver/0,-1.csv
-Myryad/Receiver/18,-1.csv
-Myryad/Pre-Amplifier/23,-1.csv
-Myryad/Pre-Amplifier/17,-1.csv
-Myryad/Pre-Amplifier/20,-1.csv
-Myryad/Pre-Amplifier/16,-1.csv
-Myryad/Pre-Amplifier/21,-1.csv
-Myryad/Pre-Amplifier/0,-1.csv
-Myryad/Pre-Amplifier/18,-1.csv
-Asus/Unknown_RC1974502/4,15.csv
-Asus/Unknown_Digital/0,239.csv
-Asus/Unknown_TVBox/134,107.csv
-Asus/Unknown_TV-Box/None,None.csv
-Dynex/Unknown_DX-CVS4/2,-1.csv
-Shinco/Unknown_RC-1730/0,153.csv
-Domland/Unknown_domland-MH10CA/131,101.csv
-COMAG/Unknown_6222-N1/None,None.csv
-Calrad/Video Switcher/4,-1.csv
-BBK/Unknown_RC022-03R/73,-1.csv
-BBK/Unknown_PV400s/80,-1.csv
-BBK/Unknown_Popcorn/4,203.csv
-Hughes/Satellite/4,-1.csv
-Hughes/Satellite/60,178.csv
-Hughes/Satellite/136,-1.csv
-Hughes/Satellite/71,-1.csv
-Hughes/Satellite/133,48.csv
-Hughes/Satellite/12,-1.csv
-Hughes/Satellite/1,-1.csv
-Hughes/Satellite/12,251.csv
-Hughes/HD with TiVo/133,48.csv
-Hughes/Unknown_b2/12,251.csv
-Hughes/DSS/4,-1.csv
-Hughes/DSS/60,178.csv
-Hughes/DSS/136,-1.csv
-Hughes/DSS/71,-1.csv
-Hughes/DSS/133,48.csv
-Hughes/DSS/12,-1.csv
-Hughes/DSS/1,-1.csv
-Hughes/DSS/12,251.csv
-Hughes/Unknown_HRMC-8/12,251.csv
-Hughes/Sat_TiVo/133,48.csv
-Hughes/Sat_TiVo/210,109.csv
-Hughes/HD Satellite HD Tivo/133,48.csv
-Hughes/VCR/97,-1.csv
-Hughes/VCR/96,-1.csv
-Hughes/DVR/133,48.csv
-Hughes/DVR/12,-1.csv
-Hughes/Unknown_DSS/12,251.csv
-Hughes/TiVo/133,48.csv
-LP Morgan/Screen/0,-1.csv
-Maxx/Plasma/96,-1.csv
-Maxx/Plasma/32,64.csv
-Kenwood/Receiver/4,-1.csv
-Kenwood/Receiver/184,-1.csv
-Kenwood/Receiver/184,3.csv
-Kenwood/Receiver/25,-1.csv
-Kenwood/Receiver/12,-1.csv
-Kenwood/Receiver/184,5.csv
-Kenwood/Receiver/182,75.csv
-Kenwood/Receiver/184,7.csv
-Kenwood/Receiver/184,4.csv
-Kenwood/Receiver/184,2.csv
-Kenwood/Receiver/1,-1.csv
-Kenwood/Receiver/184,6.csv
-Kenwood/Receiver/40,-1.csv
-Kenwood/Receiver/184,1.csv
-Kenwood/Receiver/184,0.csv
-Kenwood/CD_DVD_MP-3/182,12.csv
-Kenwood/DVD Player/182,88.csv
-Kenwood/DVD Player/182,12.csv
-Kenwood/DVD Player/182,0.csv
-Kenwood/DVD Player/184,0.csv
-Kenwood/Unknown_RC-160/184,-1.csv
-Kenwood/Laser Disc/182,75.csv
-Kenwood/Unknown_RC-P600/182,-1.csv
-Kenwood/DVD Changer/182,12.csv
-Kenwood/DVD Changer/182,0.csv
-Kenwood/Unknown_RC-P2030/182,-1.csv
-Kenwood/Unknown_RC-RO503/184,-1.csv
-Kenwood/VCR/184,-1.csv
-Kenwood/VCR/184,1.csv
-Kenwood/Unknown_RC-P0702/182,-1.csv
-Kenwood/Unknown_RC-A0400/184,-1.csv
-Kenwood/Amplifier/184,7.csv
-Kenwood/Amplifier/184,4.csv
-Kenwood/Amplifier/184,2.csv
-Kenwood/Amplifier/184,1.csv
-Kenwood/Amplifier/184,0.csv
-Kenwood/Unknown_RC-P070/182,-1.csv
-Kenwood/Unknown_RC-M0301/182,4.csv
-Kenwood/Unknown_RC-P0715/182,-1.csv
-Kenwood/CD Player/184,-1.csv
-Kenwood/CD Player/182,-1.csv
-Kenwood/CD Player/182,0.csv
-Kenwood/Unknown_rc-p800/182,-1.csv
-Kenwood/Unknown_rc-p87/182,-1.csv
-Kenwood/Cassette Tape/184,-1.csv
-Kenwood/Unknown_RC-R0311E/44,44.csv
-Kenwood/Unknown_RC-P0400/182,-1.csv
-Kenwood/Unknown_RC-D0705.conf/182,12.csv
-Kenwood/CD Changer/184,-1.csv
-Kenwood/CD Changer/182,-1.csv
-Kenwood/CD Changer/182,72.csv
-Kenwood/Satellite Radio/2,255.csv
-Kenwood/Sirius/2,255.csv
-Kenwood/Pre-Amplifier/184,-1.csv
-Kenwood/Pre-Amplifier/182,75.csv
-Kenwood/Pre-Amplifier/184,1.csv
-Kenwood/Unknown_RC-P030/182,-1.csv
-Kenwood/Tuner/184,-1.csv
-Kenwood/Tuner/182,75.csv
-Kenwood/Tuner/184,1.csv
-Kenwood/Unknown_RC-M0701/182,4.csv
-ViewSonic/Unknown_vsnv6/0,-1.csv
-ViewSonic/Unknown_RC00070P/131,241.csv
-ViewSonic/Unknown_98TR7BD-ONT-VSF/131,241.csv
-Cypress/Unknown_CR-72/64,175.csv
-Shuttle/Unknown_mceusb/4,15.csv
-Get/Unknown_gethdpvr/72,36.csv
-Technotrend/Unknown_Micro/21,-1.csv
-Technotrend/Unknown_DVB/21,-1.csv
-Technotrend/Unknown_remote/21,-1.csv
-Technotrend/Unknown_S2400/21,-1.csv
-Technotrend/Unknown_Technotrend/21,-1.csv
-alpine/Unknown_rue-4185/134,114.csv
-alpine/Unknown_RUE-4187/134,114.csv
-TeVii/Unknown_S650/0,255.csv
-Recor/Unknown_IRC-1304/7,-1.csv
-CAT/Unknown_DVD-1122/0,-1.csv
-CAT/Unknown_CS-907/0,191.csv
-CAT/Unknown_KF-9816/0,-1.csv
-SUPERSQNY/Unknown_KM-168/0,-1.csv
-Schneider/Unknown_RC-193/154,-1.csv
-Schneider/Unknown_RC901/28,-1.csv
-Schneider/Unknown_RC202/11,11.csv
-Schneider/Unknown_FB2000/5,-1.csv
-Schneider/Unknown_RC902/0,-1.csv
-Audio Control/Receiver/23,-1.csv
-Audio Control/Receiver/17,-1.csv
-Audio Control/Receiver/16,-1.csv
-Audio Control/Processor/16,-1.csv
-Audio Control/Pre-Amplifier/23,-1.csv
-Audio Control/Pre-Amplifier/17,-1.csv
-Audio Control/Pre-Amplifier/16,-1.csv
-Thompson/Unknown_THOMPSON/133,48.csv
-Daewoo/Unknown_14Q3/0,-1.csv
-Daewoo/DVD Player/21,-1.csv
-Daewoo/Unknown_R-40A06/20,-1.csv
-Daewoo/Unknown_DV-800/21,-1.csv
-Daewoo/VCR/21,-1.csv
-Daewoo/Unknown_DVDS150/32,-1.csv
-Daewoo/Unknown_R-40A15/20,-1.csv
-Daewoo/Unknown_Visa/20,-1.csv
-Daewoo/Unknown_97P1RA3AB0/21,-1.csv
-Daewoo/Unknown_97P1R2ZDA0/21,-1.csv
-Daewoo/Unknown_DS608P/17,-1.csv
-Daewoo/Unknown_DAEWOO/21,-1.csv
-Daewoo/Unknown_DAEWOO/0,-1.csv
-Daewoo/Unknown_r-22/0,-1.csv
-Daewoo/Unknown_VCR/49,-1.csv
-Daewoo/Unknown_VCR/21,-1.csv
-Daewoo/Unknown_DV-F24D/21,-1.csv
-Daewoo/TV/4,-1.csv
-Daewoo/TV/6,6.csv
-Daewoo/TV/20,-1.csv
-Daewoo/Unknown_R-43A08/20,-1.csv
-Daewoo/Unknown_R-40A10/20,-1.csv
-Daewoo/Unknown_97P04701/21,-1.csv
-Avtoolbox/Unknown_hdswitch/32,-1.csv
-Hitachi/Unknown_Hitachi/80,-1.csv
-Hitachi/Unknown_Hitachi/1,-1.csv
-Hitachi/DSS/97,-1.csv
-Hitachi/DSS/4,-1.csv
-Hitachi/DSS/96,-1.csv
-Hitachi/DSS/3,-1.csv
-Hitachi/DSS/80,-1.csv
-Hitachi/DSS/184,0.csv
-Hitachi/DSS/12,251.csv
-Hitachi/Monitor/97,-1.csv
-Hitachi/Monitor/96,-1.csv
-Hitachi/Monitor/144,0.csv
-Hitachi/Monitor/80,-1.csv
-Hitachi/Monitor/96,158.csv
-Hitachi/DVD Player/102,0.csv
-Hitachi/Unknown_CP-X345/135,69.csv
-Hitachi/Video Projector/80,-1.csv
-Hitachi/Video Projector/135,69.csv
-Hitachi/VCR/97,-1.csv
-Hitachi/VCR/96,-1.csv
-Hitachi/VCR/5,1.csv
-Hitachi/VCR/44,-1.csv
-Hitachi/VCR/80,-1.csv
-Hitachi/VCR/83,-1.csv
-Hitachi/VCR/96,158.csv
-Hitachi/VCR/0,-1.csv
-Hitachi/VCR/97,159.csv
-Hitachi/VCR/40,-1.csv
-Hitachi/DVD_VCR Combo/44,-1.csv
-Hitachi/DVD_VCR Combo/40,-1.csv
-Hitachi/DVD_VCR Combo/128,35.csv
-Hitachi/CD Player/168,-1.csv
-Hitachi/Unknown_CLE-941/80,-1.csv
-Hitachi/Unknown_hitachi.conf/91,-1.csv
-Hitachi/Unknown_CLE-947/80,-1.csv
-Hitachi/LCD/86,171.csv
-Hitachi/Unknown_RM-613a/96,159.csv
-Hitachi/Unknown_FX7/91,-1.csv
-Hitachi/Unknown_DV-RM335E/128,35.csv
-Hitachi/Plasma/80,173.csv
-Hitachi/Plasma/80,-1.csv
-Hitachi/TV/80,143.csv
-Hitachi/TV/96,-1.csv
-Hitachi/TV/80,173.csv
-Hitachi/TV/80,-1.csv
-Hitachi/TV/12,251.csv
-Hitachi/Cable Box/80,-1.csv
-Hitachi/Unknown_HFTV/71,-1.csv
-Hitachi/Display/80,-1.csv
-kosmos/Unknown_kosmos/8,-1.csv
-Dream Multimedia/Unknown_URC7562/0,-1.csv
-Nokia/Unknown_MM9780S/14,0.csv
-Nokia/Satellite/6,-1.csv
-Nokia/Satellite/24,-1.csv
-Nokia/Unknown_VCN620/3,-1.csv
-Nokia/Unknown_RCN610/74,-1.csv
-Nokia/Unknown_Nokia/14,0.csv
-Nokia/Unknown_NokiaVC620/3,-1.csv
-Nokia/Unknown_VCR/137,119.csv
-Nokia/Unknown_624/74,-1.csv
-Venturer/Unknown_boombox/129,129.csv
-Venturer/Unknown_STB7766G1/66,187.csv
-Optex/Unknown_ORT/0,-1.csv
-Atlas/Unknown_8776/8,0.csv
-Life-view/Unknown_3000/96,1.csv
-Life-view/Unknown_flyvideo/96,1.csv
-LiteOn/DVD Recorder/10,247.csv
-Digital Music Expres/DMX/38,-1.csv
-Askey/Unknown_AS-218/134,107.csv
-Pansat/Unknown_2700/8,-1.csv
-Pansat/Unknown_2500a/0,249.csv
-Pansat/Unknown_2700a/8,-1.csv
-Axonix/DVD Player/17,-1.csv
-Axonix/MediaMax/17,20.csv
-Axonix/Media Server/17,-1.csv
-Dream/Satellite/11,0.csv
-Dream/Satellite/10,0.csv
-Dream/Satellite/25,0.csv
-Dream/Satellite/26,0.csv
-Dream/Satellite/41,0.csv
-Dream/Satellite/0,-1.csv
-BORK/Unknown_DV/8,-1.csv
-DVDO/Video Processor/132,32.csv
-DVDO/Video Processor/0,45.csv
-DVDO/Scaler/132,32.csv
-DVDO/Scaler/0,45.csv
-starhub/Unknown_starhub/33,144.csv
-Bench/Unknown_kh2800/48,-1.csv
-Go Video/VCR/7,7.csv
-Go Video/VCR/5,5.csv
-Go Video/VCR/132,98.csv
-Go Video/DVD Recorder/10,247.csv
-Go Video/VCR_DVD Combo/33,-1.csv
-Go Video/VCR_DVD Combo/5,5.csv
-Go Video/VCR_DVD Combo/5,-1.csv
-Go Video/VCR_DVD Combo/45,45.csv
-Go Video/VCR_DVD Combo/21,-1.csv
-Go Video/VCR_DVD Combo/110,-1.csv
-LG/Satellite/247,-1.csv
-LG/Unknown_6710V00133A/4,-1.csv
-LG/Unknown_6710T00009B/4,-1.csv
-LG/Unknown_6710CDAP01B/44,44.csv
-LG/Unknown_MKJ40653807/4,-1.csv
-LG/Unknown_AKB72915207/4,-1.csv
-LG/DVD Player/44,44.csv
-LG/DVD Player/16,16.csv
-LG/DVD Player/45,45.csv
-LG/Unknown_6710V00091N/4,-1.csv
-LG/Unknown_MKJ61842704/4,-1.csv
-LG/Unknown_42H3000/4,-1.csv
-LG/Unknown_LG-AKB69680403/4,-1.csv
-LG/Sound Bar/44,44.csv
-LG/LCD_DVD/4,-1.csv
-LG/LCD_DVD/45,45.csv
-LG/Unknown_6710V00090N/4,-1.csv
-LG/Unknown_PBAFA0189A/110,-1.csv
-LG/HDTV Tuner/247,-1.csv
-LG/Unknown_LG.6710V00008K/4,-1.csv
-LG/DVD_VCR Combo/45,45.csv
-LG/DVR/45,45.csv
-LG/Unknown_LG/110,-1.csv
-LG/Unknown_6710V00090D/0,-1.csv
-LG/Unknown_LG.6710V00005G/110,-1.csv
-LG/Unknown_6710V00070A/0,-1.csv
-LG/Unknown_AKB69680403/4,-1.csv
-LG/Unknown_6710V00067G/0,-1.csv
-LG/Plasma/4,-1.csv
-LG/Plasma/1,1.csv
-LG/Unknown_LG-EV230/110,-1.csv
-LG/TV/4,-1.csv
-LG/TV/1,1.csv
-LG/Unknown_AKB73715601/4,-1.csv
-LG/Unknown_CC470TW/110,-1.csv
-LG/Unknown_BC205P/110,-1.csv
-LG/Unknown_BD300/45,45.csv
-LG/Blu-Ray/45,45.csv
-I-O Data/DVD Player/8,230.csv
-BenQ/Unknown_DV3080/96,-1.csv
-BenQ/Unknown_W1070/0,48.csv
-BenQ/Projector/72,80.csv
-BenQ/Projector/48,-1.csv
-BenQ/Unknown_MP620/0,48.csv
-BenQ/DLP Projector/48,-1.csv
-Thomson/Unknown_TV/7,-1.csv
-Thomson/Unknown_TM9258/128,255.csv
-Thomson/Unknown_230/0,-1.csv
-Thomson/Unknown_RCS615TCLM1/5,-1.csv
-Nextwave/Unknown_EX300/4,16.csv
-Apex/DVD Player/4,-1.csv
-Apex/Unknown_K12B-C2/64,-1.csv
-Apex/Unknown_RM-2600/1,-1.csv
-Apex/Unknown_RM-1200/4,-1.csv
-Apex/Unknown_K12K-C5/64,-1.csv
-Apex/Unknown_DV-R383/0,238.csv
-Apex/Unknown_AD-600A/4,-1.csv
-Apex/Unknown_DV-R200/0,238.csv
-Geniatech/Unknown_Supera/0,-1.csv
-universum/VCR/128,123.csv
-universum/SAT/97,135.csv
-universum/SAT_SR420/15,-1.csv
-universum/VCR_VR743A/5,-1.csv
-universum/Unknown_universum/16,16.csv
-universum/Unknown_universum/0,-1.csv
-Hauppauge/Unknown_R808/30,-1.csv
-Hauppauge/Unknown_WinTV-HVR-950Q/29,-1.csv
-Hauppauge/Unknown_MVP/3,-1.csv
-Hauppauge/Unknown_hauppauge-stb/5,-1.csv
-Hauppauge/Unknown_DSR-0095/29,-1.csv
-Hauppauge/Unknown_WinTV-HVR/4,15.csv
-US Electronics/Cable Box/0,-1.csv
-HQ/Unknown_RC/0,-1.csv
-Zolid/Unknown_ZOL100/0,239.csv
-Lightolier/Lighting Controller/0,-1.csv
-Arcam/Receiver/23,-1.csv
-Arcam/Receiver/25,-1.csv
-Arcam/Receiver/17,-1.csv
-Arcam/Receiver/16,-1.csv
-Arcam/Receiver/0,-1.csv
-Arcam/Receiver/19,-1.csv
-Arcam/Unknown_AV200/16,-1.csv
-Arcam/DVD Player/25,-1.csv
-Arcam/DVD Player/16,-1.csv
-Arcam/Unknown_Arcam/16,-1.csv
-Arcam/CD Player/20,-1.csv
-Arcam/CD Player/16,-1.csv
-Arcam/CD Player/0,-1.csv
-Arcam/Surround Receiver/25,-1.csv
-Arcam/Surround Receiver/16,-1.csv
-Arcam/Surround Receiver/0,-1.csv
-Arcam/Music System/17,-1.csv
-Arcam/Music System/20,-1.csv
-Arcam/Music System/16,-1.csv
-Arcam/Pre-Amplifier/16,-1.csv
-Arcam/Tuner/17,-1.csv
-Scientific Atlanta/Unknown_Atlanta-1840/27,-1.csv
-Scientific Atlanta/Unknown_RM9834/27,-1.csv
-Scientific Atlanta/Unknown_SAE8000/27,-1.csv
-Scientific Atlanta/Cable Box/71,-1.csv
-Scientific Atlanta/Cable Box/27,-1.csv
-Scientific Atlanta/Unknown_IV/27,-1.csv
-Turtlebeach/Unknown_Audiotron/1,249.csv
-Fast/TVS/28,-1.csv
-Fast/TV/28,-1.csv
-Freecom/Unknown_usb/128,-1.csv
-Freecom/Unknown_MP35/128,-1.csv
-Starview/Unknown_Starview/0,249.csv
-XORO/Sat/0,191.csv
-XORO/Unknown_DVB/1,-1.csv
-Eagle Aspen/Unknown_Aspen/120,-1.csv
-LXI/TV/4,-1.csv
-Zoltrix/Unknown_Zoltrix/0,252.csv
-Generic/Unknown_RC-5/None,None.csv
-Generic/Unknown_SONY/None,None.csv
-Generic/Unknown_Sanyo/None,None.csv
-Generic/Unknown_XMP/None,None.csv
-Generic/Unknown_MOTOROLA/-1,-1.csv
-Generic/Unknown_DENON/None,None.csv
-Generic/Unknown_NEC/None,None.csv
-Generic/Unknown_RC-6/None,None.csv
-Generic/Unknown_RCMM-32/None,None.csv
-Generic/Unknown_RECS80/None,None.csv
-Traxis/Unknown_3500/4,-1.csv
-GAMEFACTORY/Unknown_PS2DVD/0,246.csv
-Sigma Designs/DVD Player/128,-1.csv
-Sigma Designs/Unknown_SIR/128,-1.csv
-Snazio/Unknown_Net/8,230.csv
-Carver/Receiver/12,-1.csv
-Carver/Receiver/17,-1.csv
-Carver/Receiver/135,123.csv
-Carver/Receiver/5,-1.csv
-Carver/Receiver/20,-1.csv
-Carver/Receiver/16,-1.csv
-Carver/Receiver/0,-1.csv
-Carver/Laser Disc/102,0.csv
-Carver/Amplifier/135,123.csv
-Carver/CD Player/135,123.csv
-Carver/CD Player/42,-1.csv
-Carver/CD Player/20,-1.csv
-Carver/CD Player/60,-1.csv
-Carver/CD Player/99,0.csv
-Carver/CD Player/68,-1.csv
-Carver/Cassette Tape/130,111.csv
-Carver/Cassette Tape/135,126.csv
-Carver/Cassette Tape/18,-1.csv
-Carver/Pre-Amplifier/23,-1.csv
-Carver/Pre-Amplifier/12,-1.csv
-Carver/Pre-Amplifier/17,-1.csv
-Carver/Pre-Amplifier/135,123.csv
-Carver/Pre-Amplifier/5,-1.csv
-Carver/Pre-Amplifier/20,-1.csv
-Carver/Pre-Amplifier/16,-1.csv
-Carver/Pre-Amplifier/21,-1.csv
-Carver/Pre-Amplifier/0,-1.csv
-Carver/Tuner/17,-1.csv
-Carver/Tuner/135,123.csv
-Carver/Tuner/20,-1.csv
-Carver/Tuner/16,-1.csv
-Da Lite/Screen/0,-1.csv
-NorthQ/Unknown_6400/8,-1.csv
-Atlona/Matrix Switcher/134,107.csv
-Atlona/Matrix Switcher/0,-1.csv
-Atlona/Switcher/134,107.csv
-kendo/Unknown_RC-610/134,124.csv
-KENMORE/Unknown_253-79081/8,245.csv
-Aopen/Media PC/4,-1.csv
-Aopen/Unknown_RC-R470/4,-1.csv
-Captain/Unknown_7100usb/4,250.csv
-TECHNICS/Unknown_EUR64799/160,10.csv
-TECHNICS/Unknown_sl-ps670a/160,10.csv
-TECHNICS/Unknown_EUR64798/160,10.csv
-TECHNICS/Unknown_EURXP300/160,10.csv
-TECHNICS/Unknown_EUR643880/160,10.csv
-TECHNICS/Unknown_cd/160,10.csv
-Onkyo Integra/Receiver/210,109.csv
-Onkyo Integra/Receiver/210,108.csv
-Onkyo Integra/DVD Changer/210,43.csv
-Tokai/Unknown_DVD-715/32,-1.csv
-Raite/Unknown_RaiteDVD-7xx/32,-1.csv
-FUNAI/Unknown_NF021RD/132,224.csv
-Sonicview/Unknown_SV-360/15,-1.csv
-KAWA/Unknown_TV/11,11.csv
-Trust/Unknown_RC-2400/52,15.csv
-Sgi/Unknown_SGIMON/26,9.csv
-XMS/Unknown_XMS503/32,-1.csv
-Audiovox/Monitor/128,126.csv
-Audiovox/Unknown_Sirius/16,-1.csv
-Audiovox/Unknown_SIR/16,-1.csv
-MEGATRON/Unknown_MEGATRON/255,255.csv
-Accupel/Signal Generator/0,-1.csv
-METRONIC/Unknown_060501/0,127.csv
-METRONIC/Unknown_SAT/134,-1.csv
-Madrigal/Receiver/5,-1.csv
-Madrigal/CD Player/7,-1.csv
-Madrigal/CD Player/2,-1.csv
-Madrigal/CD Player/0,-1.csv
-Zinwell/Satellite Receiver/64,223.csv
-orion/Unknown_RC-CB/128,88.csv
-orion/Unknown_orion/128,123.csv
-orion/Unknown_TV-713/0,-1.csv
-orion/Unknown_orion-RC57/128,126.csv
-Vidikron/Video Projector/0,-1.csv
-Snell/Speaker/80,0.csv
-DirecTV/Satellite/4,-1.csv
-DirecTV/Satellite/133,48.csv
-DirecTV/Satellite/12,-1.csv
-DirecTV/DSS/12,-1.csv
-DirecTV/Receiver HDDVR/71,-1.csv
-DirecTV/Receiver HDDVR/12,-1.csv
-DirecTV/Receiver HDDVR/3,-1.csv
-DirecTV/Receiver HDDVR/2,-1.csv
-DirecTV/Receiver HDDVR/15,-1.csv
-DirecTV/Receiver HDDVR/64,-1.csv
-DirecTV/Receiver HDDVR/13,-1.csv
-DirecTV/Basic Satellite/12,-1.csv
-DirecTV/Basic Satellite/7,-1.csv
-DirecTV/Unknown_RC16/12,-1.csv
-DirecTV/Receiver HD/12,-1.csv
-DirecTV/Receiver HD/13,-1.csv
-DirecTV/Receiver HD/12,251.csv
-DirecTV/Unknown_H23/12,-1.csv
-DirecTV/HDTV Tuner/12,-1.csv
-DirecTV/Receiver SDDVR/133,48.csv
-DirecTV/Receiver SDDVR/12,-1.csv
-DirecTV/Receiver SDDVR/15,-1.csv
-DirecTV/Unknown_RC64/12,-1.csv
-DirecTV/Unknown_HD20-100/12,-1.csv
-DirecTV/Unknown_RC32/12,-1.csv
-DirecTV/Receiver SD/12,-1.csv
-DirecTV/Receiver SD/13,-1.csv
-DirecTV/DVR/133,48.csv
-DirecTV/Unknown/12,-1.csv
-DirecTV/Unknown/15,-1.csv
-DirecTV/Unknown/12,251.csv
-DirecTV/Receiver_HDR/133,48.csv
-DirecTV/Tivo_Sat Reciever/133,48.csv
-DirecTV/Unknown_G051204/12,-1.csv
-Classe Audio/DVD Player/200,-1.csv
-Classe Audio/DVD Player/4,-1.csv
-Classe Audio/DVD Player/25,-1.csv
-Classe Audio/DVD Player/12,-1.csv
-Classe Audio/DVD Player/20,-1.csv
-Classe Audio/DVD Player/7,-1.csv
-Classe Audio/SACD/20,-1.csv
-Classe Audio/SACD/7,-1.csv
-Classe Audio/Surround Processor/200,-1.csv
-Classe Audio/Surround Processor/25,-1.csv
-Classe Audio/Surround Processor/116,-1.csv
-Classe Audio/CRCD/17,-1.csv
-Classe Audio/CRCD/20,-1.csv
-Classe Audio/CRCD/16,-1.csv
-Classe Audio/Integrated Amplifier/7,-1.csv
-Classe Audio/Amplifier/3,-1.csv
-Classe Audio/Amplifier/7,-1.csv
-Classe Audio/Amplifier/201,-1.csv
-Classe Audio/Surround Sound/200,-1.csv
-Classe Audio/Surround Sound/116,-1.csv
-Classe Audio/CD Player/134,97.csv
-Classe Audio/CD Player/20,-1.csv
-Classe Audio/CD_DVD/200,-1.csv
-Classe Audio/CD_DVD/4,-1.csv
-Classe Audio/CD_DVD/20,-1.csv
-Classe Audio/Pre-Amplifier/200,-1.csv
-Classe Audio/Pre-Amplifier/25,-1.csv
-Classe Audio/Pre-Amplifier/3,-1.csv
-Classe Audio/Pre-Amplifier/7,-1.csv
-Classe Audio/Pre-Amplifier/16,-1.csv
-Classe Audio/Tuner/17,-1.csv
-Classe Audio/Tuner/7,-1.csv
-Pinnacle Systems/Unknown_RC-42D/7,-1.csv
-Pinnacle Systems/Unknown_300i/17,20.csv
-Pinnacle Systems/Unknown_800i/7,-1.csv
-Pinnacle Systems/Unknown_PCTV/7,-1.csv
-Boxlight/Projector/135,78.csv
-Boxlight/Projector/48,206.csv
-Boxlight/Projector/48,-1.csv
-FTE Maximal/Unknown_FTE/73,-1.csv
-CHINON/Unknown_CHINON/64,0.csv
-Yakumo/Unknown_DVD/4,-1.csv
-Lexicon/Receiver/130,11.csv
-Lexicon/DVD Player/4,-1.csv
-Lexicon/Surround Processor/130,11.csv
-Lexicon/Surround Processor/28,-1.csv
-Lexicon/Surround Processor/133,2.csv
-MS-Tech/Unknown_MS-Tech/0,95.csv
-MS-Tech/Unknown_HTPC/0,95.csv
-Arrakis Systems/CD Jukebox/39,-1.csv
-Arrakis Systems/CD Jukebox/71,-1.csv
-Arrakis Systems/CD Jukebox/103,-1.csv
-sun/Unknown_sun/26,9.csv
-Denon/Receiver/97,-1.csv
-Denon/Receiver/4,3.csv
-Denon/Receiver/7,8.csv
-Denon/Receiver/4,-1.csv
-Denon/Receiver/4,2.csv
-Denon/Receiver/7,7.csv
-Denon/Receiver/6,-1.csv
-Denon/Receiver/96,-1.csv
-Denon/Receiver/12,-1.csv
-Denon/Receiver/7,5.csv
-Denon/Receiver/7,6.csv
-Denon/Receiver/7,4.csv
-Denon/Receiver/80,-1.csv
-Denon/Receiver/2,-1.csv
-Denon/Receiver/4,7.csv
-Denon/Receiver/4,1.csv
-Denon/Receiver/4,5.csv
-Denon/Receiver/2,3.csv
-Denon/Receiver/8,-1.csv
-Denon/DVD Player/4,-1.csv
-Denon/DVD Player/6,-1.csv
-Denon/DVD Player/2,-1.csv
-Denon/DVD Player/2,1.csv
-Denon/DVD Player/176,0.csv
-Denon/DVD Player/8,-1.csv
-Denon/AV Receiver/4,3.csv
-Denon/AV Receiver/4,-1.csv
-Denon/AV Receiver/4,2.csv
-Denon/AV Receiver/12,-1.csv
-Denon/AV Receiver/7,5.csv
-Denon/AV Receiver/2,-1.csv
-Denon/AV Receiver/4,7.csv
-Denon/AV Receiver/4,1.csv
-Denon/AV Receiver/4,5.csv
-Denon/AV Receiver/2,3.csv
-Denon/Unknown_RC267/6,-1.csv
-Denon/Laser Disc/168,-1.csv
-Denon/Unknown_denon-rc-266/8,-1.csv
-Denon/Unknown_RC-861/2,2.csv
-Denon/Amplifier/4,-1.csv
-Denon/Amplifier/6,-1.csv
-Denon/Amplifier/12,-1.csv
-Denon/Amplifier/2,-1.csv
-Denon/Amplifier/8,-1.csv
-Denon/Processor/4,3.csv
-Denon/Processor/4,-1.csv
-Denon/Processor/12,-1.csv
-Denon/Processor/2,-1.csv
-Denon/Processor/4,1.csv
-Denon/Processor/4,5.csv
-Denon/Unknown_RC-224/8,-1.csv
-Denon/CD Receiver/4,-1.csv
-Denon/CD Receiver/6,-1.csv
-Denon/CD Receiver/12,-1.csv
-Denon/CD Receiver/8,-1.csv
-Denon/Mini-Disc/6,-1.csv
-Denon/CD Player/4,-1.csv
-Denon/CD Player/168,-1.csv
-Denon/CD Player/6,-1.csv
-Denon/CD Player/175,-1.csv
-Denon/CD Player/8,-1.csv
-Denon/Unknown_RC-541/176,0.csv
-Denon/Surround Receiver/4,-1.csv
-Denon/Surround Receiver/12,-1.csv
-Denon/Surround Receiver/2,-1.csv
-Denon/Unknown_RC-241/8,-1.csv
-Denon/Unknown_RC-220/8,-1.csv
-Denon/Unknown/176,0.csv
-Denon/DAT/4,-1.csv
-Denon/Cassette Tape/4,-1.csv
-Denon/Cassette Tape/12,-1.csv
-Denon/Cassette Tape/2,-1.csv
-Denon/Cassette Tape/8,-1.csv
-Denon/Unknown_denon-rc-251/8,-1.csv
-Denon/Unknown_Denon/91,-1.csv
-Denon/CD Jukebox/4,-1.csv
-Denon/CD Jukebox/8,-1.csv
-Denon/Pre-Amplifier/12,-1.csv
-Denon/Pre-Amplifier/2,-1.csv
-Denon/Receiver_CD/4,-1.csv
-Denon/Receiver_CD/6,-1.csv
-Denon/Receiver_CD/12,-1.csv
-Denon/Receiver_CD/8,-1.csv
-Denon/Tuner/6,70.csv
-Denon/Tuner/6,245.csv
-Denon/Tuner/6,195.csv
-Denon/Tuner/6,66.csv
-Denon/Tuner/6,37.csv
-Denon/Tuner/6,162.csv
-Denon/Tuner/6,129.csv
-Denon/Tuner/6,34.csv
-Denon/Tuner/6,145.csv
-Denon/Tuner/6,214.csv
-Denon/Tuner/6,230.csv
-Denon/Tuner/6,115.csv
-Denon/Tuner/6,246.csv
-Denon/Tuner/6,116.csv
-Denon/Tuner/6,53.csv
-Denon/Tuner/6,134.csv
-Denon/Tuner/6,101.csv
-Denon/Tuner/6,228.csv
-Denon/Tuner/6,50.csv
-Denon/Tuner/6,164.csv
-Denon/Tuner/6,3.csv
-Denon/Tuner/6,65.csv
-Denon/Tuner/6,244.csv
-Denon/Tuner/6,49.csv
-Denon/Tuner/6,179.csv
-Denon/Tuner/6,226.csv
-Denon/Tuner/6,6.csv
-Denon/Tuner/6,163.csv
-Denon/Tuner/6,166.csv
-Denon/Tuner/6,196.csv
-Denon/Tuner/6,130.csv
-Denon/Tuner/12,-1.csv
-Denon/Tuner/6,132.csv
-Denon/Tuner/6,113.csv
-Denon/Tuner/6,149.csv
-Denon/Tuner/6,161.csv
-Denon/Tuner/6,20.csv
-Denon/Tuner/6,147.csv
-Denon/Tuner/6,86.csv
-Denon/Tuner/6,5.csv
-Denon/Tuner/6,212.csv
-Denon/Tuner/6,17.csv
-Denon/Tuner/6,22.csv
-Denon/Tuner/6,52.csv
-Denon/Tuner/6,198.csv
-Denon/Tuner/6,210.csv
-Denon/Tuner/6,21.csv
-Denon/Tuner/6,54.csv
-Denon/Tuner/6,98.csv
-Denon/Tuner/6,33.csv
-Denon/Tuner/6,36.csv
-Denon/Tuner/6,181.csv
-Denon/Tuner/6,182.csv
-Denon/Tuner/6,97.csv
-Denon/Tuner/6,241.csv
-Denon/Tuner/6,1.csv
-Denon/Tuner/6,67.csv
-Denon/Tuner/6,84.csv
-Denon/Tuner/6,4.csv
-Denon/Tuner/2,-1.csv
-Denon/Tuner/6,69.csv
-Denon/Tuner/6,178.csv
-Denon/Tuner/6,68.csv
-Denon/Tuner/6,85.csv
-Denon/Tuner/6,82.csv
-Denon/Tuner/6,193.csv
-Denon/Tuner/6,165.csv
-Denon/Tuner/6,225.csv
-Denon/Tuner/6,211.csv
-Denon/Tuner/6,18.csv
-Denon/Tuner/6,148.csv
-Denon/Tuner/6,243.csv
-Denon/Tuner/6,227.csv
-Denon/Tuner/6,117.csv
-Denon/Tuner/6,177.csv
-Denon/Tuner/6,102.csv
-Denon/Tuner/6,114.csv
-Denon/Tuner/6,209.csv
-Denon/Tuner/6,100.csv
-Denon/Tuner/6,118.csv
-Denon/Tuner/6,150.csv
-Denon/Tuner/6,197.csv
-Denon/Tuner/6,83.csv
-Denon/Tuner/6,19.csv
-Denon/Tuner/6,35.csv
-Denon/Tuner/6,133.csv
-Denon/Tuner/6,2.csv
-Denon/Tuner/6,194.csv
-Denon/Tuner/6,146.csv
-Denon/Tuner/6,131.csv
-Denon/Tuner/6,81.csv
-Denon/Tuner/6,180.csv
-Denon/Tuner/6,99.csv
-Denon/Tuner/6,51.csv
-Denon/Tuner/6,242.csv
-Denon/Tuner/6,38.csv
-Denon/Tuner/6,213.csv
-Denon/Tuner/6,229.csv
-Denon/Blu-Ray/2,1.csv
-Denon/AV Processor/4,-1.csv
-Denon/AV Processor/12,-1.csv
-Denon/AV Processor/2,-1.csv
-LeadTek/Unknown_RM-0007/3,-1.csv
-LeadTek/Unknown_Y0400046/3,-1.csv
-LeadTek/Unknown_Y04G0004/3,-1.csv
-LeadTek/Unknown_PVR2000/None,None.csv
-LeadTek/Unknown_Y0400052/3,-1.csv
-One For All/Unknown_URC-6012w/2,-1.csv
-One For All/Unknown_For/0,-1.csv
-One For All/Unknown_For/8,-1.csv
-One For All/Unknown_ofa-urc-7550-vcr0150/5,-1.csv
-One For All/Unknown_URC-8910/7,-1.csv
-One For All/Unknown_7720/0,-1.csv
-One For All/Unknown_URC-3021B00-VCR-0081/5,-1.csv
-One For All/Unknown_URC-7020/5,-1.csv
-One For All/Unknown_URC-8204.1300/32,8.csv
-One For All/Unknown_SAT/32,8.csv
-One For All/Unknown_urc7730/0,-1.csv
-One For All/Unknown_urc7562/0,-1.csv
-One For All/Unknown_Phillips/5,-1.csv
-One For All/Unknown_URC-7710/0,-1.csv
-One For All/Unknown_One-For-All/0,-1.csv
-One For All/Unknown_URC-7555/0,-1.csv
-One For All/Unknown_URC-7240/5,-1.csv
-One For All/Unknown_URC-3440/5,-1.csv
-One For All/Unknown_URC-2510(12341)/71,-1.csv
-One For All/Unknown_VCR/113,-1.csv
-One For All/Unknown_URC-7530/7,-1.csv
-One For All/Unknown_URC-7562/68,-1.csv
-One For All/Unknown_control-Philips-0081d/0,-1.csv
-One For All/Unknown_URC-5550/11,-1.csv
-Zenith/Unknown_ZN5015/26,154.csv
-Zenith/Unknown_TV/4,-1.csv
-Zenith/Video Projector/6,0.csv
-Zenith/Video Projector/5,1.csv
-Zenith/VCR/7,0.csv
-Zenith/Unknown_C32V37/4,-1.csv
-Zenith/Unknown_AKB36157102/247,-1.csv
-Zenith/Unknown_VCR/2,-1.csv
-Zenith/TV/5,1.csv
-Zenith/TV/7,1.csv
-Zenith/TV/7,0.csv
-Elmo/Video Projector/132,132.csv
-Elmo/Video Projector/134,134.csv
-Elmo/CAMERA_PRC-100S/32,-1.csv
-Elmo/Camera/128,-1.csv
-Fusion Research/DVD Server/17,-1.csv
-Niles Audio/Unknown/132,18.csv
-Niles Audio/Unknown/128,93.csv
-Morgans Daytona/Unknown_Tornado/202,165.csv
-Morgans Daytona/Unknown_T15/128,38.csv
-Axion/Unknown_AXN-6075/2,255.csv
-YES/Unknown_YES/132,60.csv
-MAGNASONIC/Unknown_TV/131,122.csv
-FSC/DVD Player/4,15.csv
-Memorex/DVD Player/0,-1.csv
-Memorex/TV/4,-1.csv
-Corvo/Relaybox/27,-1.csv
-Electrokinetics/Plasma Lift/0,-1.csv
-Lacie/Unknown_PNE-N1SS/0,127.csv
-Lacie/Unknown_Lacie/64,64.csv
-Replay Networks/Digital Recorder/1,0.csv
-Mvision/Unknown_FCIS7000E+/64,64.csv
-Gryphon/Integrated Amplifier/16,-1.csv
-BTX/Drapery Controller/148,-1.csv
-BTX/Drapery Controller/84,-1.csv
-BTX/Drapery Controller/146,-1.csv
-BTX/Drapery Controller/147,-1.csv
-BTX/Drapery Controller/193,-1.csv
-BTX/Drapery Controller/145,-1.csv
-BTX/Drapery Controller/83,-1.csv
-BTX/Drapery Controller/195,-1.csv
-BTX/Drapery Controller/196,-1.csv
-BTX/Drapery Controller/81,-1.csv
-BTX/Drapery Controller/82,-1.csv
-BTX/Drapery Controller/194,-1.csv
-Kworld/Unknown_VS-PRV-TV/134,107.csv
-Kworld/Unknown_KWorld-DVBT-220/0,251.csv
-Kworld/Unknown_DVB-T/134,107.csv
-Kworld/Unknown_KWorld-DVBT-PE310/0,251.csv
-Kworld/Unknown_ATSC/0,251.csv
-Meridian/Remote Control/19,-1.csv
-Meridian/DVD Player/69,-1.csv
-Meridian/DVD Player/19,-1.csv
-Meridian/System Remote/19,-1.csv
-Meridian/DVD/19,-1.csv
-Meridian/Surround Processor/19,-1.csv
-Meridian/Processor/19,-1.csv
-Meridian/CD Player/19,-1.csv
-Meridian/800 System Remote/19,-1.csv
-Meridian/CD-R/19,-1.csv
-Meridian/Pre-Amplifier/26,73.csv
-Meridian/Pre-Amplifier/19,-1.csv
-LiteTouch/Lighting Controller/129,-1.csv
-LiteTouch/Lighting Controller/148,-1.csv
-LiteTouch/Lighting Controller/136,-1.csv
-LiteTouch/Lighting Controller/149,-1.csv
-LiteTouch/Lighting Controller/146,-1.csv
-LiteTouch/Lighting Controller/144,-1.csv
-LiteTouch/Lighting Controller/147,-1.csv
-LiteTouch/Lighting Controller/255,-1.csv
-LiteTouch/Lighting Controller/130,-1.csv
-LiteTouch/Lighting Controller/132,-1.csv
-LiteTouch/Lighting Controller/153,-1.csv
-LiteTouch/Lighting Controller/137,-1.csv
-LiteTouch/Lighting Controller/131,-1.csv
-LiteTouch/Lighting Controller/150,-1.csv
-LiteTouch/Lighting Controller/145,-1.csv
-LiteTouch/Lighting Controller/152,-1.csv
-LiteTouch/Lighting Controller/133,-1.csv
-LiteTouch/Lighting Controller/135,-1.csv
-LiteTouch/Lighting Controller/151,-1.csv
-LiteTouch/Lighting Controller/134,-1.csv
-Compro/Unknown_DVB-T200/128,126.csv
-Compro/Unknown_VideoMate-K300/4,15.csv
-Universal/Unknown_URC-6012w/2,-1.csv
-Universal/Unknown_111/135,124.csv
-Universal/Unknown_089/6,-1.csv
-Universal/Unknown_RM-V211T/2,-1.csv
-Universal/Unknown_001/4,15.csv
-Universal/Unknown_cme/7,-1.csv
-Universal/Unknown_lt3607-aux599/135,124.csv
-Universal/Unknown_lircd.conf/0,-1.csv
-Universal/Unknown_lircd.conf/128,123.csv
-Universal/Unknown_MC-10/5,-1.csv
-Universal/Unknown_tv/1,-1.csv
-Universal/Unknown_Knopex/7,-1.csv
-Universal/Unknown_RC/0,-1.csv
-Universal/Unknown_Powerhouse/166,-1.csv
-Universal/Unknown_RZ-55/1,-1.csv
-Universal/Unknown_101/6,-1.csv
-Universal/Unknown_testrecord.config/0,-1.csv
-Universal/Unknown_006/56,-1.csv
-Dell/Video Projector/79,80.csv
-Dell/Unknown_XPS/43,28.csv
-Dell/TV/0,28.csv
-Xlogic/Unknown_XLOGIC-KF8000D/64,63.csv
-Mintek/DVD Player/0,153.csv
-Majestic/Unknown_DVX377USB/0,-1.csv
-Trutech/Unknown_TV/0,1.csv
-ADB/Set Top Box/42,17.csv
-ADB/SAT_ICAN3000/8,0.csv
-Lasonic/Unknown_LasonicR2000/16,-1.csv
-Nagra/Unknown_TVA/8,-1.csv
-Sanyo/Unknown_RB-SL22/60,196.csv
-Sanyo/Unknown_B12628/49,-1.csv
-Sanyo/Unknown_RB-DA300/60,-1.csv
-Sanyo/Unknown_A05800/49,-1.csv
-Sanyo/Unknown_TV/56,-1.csv
-Sanyo/Unknown_B01004/49,-1.csv
-Sanyo/Video Projector/48,-1.csv
-Sanyo/Unknown_Sanyo/49,-1.csv
-Sanyo/Unknown_Sanyo/56,-1.csv
-Sanyo/Unknown_Sanyo-JXZB/56,-1.csv
-Sanyo/Unknown_B01007/49,-1.csv
-Sanyo/Unknown_Sanyo-B13509/49,-1.csv
-Sanyo/Unknown_sanyoB13537/49,-1.csv
-Sanyo/Unknown_sanyo-tv01/56,-1.csv
-Sanyo/Unknown_B13540/49,-1.csv
-Sanyo/Unknown_VCR/49,-1.csv
-Sanyo/TV/56,-1.csv
-Sanyo/Unknown_RC-105C/54,-1.csv
-Sanyo/Unknown_RC700/56,-1.csv
-I24/Unknown_I24/0,-1.csv
-DigitalView/HDTV Tuner/128,-1.csv
-Vestel/Unknown_TV/0,-1.csv
-Ultrawave/Unknown_3500PFTA/2,2.csv
-Conrad/Unknown_Promo8/0,-1.csv
-Conrad/Unknown_006/56,-1.csv
-Kensington/MP3 Player/51,170.csv
-Kensington/iPod Dock/51,170.csv
-JBL/Receiver/64,47.csv
-JBL/Surround Processor/132,66.csv
-JBL/Surround Processor/130,11.csv
-JBL/Surround Processor/28,-1.csv
-Genus/Unknown_DU1/128,-1.csv
-Sagem/Unknown_DVB-T-Receiver/135,94.csv
-Sagem/Unknown_HD103-C/135,94.csv
-Sagem/Unknown_Sagem/135,94.csv
-MIRO/Unknown_MIRO/134,107.csv
-Westinghouse/Unknown_LVM-47W1/1,-1.csv
-Westinghouse/Unknown_RMT/1,-1.csv
-Magnum Dynalab/Tuner/7,-1.csv
-Durabrand/Unknown_PTV141/128,99.csv
-Minolta/Unknown_RC3/52,202.csv
-MSI/Unknown_PC/134,107.csv
-MSI/Unknown_test/134,107.csv
-MSI/Unknown_MegaPC/134,107.csv
-MSI/Unknown_lircd.conf/134,107.csv
-Speed-link/Unknown_SL-6399/0,-1.csv
-Rega/Receiver/16,-1.csv
-Rega/Receiver/135,124.csv
-Rega/Receiver/110,-1.csv
-xsat/Unknown_xsat/34,-1.csv
-Homecast/Unknown_DVB-T/64,64.csv
-Homecast/Satellite Receiver/1,-1.csv
-Homecast/Unknown_DVB-S/32,32.csv
-Belkin/Unknown_F5X019/27,-1.csv
-Irradio/Unknown_IrradioHIFI1300V/162,162.csv
-Hip Interactive/Unknown_GE1002/0,246.csv
-BnK Components/Receiver/27,78.csv
-BnK Components/Receiver/203,67.csv
-BnK Components/Receiver/139,71.csv
-BnK Components/Matrix Switcher/199,131.csv
-BnK Components/Matrix Switcher/192,243.csv
-BnK Components/Matrix Switcher/119,-1.csv
-BnK Components/Matrix Switcher/15,15.csv
-BnK Components/Matrix Switcher/219,66.csv
-BnK Components/Matrix Switcher/204,-1.csv
-BnK Components/Matrix Switcher/143,7.csv
-BnK Components/Matrix Switcher/239,1.csv
-BnK Components/Matrix Switcher/95,10.csv
-BnK Components/Matrix Switcher/7,143.csv
-BnK Components/Matrix Switcher/71,139.csv
-BnK Components/Matrix Switcher/255,-1.csv
-BnK Components/Matrix Switcher/183,132.csv
-BnK Components/Matrix Switcher/123,72.csv
-BnK Components/Matrix Switcher/59,76.csv
-BnK Components/Matrix Switcher/23,142.csv
-BnK Components/Matrix Switcher/243,192.csv
-BnK Components/Matrix Switcher/39,141.csv
-BnK Components/Matrix Switcher/103,137.csv
-BnK Components/Matrix Switcher/187,-1.csv
-BnK Components/Matrix Switcher/76,59.csv
-BnK Components/Matrix Switcher/44,61.csv
-BnK Components/Matrix Switcher/108,57.csv
-BnK Components/Matrix Switcher/167,133.csv
-BnK Components/Matrix Switcher/135,135.csv
-BnK Components/Matrix Switcher/64,251.csv
-BnK Components/Matrix Switcher/128,247.csv
-BnK Components/Matrix Switcher/247,128.csv
-BnK Components/Matrix Switcher/0,-1.csv
-BnK Components/Matrix Switcher/55,140.csv
-BnK Components/Matrix Switcher/223,2.csv
-BnK Components/Matrix Switcher/242,208.csv
-BnK Components/Matrix Switcher/91,74.csv
-BnK Components/Matrix Switcher/159,6.csv
-BnK Components/Matrix Switcher/63,12.csv
-BnK Components/Matrix Switcher/31,14.csv
-BnK Components/Matrix Switcher/251,64.csv
-BnK Components/Matrix Switcher/79,11.csv
-BnK Components/Matrix Switcher/111,9.csv
-BnK Components/Matrix Switcher/172,53.csv
-BnK Components/Matrix Switcher/127,8.csv
-BnK Components/Theater-Zone 2/75,75.csv
-BnK Components/Theater-Zone 2/43,77.csv
-BnK Components/Theater-Zone 2/11,79.csv
-BnK Components/Surround Processor/27,78.csv
-BnK Components/Surround Processor/11,79.csv
-BnK Components/Multi-Zone Receiver/199,131.csv
-BnK Components/Multi-Zone Receiver/119,-1.csv
-BnK Components/Multi-Zone Receiver/15,15.csv
-BnK Components/Multi-Zone Receiver/219,66.csv
-BnK Components/Multi-Zone Receiver/143,7.csv
-BnK Components/Multi-Zone Receiver/7,143.csv
-BnK Components/Multi-Zone Receiver/71,139.csv
-BnK Components/Multi-Zone Receiver/183,132.csv
-BnK Components/Multi-Zone Receiver/123,72.csv
-BnK Components/Multi-Zone Receiver/59,76.csv
-BnK Components/Multi-Zone Receiver/23,142.csv
-BnK Components/Multi-Zone Receiver/243,192.csv
-BnK Components/Multi-Zone Receiver/39,141.csv
-BnK Components/Multi-Zone Receiver/103,137.csv
-BnK Components/Multi-Zone Receiver/187,-1.csv
-BnK Components/Multi-Zone Receiver/167,133.csv
-BnK Components/Multi-Zone Receiver/135,135.csv
-BnK Components/Multi-Zone Receiver/231,129.csv
-BnK Components/Multi-Zone Receiver/87,138.csv
-BnK Components/Multi-Zone Receiver/247,128.csv
-BnK Components/Multi-Zone Receiver/215,130.csv
-BnK Components/Multi-Zone Receiver/55,140.csv
-BnK Components/Multi-Zone Receiver/242,208.csv
-BnK Components/Multi-Zone Receiver/91,74.csv
-BnK Components/Multi-Zone Receiver/31,14.csv
-BnK Components/Multi-Zone Receiver/251,64.csv
-BnK Components/Multi-Zone Receiver/79,11.csv
-BnK Components/Multi-Zone Receiver/151,134.csv
-BnK Components/Theater Preamplifier/27,78.csv
-BnK Components/Theater Preamplifier/203,67.csv
-BnK Components/Theater Preamplifier/139,71.csv
-BnK Components/6 Zone Receiver/219,66.csv
-BnK Components/6 Zone Receiver/27,78.csv
-BnK Components/6 Zone Receiver/75,75.csv
-BnK Components/6 Zone Receiver/123,72.csv
-BnK Components/6 Zone Receiver/59,76.csv
-BnK Components/6 Zone Receiver/243,192.csv
-BnK Components/6 Zone Receiver/187,-1.csv
-BnK Components/6 Zone Receiver/43,77.csv
-BnK Components/6 Zone Receiver/203,67.csv
-BnK Components/6 Zone Receiver/139,71.csv
-BnK Components/6 Zone Receiver/242,208.csv
-BnK Components/6 Zone Receiver/91,74.csv
-BnK Components/6 Zone Receiver/251,64.csv
-BnK Components/6 Zone Receiver/11,79.csv
-BnK Components/2-Channel Preamp/11,-1.csv
-BnK Components/2-Channel Preamp/11,79.csv
-BnK Components/Tuner_preamp/11,-1.csv
-BnK Components/Tuner_preamp/11,79.csv
-BnK Components/Pre-Amplifier/27,78.csv
-BnK Components/Pre-Amplifier/5,1.csv
-BnK Components/Pre-Amplifier/11,-1.csv
-BnK Components/Pre-Amplifier/6,1.csv
-BnK Components/Pre-Amplifier/203,67.csv
-BnK Components/Pre-Amplifier/139,71.csv
-BnK Components/Pre-Amplifier/11,79.csv
-mivar/Unknown_mivar/7,-1.csv
-Skymaster/Unknown_2421/2,-1.csv
-Skymaster/Unknown_skymaster/19,1.csv
-Skymaster/Unknown_DCI/5,-1.csv
-Skymaster/Unknown_XL10/6,-1.csv
-Skymaster/Unknown_2424/37,250.csv
-Skymaster/Unknown_SkymasterXLS99/19,1.csv
-Atlanta DTH/Unknown_DTH/5,-1.csv
-Comcast/Digital Cable/27,-1.csv
-Comcast/Digital Cable/15,-1.csv
-Comcast/HD Cable with DVR/14,-1.csv
-Comcast/HD Cable with DVR/0,-1.csv
-Comcast/Cable Box/14,-1.csv
-Comcast/Cable Box/62,16.csv
-Comcast/Cable Box/27,-1.csv
-Comcast/Cable Box/1,-1.csv
-Comcast/Cable Box/15,-1.csv
-Comcast/Cable Box/0,-1.csv
-Aristona/Unknown_5525/0,-1.csv
-Aristona/Unknown_9067/5,-1.csv
-Sitronics/Unknown_RC-D010E/0,251.csv
-Terratec/Unknown_1400/4,235.csv
-Terratec/Unknown_home/1,-1.csv
-Terratec/Unknown_Cinergy/134,107.csv
-Terratec/Unknown_Cinergy/20,-1.csv
-Terratec/Unknown_Cinergy/4,235.csv
-Terratec/Internet Radio/4,243.csv
-Terratec/Unknown_M3PO/10,-1.csv
-Topfield/Unknown_PVR/32,-1.csv
-Topfield/Unknown_TF4000Fi/4,255.csv
-Topfield/Unknown_TF4000PVR/32,-1.csv
-Channel Master/Satellite/132,99.csv
-Tevion/Unknown_TDR51DV/0,159.csv
-Tevion/Unknown_TevionMd3607/7,-1.csv
-Tevion/Unknown_DFA/0,-1.csv
-Tevion/Unknown_TEV1020/0,-1.csv
-Tevion/Unknown_SAT928/5,-1.csv
-Tevion/Unknown_MDC-982PLL/162,162.csv
-Tevion/Unknown_MD/23,105.csv
-Tevion/Unknown_MD/48,-1.csv
-Tevion/Unknown_MD-5410/5,-1.csv
-Tevion/Unknown_RS20536/67,71.csv
-Tevion/Unknown_Tevion-MD80383/5,5.csv
-Tevion/Unknown_3830/1,-1.csv
-Tevion/Unknown_41666/131,69.csv
-Tevion/Unknown_DVD/67,71.csv
-Tevion/Unknown_TDR-250HD/0,159.csv
-Tevion/Unknown_Tevion-MD81035-ASAT-Code-0905/23,105.csv
-Tevion/Unknown_TE-0603/64,63.csv
-palmbutler/Unknown_palmbutler/7,-1.csv
-Proscan/DVD Player/5,-1.csv
-Proscan/DVD Player/15,-1.csv
-Proscan/Unknown_proscan-vcr/14,-1.csv
-Proscan/TV/15,-1.csv
-Hello Kitty/Unknown_Kitty/0,-1.csv
-Faroudja/Line Doubler/1,-1.csv
-Faroudja/DVD Player/175,-1.csv
-Faroudja/DVD Player/163,-1.csv
-Faroudja/Video Projector/135,78.csv
-Faroudja/Video Projector/30,-1.csv
-Faroudja/Video Projector/24,-1.csv
-Faroudja/Video Projector/24,24.csv
-Faroudja/Video Projector/1,-1.csv
-Faroudja/Video Projector/0,-1.csv
-Faroudja/Video Projector/13,-1.csv
-Faroudja/Processor/1,-1.csv
-Faroudja/Video Processor/27,-1.csv
-Faroudja/Video Processor/1,-1.csv
-Faroudja/Line Quadrupler/1,-1.csv
-General/Unknown_VCR/22,-1.csv
-Grand Tech/Cable Box/2,-1.csv
-Cisco/DVR/35,64.csv
-Draper/Electric Screen/0,-1.csv
-Draper/Dropdown Screen/0,-1.csv
-Draper/Screen/2,-1.csv
-Draper/Screen/0,-1.csv
-Hermstedt/Unknown_Hifidelio/16,-1.csv
-E Max/DVD Player/0,223.csv
-HP/Unknown_RC1762302-00/4,17.csv
-HP/Unknown_DV6331/4,17.csv
-HP/Unknown_Pavilion/4,15.csv
-HP/Unknown_RC1762307-01/4,15.csv
-HP/Unknown_RC2234302-01B/4,15.csv
-HP/Unknown_465539-002/4,15.csv
-HP/Unknown_DV4-1125NR/4,15.csv
-HP/Unknown_RC172308-01B/4,15.csv
-Medion/Unknown_medion/128,123.csv
-Medion/Unknown_rc2000/5,-1.csv
-Medion/Unknown_MD81880/23,105.csv
-Medion/Unknown_MD-5410/5,-1.csv
-Medion/Unknown_JX-2006B/0,-1.csv
-Medion/Unknown_MD81035/23,105.csv
-FUBA/Unknown_ALPS/134,75.csv
-FUBA/Unknown_FUBA/134,75.csv
-Delphi/Satellite Receiver/27,-1.csv
-Sharp/Unknown_sharp1781/1,-1.csv
-Sharp/Monitor/1,-1.csv
-Sharp/Unknown_SHARP/1,-1.csv
-Sharp/Unknown_G0048TA/19,-1.csv
-Sharp/Unknown_G1014BMSA/1,-1.csv
-Sharp/Unknown_RRMCGA030WJSA/8,48.csv
-Sharp/Unknown_CV-2131CK1/1,-1.csv
-Sharp/Unknown_GJ210/0,189.csv
-Sharp/Video Projector/13,-1.csv
-Sharp/VCR/3,-1.csv
-Sharp/Unknown_G0412GE/3,-1.csv
-Sharp/Unknown_G0938CESA/1,-1.csv
-Sharp/DTV Decoder/1,-1.csv
-Sharp/TV/1,-1.csv
-Sharp/Unknown_G1044BMSA/1,-1.csv
-DK digital/DVD Player/0,-1.csv
-Dedicated Micros/Camera Switcher/4,-1.csv
-Mitsubishi/Satellite/12,251.csv
-Mitsubishi/Receiver/119,-1.csv
-Mitsubishi/Receiver/168,-1.csv
-Mitsubishi/Receiver/71,-1.csv
-Mitsubishi/Receiver/87,-1.csv
-Mitsubishi/DSS/71,-1.csv
-Mitsubishi/DSS/64,-1.csv
-Mitsubishi/DSS/12,251.csv
-Mitsubishi/Monitor/119,-1.csv
-Mitsubishi/Monitor/4,-1.csv
-Mitsubishi/Monitor/71,-1.csv
-Mitsubishi/Monitor/2,-1.csv
-Mitsubishi/Monitor/87,-1.csv
-Mitsubishi/Monitor/130,100.csv
-Mitsubishi/Monitor/1,-1.csv
-Mitsubishi/DVD Player/71,-1.csv
-Mitsubishi/DVD Player/87,-1.csv
-Mitsubishi/DVD Player/103,-1.csv
-Mitsubishi/HDTV Receiver/71,-1.csv
-Mitsubishi/HDTV Receiver/12,251.csv
-Mitsubishi/Laser Disc/168,-1.csv
-Mitsubishi/Laser Disc/175,-1.csv
-Mitsubishi/DVD/103,-1.csv
-Mitsubishi/Video Projector/71,-1.csv
-Mitsubishi/VCR/119,-1.csv
-Mitsubishi/VCR/71,-1.csv
-Mitsubishi/VCR/23,-1.csv
-Mitsubishi/VCR/3,-1.csv
-Mitsubishi/VCR/7,-1.csv
-Mitsubishi/VCR/87,-1.csv
-Mitsubishi/Unknown_mitsubishi/71,-1.csv
-Mitsubishi/Unknown_HD1000/240,-1.csv
-Mitsubishi/CD Player Laser Disc/168,-1.csv
-Mitsubishi/CD Player/119,-1.csv
-Mitsubishi/Unknown/119,-1.csv
-Mitsubishi/Unknown/71,-1.csv
-Mitsubishi/Unknown/87,-1.csv
-Mitsubishi/Unknown_tv/71,-1.csv
-Mitsubishi/Cassette Tape/119,-1.csv
-Mitsubishi/Cassette Tape/141,-1.csv
-Mitsubishi/Cassette Tape/138,-1.csv
-Mitsubishi/Unknown_HS-349/87,-1.csv
-Mitsubishi/Unknown_75501/87,-1.csv
-Mitsubishi/TV/119,-1.csv
-Mitsubishi/TV/71,-1.csv
-Mitsubishi/TV/87,-1.csv
-Mitsubishi/TV/1,-1.csv
-Mitsubishi/Cable Box/0,-1.csv
-Bush/Unknown_4400/0,-1.csv
-Bush/Unknown_WS6680/0,-1.csv
-Bush/Unknown_DFTA1xi/8,-1.csv
-Bush/Light/29,-1.csv
-Acorp/Unknown_Acorp-878/134,107.csv
-Khl/Unknown_REC-R3000/65,-1.csv
-Echostar/Unknown_DSB-616/5,-1.csv
-Echostar/Unknown_DSB-636/4,0.csv
-Echostar/Satellite/0,0.csv
-Echostar/Satellite/4,-1.csv
-Echostar/Satellite/1,0.csv
-Echostar/Satellite/16,0.csv
-Echostar/Satelite DVR/0,0.csv
-Echostar/Satelite DVR/1,0.csv
-Echostar/Satelite DVR/1,4.csv
-Echostar/Satelite DVR/0,4.csv
-Echostar/Satelite DVR/2,-1.csv
-Echostar/DSS/0,0.csv
-Echostar/Sat_PVR Recorder Box/1,4.csv
-Echostar/Sat_PVR Recorder Box/0,4.csv
-Echostar/PVR SAT/0,0.csv
-Echostar/PVR SAT/1,0.csv
-Echostar/DVR/0,0.csv
-Echostar/DVR/1,0.csv
-Echostar/Dish Network/0,0.csv
-Echostar/Unknown_AD3000IP/4,0.csv
-eltax/Unknown_corniche/0,246.csv
-Symphonic/VCR/44,-1.csv
-Symphonic/VCR/40,-1.csv
-Symphonic/TV/41,-1.csv
-TEAC/DVD Player/175,-1.csv
-TEAC/DVD Player/163,-1.csv
-TEAC/Unknown_CD/134,97.csv
-TEAC/Unknown_RC-614/0,-1.csv
-TEAC/Unknown_RC-909/34,1.csv
-TEAC/Unknown_RC-548/128,114.csv
-TEAC/Unknown_RC-558/130,120.csv
-TEAC/Unknown_DMP/255,255.csv
-TEAC/Unknown_RC-547/3,1.csv
-Viewmaster/Unknown_RC-03/73,-1.csv
-Lifetec/Unknown_LT9096/128,123.csv
-Lifetec/Unknown_RC2000/5,-1.csv
-Lifetec/Unknown_remote/164,164.csv
-Vistron/Unknown_DVD-5211/0,-1.csv
-Vistron/Unknown_LTM-3271E/8,-1.csv
-Fresat/Unknown_SER-3000PL/8,64.csv
-Audio Refinement/Amplifier/20,-1.csv
-Audio Refinement/CD Player/20,-1.csv
-Audio Refinement/Tuner/20,-1.csv
-Insignia/DVD Player/135,34.csv
-Insignia/DVD_VCR Combo/45,45.csv
-Insignia/DVD_VCR Combo/110,-1.csv
-Insignia/Unknown_WIR147002-8301/67,71.csv
-Insignia/TV/134,5.csv
-Insignia/Blu-Ray/135,34.csv
-Insignia/Blu-Ray/133,237.csv
-AutumnWave/Unknown_Onair/8,-1.csv
-Fedders/Air Conditioner/32,-1.csv
-Siemens/Unknown_siemens1/49,-1.csv
-Siemens/Unknown_fb405/134,84.csv
-Siemens/Unknown_siemens-fb400/131,89.csv
-HERCULES/Unknown_SMARTTV/None,None.csv
-Falcon/Unknown_VT-1000/16,47.csv
-audiosonic/Unknown_TXCD-1240/129,129.csv
-Esoteric Audio/DVD Player/133,32.csv
-Barix/CD Jukebox/0,127.csv
-Cinemateq/DVD Player/26,0.csv
-Cinemateq/Video Scaler/27,1.csv
-Illusion/Unknown_M3/22,-1.csv
-Imerge/Digital Jukebox/14,-1.csv
-Imerge/Digital Jukebox/255,-1.csv
-Imerge/Digital Jukebox/162,-1.csv
-Imerge/Digital Jukebox/164,-1.csv
-Imerge/Digital Jukebox/166,-1.csv
-Imerge/Digital Jukebox/165,-1.csv
-Imerge/Digital Jukebox/161,-1.csv
-Imerge/Digital Jukebox/163,-1.csv
-Imerge/Digital Jukebox/191,-1.csv
-Fujitsu Siemens/Unknown_RC1-1241-21/32,176.csv
-Fujitsu Siemens/Unknown_RC811/4,15.csv
-Silvercrest/Unknown_URC-801/4,15.csv
-Silvercrest/Unknown_RCH7S52/32,-1.csv
-SHANNON/Unknown_SHANNON/None,None.csv
-Nakamichi/Receiver/92,161.csv
-Nakamichi/Receiver/130,93.csv
-Nakamichi/Receiver/186,-1.csv
-Nakamichi/Receiver/92,-1.csv
-Nakamichi/Receiver/103,-1.csv
-Nakamichi/Unknown_lirc.config/103,-1.csv
-Nakamichi/DVD Player/92,162.csv
-Nakamichi/Amplifier/87,-1.csv
-Nakamichi/CD Player/92,-1.csv
-Nakamichi/CD Player/103,-1.csv
-Nakamichi/Tuner/92,-1.csv
-Nakamichi/Tuner/103,-1.csv
-M3 Electronic/Unknown_DVD-209/0,-1.csv
-Mas/Unknown_HSD-400/0,-1.csv
-Mas/Unknown_RC-0135/6,-1.csv
-Mas/Unknown_HSD-303/0,-1.csv
-Protek/Unknown_Protek/1,-1.csv
-Midiland/Digital Decoder/81,175.csv
-RSQ/Karaoke/3,-1.csv
-RSQ/Karaoke/179,-1.csv
-RSQ/Karaoke/191,-1.csv
-Creative/Unknown_BreakOut-Box/None,None.csv
-Creative/Unknown_INFRA/33,172.csv
-Creative/Unknown_RM-1500/193,68.csv
-Creative/Unknown_RM-1800/193,68.csv
-Creative/Unknown_rm1000w/193,68.csv
-Creative/Unknown_DDTS-100/193,68.csv
-Creative/Unknown_RM900/193,68.csv
-Creative/Unknown_JUKEBOX3/33,172.csv
-Creative/Unknown_RM-850/193,68.csv
-Acer/Projector/8,19.csv
-Acer/Unknown_AT3201W/97,99.csv
-Acer/Unknown_Aspire/4,15.csv
-Acer/Unknown_RC-802/16,37.csv
-Mitochiba/Unknown_JX-9902/134,107.csv
-Mitochiba/Unknown_KF220100/134,107.csv
-fenner/Unknown_fenner/95,0.csv
-Supermax/Unknown_Supermax/128,38.csv
-Motorola/Unknown_DCT2524/0,-1.csv
-Motorola/Unknown_Cable/0,-1.csv
-Motorola/DSS/1,-1.csv
-Motorola/IP box/16,0.csv
-Motorola/Unknown_VIP/35,64.csv
-Motorola/Unknown_DTH355/134,47.csv
-Motorola/Remote/3,-1.csv
-Motorola/Remote/0,-1.csv
-Motorola/Unknown_DCT2000/0,-1.csv
-Motorola/Unknown_DTH320-4/134,47.csv
-Motorola/Unknown_MOTOROLA/0,-1.csv
-Motorola/Unknown_4dtv/0,-1.csv
-Motorola/Unknown_QIP2500/0,-1.csv
-Motorola/DVR/0,-1.csv
-Motorola/Unknown_RC1445302-00B-REV2/0,-1.csv
-Motorola/Unknown_DRC800/0,-1.csv
-Motorola/Unknown_DCT2244/0,-1.csv
-Motorola/Unknown_DVi2030/0,-1.csv
-Motorola/Unknown_DCH3416/0,-1.csv
-Motorola/Cable Box/170,-1.csv
-Motorola/Cable Box/4,-1.csv
-Motorola/Cable Box/5,1.csv
-Motorola/Cable Box/5,-1.csv
-Motorola/Cable Box/3,-1.csv
-Motorola/Cable Box/9,-1.csv
-Motorola/Cable Box/1,-1.csv
-Motorola/Cable Box/15,-1.csv
-Motorola/Cable Box/0,-1.csv
-Motorola/Cable Box/68,-1.csv
-Motorola/Cable Box/64,-1.csv
-Motorola/Cable Box/18,0.csv
-Motorola/Cox/0,-1.csv
-Motorola/Cox/64,-1.csv
-Atlantic Technology/Surround Processor/7,-1.csv
-Atlantic Technology/Surround Processor/64,64.csv
-Atlantic Technology/Surround Processor/131,95.csv
-Panda/Unknown_DVD-6838/0,-1.csv
-Logitech/Unknown_z5500/8,-1.csv
-Logitech/Unknown_HarmonyOne/30,-1.csv
-PS Audio/CD Player/20,-1.csv
-Twinhan/Unknown_AD-SP200/0,-1.csv
-Twinhan/Unknown_DTV/0,-1.csv
-Twinhan/Unknown_MagicBox/None,None.csv
-Mustek/Unknown_RMC-V300/16,237.csv
-Mustek/Unknown_MustekDVD/16,237.csv
-Mustek/Unknown_DVD/16,237.csv
-TECHNISAT/Unknown_100TS035/10,-1.csv
-TECHNISAT/Unknown_TTS35AI/10,-1.csv
-TECHNISAT/Unknown_ST3002S/1,-1.csv
-TECHNISAT/Unknown_st-6000e/131,121.csv
-TECHNISAT/Unknown_FBPNA35/10,-1.csv
-TECHNISAT/Unknown_ST3004S/1,-1.csv
-TECHNISAT/Unknown_TTS35AI.conf/10,-1.csv
-TECHNISAT/Unknown_FBPVR335A/10,-1.csv
-TECHNISAT/Unknown_TECHNISAT/1,-1.csv
-Sunfire/Surround Processor/184,3.csv
-Sunfire/Surround Processor/184,1.csv
-Sunfire/Surround Processor/184,0.csv
-huth/Unknown_prof/15,1.csv
-Ayre/Amplifier/16,-1.csv
-Coby/DVD Player/0,-1.csv
-Coby/TV/0,127.csv
-Mark/Unknown_rc5/0,-1.csv
-ReplayTV/Unknown_5000/1,0.csv
-Hokkaido/Unknown_Airconditioner/77,178.csv
+AmPro/Video Projector/11,-1.csv
+AmPro/Video Projector/134,-1.csv
+AmPro/Video Projector/5,1.csv
+AmPro/Video Projector/7,0.csv
+AmPro/Video Projector/85,-1.csv
+Amstrad/Twin Receiver/128,105.csv
+Amstrad/Unknown_DX3070/0,-1.csv
+Amstrad/Unknown_srd650/128,105.csv
+Amstrad/Unknown_SRX340/128,105.csv
 AMX/PLR-IR1/4,-1.csv
 AMX/PLR-IR1/85,-1.csv
-Yamada/Unknown_DVX-6xxx/4,-1.csv
-Yamada/Unknown_PVD-500/0,-1.csv
-2wire/Unknown_2wire/32,159.csv
-konig/Unknown_konig/128,99.csv
-Harman Kardon/Receiver/4,-1.csv
-Harman Kardon/Receiver/132,116.csv
-Harman Kardon/Receiver/132,66.csv
-Harman Kardon/Receiver/134,118.csv
-Harman Kardon/Receiver/164,-1.csv
-Harman Kardon/Receiver/128,112.csv
-Harman Kardon/Receiver/7,-1.csv
-Harman Kardon/Receiver/161,-1.csv
-Harman Kardon/Receiver/40,-1.csv
-Harman Kardon/Receiver/130,114.csv
-Harman Kardon/DVD Player/130,114.csv
-Harman Kardon/Video Projector/30,-1.csv
-Harman Kardon/Video Projector/1,-1.csv
-Harman Kardon/Video Projector/0,-1.csv
-Harman Kardon/Video Projector/7,0.csv
-Harman Kardon/Surround Processor/6,-1.csv
-Harman Kardon/Surround Processor/23,-1.csv
-Harman Kardon/Surround Processor/12,-1.csv
-Harman Kardon/Surround Processor/17,-1.csv
-Harman Kardon/Surround Processor/5,-1.csv
-Harman Kardon/Surround Processor/20,-1.csv
-Harman Kardon/Surround Processor/128,112.csv
-Harman Kardon/Surround Processor/16,-1.csv
-Harman Kardon/Surround Processor/0,-1.csv
-Harman Kardon/Surround Processor/18,-1.csv
-Harman Kardon/Surround Processor/64,-1.csv
-Harman Kardon/Surround Processor/130,114.csv
-Harman Kardon/Amplifier/128,112.csv
-Harman Kardon/Amplifier/130,114.csv
-Harman Kardon/CD Player/128,112.csv
-Harman Kardon/CD Player/0,-1.csv
-Harman Kardon/CD Player/131,74.csv
-Harman Kardon/Surround Receiver/128,112.csv
-Harman Kardon/Surround Receiver/130,114.csv
-Harman Kardon/Unknown_HD730/131,74.csv
-Harman Kardon/Unknown/130,114.csv
-Harman Kardon/CD-R/128,112.csv
-Harman Kardon/Cassette Tape/130,114.csv
-Harman Kardon/Unknown_Kardon-DVD/130,114.csv
-Harman Kardon/CD Changer/128,112.csv
-Harman Kardon/Unknown_DVD/130,114.csv
-Harman Kardon/iPod/130,114.csv
-Harman Kardon/Unknown_harmankardon/128,112.csv
-Harman Kardon/Pre-Amplifier/128,112.csv
-Harman Kardon/Pre-Amplifier/130,114.csv
-Harman Kardon/Tuner/128,112.csv
-Harman Kardon/Tuner/0,-1.csv
-Harman Kardon/Tuner/130,114.csv
-Harman Kardon/Blu-Ray/132,116.csv
-Loewe/Unknown_8500H/110,-1.csv
-Loewe/DVD Player/4,-1.csv
-Loewe/DVD Player/33,-1.csv
-Loewe/DVD Player/45,45.csv
-Loewe/DVD Player/32,-1.csv
-Loewe/DVD Player/0,-1.csv
-Loewe/Unknown_control/0,-1.csv
-Loewe/VCR/144,1.csv
-Loewe/VCR/144,0.csv
-Loewe/VCR/5,-1.csv
-Loewe/Unknown_150/255,255.csv
-Loewe/TV/31,-1.csv
-Loewe/TV/6,-1.csv
-Loewe/TV/33,-1.csv
-Loewe/TV/27,-1.csv
-Loewe/TV/5,-1.csv
-Loewe/TV/0,-1.csv
+Amytel/Unknown_ACI-200/0,-1.csv
+ANIMAX/MOUSE/0,-1.csv
+ANITECH/TV/0,-1.csv
+Antex Electronics/Satellite Radio/26,-1.csv
+anysee/Unknown_anysee/8,-1.csv
 AOC/TV/0,189.csv
-Century Concept/Unknown_dvd/0,246.csv
-X10/Unknown_MD1/None,None.csv
-Emerson/Unknown_Emerson-NB050-DVD/135,34.csv
-Emerson/Unknown_emerson/134,5.csv
-Emerson/Unknown_emerson-cd/3,1.csv
-Emerson/VCR/4,-1.csv
-Emerson/VCR/21,-1.csv
-Emerson/VCR/40,-1.csv
-Emerson/Unknown_emersontv/22,22.csv
-Emerson/TV/135,34.csv
-Emerson/TV/0,-1.csv
-Sony/Unknown_RM-D690/17,-1.csv
-Sony/Unknown_RM-D295/17,-1.csv
-Sony/Unknown_RM-X42/132,-1.csv
-Sony/Unknown_D1000/89,-1.csv
-Sony/Receiver/26,66.csv
-Sony/Receiver/4,-1.csv
-Sony/Receiver/6,-1.csv
-Sony/Receiver/23,-1.csv
-Sony/Receiver/176,-1.csv
-Sony/Receiver/144,-1.csv
-Sony/Receiver/12,-1.csv
-Sony/Receiver/17,-1.csv
-Sony/Receiver/11,-1.csv
-Sony/Receiver/20,-1.csv
-Sony/Receiver/7,-1.csv
-Sony/Receiver/2,-1.csv
-Sony/Receiver/16,-1.csv
-Sony/Receiver/36,-1.csv
-Sony/Receiver/1,-1.csv
-Sony/Receiver/121,-1.csv
-Sony/Receiver/15,-1.csv
-Sony/Receiver/48,-1.csv
-Sony/Receiver/26,73.csv
-Sony/Receiver/18,-1.csv
-Sony/Receiver/8,-1.csv
-Sony/Receiver/13,-1.csv
-Sony/Unknown_RM-D7M/15,-1.csv
-Sony/Unknown_RMT-506/7,-1.csv
-Sony/DSP/26,233.csv
-Sony/Unknown_rm-d5/17,-1.csv
-Sony/DSS/23,133.csv
-Sony/DSS/183,-1.csv
-Sony/DSS/5,1.csv
-Sony/DSS/11,-1.csv
-Sony/DSS/3,-1.csv
-Sony/DSS/1,-1.csv
-Sony/DSS/64,-1.csv
-Sony/Unknown_RM-D90/17,-1.csv
-Sony/DV Cam/7,-1.csv
-Sony/DV Cam/185,-1.csv
-Sony/DV Cam/217,-1.csv
-Sony/Unknown_CDIR/17,-1.csv
-Sony/Unknown_RMT-V108-VTR/255,255.csv
-Sony/Unknown_RM-DX740/17,-1.csv
-Sony/DVD Player/26,218.csv
-Sony/DVD Player/4,-1.csv
-Sony/DVD Player/26,83.csv
-Sony/DVD Player/26,98.csv
-Sony/DVD Player/164,-1.csv
-Sony/DVD Player/1,-1.csv
-Sony/DVD Player/26,73.csv
-Sony/Unknown_RM-860/1,-1.csv
-Sony/Unknown_TUNER/13,-1.csv
-Sony/Unknown_RM-DM7/17,-1.csv
-Sony/Unknown_sonytv/1,-1.csv
-Sony/Laser Disc/6,-1.csv
-Sony/Unknown_CD/17,-1.csv
-Sony/Unknown_RM-X47/132,-1.csv
-Sony/Unknown_RM-861/1,-1.csv
-Sony/Unknown_RM-D706/17,-1.csv
-Sony/Unknown_RM-Y180/1,-1.csv
-Sony/Unknown_rm-dm9/223,-1.csv
-Sony/Unknown_CDP-790/17,-1.csv
-Sony/Unknown_SCPH-10150.irman/255,255.csv
-Sony/Digital Recorder/26,154.csv
-Sony/Digital Recorder/26,98.csv
-Sony/Digital Recorder/1,-1.csv
-Sony/Digital Recorder/26,73.csv
-Sony/Unknown_870/1,-1.csv
-Sony/Video Projector/84,-1.csv
-Sony/Video Projector/26,42.csv
-Sony/Unknown_RMT-D129A/26,73.csv
-Sony/Unknown_VPL-W400/84,-1.csv
-Sony/Unknown_RM-X30/132,-1.csv
-Sony/Unknown_RM-V211T/2,-1.csv
-Sony/Unknown_RMT-DSC2/26,241.csv
-Sony/Unknown_RM-D55/17,-1.csv
-Sony/Surround Processor/26,233.csv
-Sony/Unknown_rm-x95/132,-1.csv
-Sony/Unknown_VaioRemote/4,15.csv
-Sony/VCR/25,37.csv
-Sony/VCR/186,-1.csv
-Sony/VCR/180,-1.csv
-Sony/VCR/11,-1.csv
-Sony/VCR/5,-1.csv
-Sony/VCR/7,-1.csv
-Sony/VCR/185,-1.csv
-Sony/VCR/2,-1.csv
-Sony/VCR/9,-1.csv
-Sony/VCR/25,69.csv
-Sony/VCR/1,-1.csv
-Sony/VCR/0,-1.csv
-Sony/Unknown_RMT-D126E/26,73.csv
-Sony/Unknown_RM-U302/255,255.csv
-Sony/Unknown_RM-D270/17,-1.csv
-Sony/Unknown_SONY/17,-1.csv
-Sony/Unknown_SONY/1,-1.csv
-Sony/Unknown_RM-Y812/183,-1.csv
-Sony/Unknown_RM-D520/17,-1.csv
-Sony/Mini-Disc/17,-1.csv
-Sony/Mini-Disc/15,-1.csv
-Sony/Unknown_RM-D991/17,-1.csv
-Sony/Unknown_RM-SG7/131,0.csv
-Sony/Unknown_rm-d10p/26,97.csv
-Sony/Unknown_RM-D320/17,-1.csv
-Sony/Unknown_RMT-V270/11,-1.csv
-Sony/Unknown_RM-873/1,-1.csv
-Sony/CD Player/17,-1.csv
-Sony/CD Player/57,-1.csv
-Sony/CD Player/1,-1.csv
-Sony/CD Player/81,-1.csv
-Sony/Unknown_rm-v10t/1,-1.csv
-Sony/Unknown_RM-SG20/131,0.csv
-Sony/Unknown_RM-SG5/131,0.csv
-Sony/Unknown_RM-D921/17,-1.csv
-Sony/Unknown_lircd.conf/17,-1.csv
-Sony/Unknown_RM-ED019/26,73.csv
-Sony/Unknown_DAT/28,-1.csv
-Sony/DAT/28,-1.csv
-Sony/Unknown_tv/2,-1.csv
-Sony/Unknown_tv/1,-1.csv
-Sony/Boombox/100,-1.csv
-Sony/Boombox/68,-1.csv
-Sony/Unknown_RMT-B101A/26,226.csv
-Sony/Unknown_RMT-136/2,-1.csv
-Sony/TiVo/26,154.csv
-Sony/TiVo/23,133.csv
-Sony/TiVo/183,-1.csv
-Sony/Cassette Tape/14,-1.csv
-Sony/Cassette Tape/16,-1.csv
-Sony/Unknown_rm-d29m/15,-1.csv
-Sony/Unknown_RM-W101/1,-1.csv
-Sony/Unknown_RM-D325/17,-1.csv
-Sony/Unknown_RMT-V107/11,-1.csv
-Sony/Unknown_RM-D797/17,-1.csv
-Sony/Unknown_RM-X40/132,-1.csv
-Sony/CD Changer/17,-1.csv
-Sony/Unknown_RM-687C/1,-1.csv
-Sony/Unknown_RM-Y800/183,-1.csv
-Sony/Unknown_RMT-V501A/26,83.csv
-Sony/Unknown_sony-cd/17,-1.csv
-Sony/Unknown_RM-D190/17,-1.csv
-Sony/Unknown_DVD/26,18.csv
-Sony/Unknown_DVD/26,73.csv
-Sony/Unknown_RM-PJP1/26,42.csv
-Sony/Unknown_RM-D820/17,-1.csv
-Sony/Unknown_RMT-CS33R/255,255.csv
-Sony/CD Jukebox/26,153.csv
-Sony/CD Jukebox/23,-1.csv
-Sony/CD Jukebox/17,-1.csv
-Sony/CD Jukebox/57,-1.csv
-Sony/CD Jukebox/36,-1.csv
-Sony/CD Jukebox/1,-1.csv
-Sony/CD Jukebox/81,-1.csv
-Sony/TV/119,-1.csv
-Sony/TV/84,-1.csv
-Sony/TV/183,-1.csv
-Sony/TV/3,-1.csv
-Sony/TV/164,-1.csv
-Sony/TV/1,-1.csv
-Sony/TV/151,-1.csv
-Sony/TV/26,42.csv
-Sony/Pre-Amplifier/26,66.csv
-Sony/Pre-Amplifier/6,-1.csv
-Sony/Pre-Amplifier/23,-1.csv
-Sony/Pre-Amplifier/183,-1.csv
-Sony/Pre-Amplifier/144,-1.csv
-Sony/Pre-Amplifier/12,-1.csv
-Sony/Pre-Amplifier/17,-1.csv
-Sony/Pre-Amplifier/11,-1.csv
-Sony/Pre-Amplifier/20,-1.csv
-Sony/Pre-Amplifier/7,-1.csv
-Sony/Pre-Amplifier/2,-1.csv
-Sony/Pre-Amplifier/16,-1.csv
-Sony/Pre-Amplifier/36,-1.csv
-Sony/Pre-Amplifier/15,-1.csv
-Sony/Pre-Amplifier/26,73.csv
-Sony/Pre-Amplifier/18,-1.csv
-Sony/Unknown_RM-D391/17,-1.csv
-Sony/Unknown_RM-Y155B/1,-1.csv
-Sony/Unknown_RM-D302/17,-1.csv
-Sony/Unknown_RMT-CF1A/26,19.csv
-Sony/Unknown_RMT-D126A/26,73.csv
-Sony/Unknown_RM-Y173/1,-1.csv
-Sony/Unknown_RMT-D115P/26,73.csv
-Sony/Unknown_sonyRM-sep303/4,-1.csv
-Proceed/Surround Processor/5,-1.csv
-viewmaxpro/Unknown_viewmaxpro/32,64.csv
-Avermedia/Unknown_RM-H7/0,237.csv
-Avermedia/Unknown_RM-KV/4,-1.csv
-Avermedia/Unknown_Avermedia/64,-1.csv
-Avermedia/Unknown_AVerTV5/0,237.csv
-Novaplex/Cable Box/27,-1.csv
-Thinkgeek/Unknown_Lightbulb/64,-1.csv
-Linksys/Media Adapter/134,107.csv
-Linksys/Unknown_WMA11B-R/134,107.csv
-Fosgate/Surround Processor/132,66.csv
-Fosgate/Pre-Amplifier/64,64.csv
-Fosgate/Pre-Amplifier/131,69.csv
-Fosgate/Pre-Amplifier/131,95.csv
-Vizio/Unknown_VX37L/4,-1.csv
-Vizio/Unknown_Vizio/4,-1.csv
-Tensai/Unknown_5340fb/134,124.csv
-Lpi/Unknown_PCremote/71,-1.csv
-multiTEC/Unknown_multiTEC/7,-1.csv
-devinput/Unknown_devinput/None,None.csv
-Casio/Unknown_CMD-40/170,-1.csv
-Nebula Electronics/Unknown_DVB/0,-1.csv
-Umax/Unknown_D-701/0,240.csv
-Genesis/Theater in Box/0,-1.csv
-E-tech/Unknown_FLY98/96,1.csv
-Digital Stream/HDTV Tuner/4,2.csv
-Digital Stream/Unknown_Stream/18,52.csv
-Sansonic/Unknown_FT-300A/0,-1.csv
-RCA/DSS/7,-1.csv
-RCA/DSS/15,-1.csv
-RCA/Unknown_TV/15,-1.csv
-RCA/Unknown_DTA800b/7,-1.csv
-RCA/DVD Player/5,-1.csv
-RCA/Laser Disc/13,-1.csv
-RCA/Unknown_BR-RCA/39,-1.csv
-RCA/VCR/14,-1.csv
-RCA/VCR/15,-1.csv
-RCA/Unknown_R130A1/15,-1.csv
-RCA/Unknown_RCZ/135,94.csv
-RCA/TV/14,-1.csv
-RCA/TV/7,-1.csv
-RCA/TV/15,-1.csv
-RCA/Unknown_RCA-F20507CP/15,-1.csv
-Scott/Unknown_scott-dvd/4,-1.csv
-Scott/Unknown_DVD-838/8,-1.csv
-italtel/Unknown_italtel/1,-1.csv
-Hama/Unknown_PhotoPlayer/134,107.csv
-Hama/Unknown_Internet/0,-1.csv
-Palcom/Unknown_DSL-6/192,-1.csv
-Tab Electronics/Unknown_Kit/0,-1.csv
-Luxor/Unknown_DV405/67,71.csv
-3M/Video Projector/134,-1.csv
-3M/Projector/134,-1.csv
-Goodmans/Unknown_md305/135,108.csv
-Goodmans/Unknown_GDB/8,-1.csv
-Goodmans/Unknown_GDVD124/0,-1.csv
-Goodmans/Unknown_RC-BM/128,123.csv
-Adelphia/Cable Box/27,-1.csv
-Adelphia/Cable Box/1,-1.csv
-Adelphia/Cable Box/0,-1.csv
-TCM/Unknown_225925/24,233.csv
-TCM/Unknown_218681/5,5.csv
-TCM/Unknown_96518/0,-1.csv
-TCM/Unknown_TCM/176,0.csv
-TCM/Unknown_225926/35,-1.csv
-TCM/Unknown_212845-CD/5,-1.csv
-Big Ben/Game Console/67,164.csv
-Crestron/Lighting Controller/30,-1.csv
-Crestron/IR Receiver/4,-1.csv
-Crestron/IR Receiver/3,-1.csv
-Crestron/IR Receiver/2,-1.csv
-Crestron/IR Receiver/1,-1.csv
-Crestron/IR Receiver/0,-1.csv
-Crestron/Music Server/14,-1.csv
-Knoll/Video Projector/24,233.csv
-Hampton Bay/Unknown_Bay/129,102.csv
-Friedrich/Air Conditioner/16,-1.csv
-Friedrich/Air Conditioner/1,-1.csv
-Toshiba/Unknown_CT-90326/64,-1.csv
-Toshiba/Unknown_CT-816/64,-1.csv
-Toshiba/Unknown_SE-R0031/69,-1.csv
-Toshiba/Unknown_CT-9881/134,107.csv
-Toshiba/DVD Player/69,-1.csv
-Toshiba/Unknown_SE-R0127/69,-1.csv
-Toshiba/Unknown_Toshiba-SE-R0090/69,-1.csv
-Toshiba/Unknown_TOSHTV/64,-1.csv
-Toshiba/Unknown_CT-90298/64,-1.csv
-Toshiba/Unknown_VT-204G/68,-1.csv
-Toshiba/Unknown_CT-90205/231,10.csv
-Toshiba/Unknown_SE-R0313/69,186.csv
-Toshiba/Unknown_CT-9573/64,-1.csv
-Toshiba/Unknown_CT-9784/64,-1.csv
-Toshiba/VCR/68,-1.csv
-Toshiba/Unknown_CT-90038/231,10.csv
-Toshiba/Unknown_VT-11/68,-1.csv
-Toshiba/Unknown_toshiba-RM-A210/42,-1.csv
-Toshiba/Unknown_G83C0008A110/4,15.csv
-Toshiba/Unknown_SE-R0058/69,-1.csv
-Toshiba/Unknown_Toshiba-SE-R0047/69,-1.csv
-Toshiba/Unknown_CT-9952/64,-1.csv
-Toshiba/Unknown_toshiba-tv/255,255.csv
-Toshiba/Unknown_RM-614Q/5,5.csv
-Toshiba/Unknown_CT-826/64,-1.csv
-Toshiba/Unknown_VC-642T/68,-1.csv
-Toshiba/Unknown_TOSHIBA/68,-1.csv
-Toshiba/Unknown_TOSHIBA/64,-1.csv
-Toshiba/Unknown_CT-832/64,-1.csv
-Toshiba/Unknown_TSR-101R/66,187.csv
-Toshiba/TV/64,-1.csv
-Toshiba/Unknown_VC-90B/68,-1.csv
-Toshiba/Unknown_VT-209W/68,-1.csv
-Toshiba/Unknown_VT-75F/68,-1.csv
-Toshiba/Unknown_CT-859/64,-1.csv
-Toshiba/Unknown_SE-R0049/69,-1.csv
-Allsat/Unknown_sat/8,-1.csv
-QUADRAL/Unknown_RC-804/19,1.csv
-Expressvu/Unknown_3100/0,0.csv
-Zalman/Unknown_HD160XT/115,154.csv
-Aesthetix/Pre-Amplifier/16,-1.csv
-Visionetics/Unknown_Cable/134,107.csv
-B.A.T./Pre-Amplifier/16,-1.csv
-Canalsat/Satellite/10,-1.csv
-Canalsat/Unknown_CanalSat/10,-1.csv
-Canalsat/Unknown_CanalSatHD/10,-1.csv
-ADS/AUDIO_Tech/0,-1.csv
-ADS/TV_Instant/2,-1.csv
-Cool Sat/Satellite/64,64.csv
-Schwaiger/Unknown_DSR/0,-1.csv
-Fisher/Unknown_RCA-9060/54,-1.csv
-Fisher/Unknown_RC720F/104,-1.csv
-Fisher/Surround Processor/54,200.csv
-Fisher/Surround Processor/48,48.csv
-Fisher/Unknown_REM-1500/162,162.csv
-Fisher/Unknown_ra/60,-1.csv
-Fisher/TV/0,-1.csv
-Fisher/TV/56,-1.csv
-Tekram/Unknown_M230/None,None.csv
-Video7/Unknown_Video7-RC750/32,-1.csv
-iPort/MP3 Player/1,222.csv
-iPort/iPort/1,222.csv
-iPort/iPod/1,222.csv
-Golden Interstar/Sat/128,255.csv
-Golden Interstar/Unknown_Interstar/4,16.csv
-Total Control/Unknown_Control/7,-1.csv
-Now Broadband TV/Unknown_Broadband/128,110.csv
-Now Broadband TV/Unknown_Broadband/64,64.csv
-DIFRNCE/Unknown_DVD5010S/0,-1.csv
-Manta/Unknown_DVD-002/0,-1.csv
-Manta/Unknown_DVD-007/0,-1.csv
-Canon/Unknown_WL-D77/133,118.csv
-Canon/Unknown_canon/133,118.csv
-Canon/Unknown_WL-V1/129,6.csv
-Canon/Unknown_CAM/133,118.csv
-Canon/Video Projector/129,6.csv
-Canon/Unknown_WL-D80/133,118.csv
-Canon/Unknown_WL-DC100/202,177.csv
-AccessHD/CONVERTER_DTA1080U/0,191.csv
-Voxson/Unknown_PT2222-1/0,-1.csv
-Revoy/Unknown_Revoy2200/0,153.csv
-Cph03x/Unknown_AS-218/134,107.csv
-Syabas/Unknown_A-100/4,203.csv
-Mark Levinson/CD Player/3,-1.csv
-Mark Levinson/CD Player/2,-1.csv
-Mark Levinson/CD Player/16,-1.csv
-Mark Levinson/CD Player/1,-1.csv
-Mark Levinson/Pre-Amplifier/4,-1.csv
-Mark Levinson/Pre-Amplifier/7,-1.csv
-Gericom/Plasma/3,-1.csv
-Gran Prix/Unknown_prix/0,-1.csv
-Hivion/Unknown_SAT/64,64.csv
-Kaleidescape/DVD Player/69,-1.csv
-Kaleidescape/Distributed/69,-1.csv
-AmPro/Video Projector/5,1.csv
-AmPro/Video Projector/11,-1.csv
-AmPro/Video Projector/85,-1.csv
-AmPro/Video Projector/7,0.csv
-AmPro/Video Projector/134,-1.csv
-Zyxel/Unknown_DMA-1000/8,230.csv
-Audio Research/Pre-Amplifier/7,-1.csv
-Extron/Switcher/128,84.csv
-Extron/Switcher/0,-1.csv
-Advanced Acoustics/Unknown_Acoustic/36,75.csv
-PHAST/PLR-IR1/85,-1.csv
-ABS/SAT_8776/8,0.csv
-Quasar/TV/128,0.csv
-Harman Video/Video Projector/1,-1.csv
-Harman Video/Video Projector/7,0.csv
-Coolsat/Unknown_Pro/1,-1.csv
-Olympus/Unknown_RM-1/134,59.csv
-Olympus/Unknown_RM-2/134,59.csv
-TELEFUNKEN/VCR_FB1550/67,-1.csv
-TELEFUNKEN/TV_RC-1345/5,-1.csv
-TELEFUNKEN/VCR_RC1323-Video-B/8,-1.csv
-TELEFUNKEN/AUDIO_IR3000/0,1.csv
-TELEFUNKEN/TV_1127/7,-1.csv
-Bell ExpressVu/Satellite/0,0.csv
-Bell ExpressVu/Satellite/1,0.csv
-Bell ExpressVu/Satellite/16,0.csv
-Bell ExpressVu/HD DVR/0,0.csv
-Bell ExpressVu/HD DVR/12,0.csv
-Bell ExpressVu/HD DVR/1,0.csv
-Bell ExpressVu/HD DVR/7,-1.csv
-Rotel/Unknown_RR-925/131,18.csv
-Rotel/CD Player/20,-1.csv
-Rotel/Tuner/82,0.csv
-Busch-Jaeger/Elektro/30,-1.csv
-Busch-Jaeger/Elektro/29,-1.csv
-Hinen Electronics/Unknown_Electronics/0,-1.csv
-Xantech/Programmer/6,-1.csv
-Xantech/Relay Module/6,-1.csv
-Galaxis/Satellite/13,80.csv
-Galaxis/Unknown_Galaxis-RCMM/13,80.csv
-Galaxis/Unknown_Galaxis.sat/81,175.csv
-Galaxis/Unknown_GALAXIS-RC5/0,-1.csv
-Galaxis/Unknown_rc1/7,-1.csv
-NTL/Unknown_DI4001N/10,-1.csv
-trio/Unknown_xms007/8,-1.csv
-roadstar/Unknown_dvd/136,-1.csv
-Parasound/Receiver/3,240.csv
-Parasound/Receiver/134,97.csv
-Parasound/Receiver/27,-1.csv
-Parasound/Surround Processor/3,240.csv
-TCUAG/Unknown_TVBOX/6,-1.csv
-Hyundai/Unknown_H-DVD5038N/0,251.csv
-Hyundai/Unknown_l17t/170,3.csv
-Meliconi/Unknown_Speedy/7,7.csv
-Meliconi/Unknown_MELICONI-U3/10,-1.csv
-Meliconi/Unknown_Facile/0,-1.csv
-Meliconi/Unknown_MeliconiSpeedy2/5,-1.csv
-SEG/Unknown_SEG-VCR4300/21,-1.csv
-SEG/Unknown_VCR2000/134,124.csv
-SEG/Unknown_SEG-DVD-430/32,-1.csv
-SEG/Unknown_SR-040/133,115.csv
-SEG/Unknown_SR-201/66,253.csv
-SEG/Unknown_SR800/4,-1.csv
-SEG/Unknown_VCR/21,-1.csv
-SEG/Unknown_E6900-X020A/2,-1.csv
-ProPlay/Unknown_PS2/0,246.csv
-NET TV/TV/2,-1.csv
-COSMEL/Unknown_COSMEL/2,-1.csv
-CIS BOX/Receiver/25,11.csv
-CIS BOX/Receiver/144,-1.csv
-CIS BOX/Receiver/25,107.csv
-CIS BOX/Receiver/7,-1.csv
-CIS BOX/Receiver/16,-1.csv
-CIS BOX/Receiver/121,-1.csv
-CIS BOX/Receiver/48,-1.csv
-CIS BOX/DSS/183,-1.csv
-CIS BOX/DVD Player/26,122.csv
-CIS BOX/DVD Player/26,73.csv
-CIS BOX/DVD Changer/26,98.csv
-CIS BOX/DVD Changer/26,73.csv
-CIS BOX/LCD Projector/84,-1.csv
-CIS BOX/VCR/2,-1.csv
-CIS BOX/CD Player/17,-1.csv
-CIS BOX/HDTV ALL/26,26.csv
-CIS BOX/HDTV ALL/164,-1.csv
-CIS BOX/HDTV ALL/1,-1.csv
-CIS BOX/HDTV ALL/151,-1.csv
-CIS BOX/Plasma/119,-1.csv
-CIS BOX/Plasma/164,-1.csv
-CIS BOX/Plasma/1,-1.csv
-CIS BOX/TV/26,26.csv
-CIS BOX/TV/84,-1.csv
-CIS BOX/TV/164,-1.csv
-CIS BOX/TV/1,-1.csv
-Wilfa/Unknown_RVC-17/64,175.csv
-Digital Projection/Video Projector/32,-1.csv
-Digital Projection/Projector/32,-1.csv
-Digital Projection/Video Scaler/58,-1.csv
-Onkyo/Unknown_RC-425DV/210,43.csv
-Onkyo/Receiver/210,109.csv
-Onkyo/Receiver/210,108.csv
-Onkyo/Unknown_CR-70R/210,109.csv
-Onkyo/DVD Player/69,-1.csv
-Onkyo/DVD Player/210,43.csv
-Onkyo/Laser Disc/168,-1.csv
-Onkyo/Unknown_RC-50/210,-1.csv
-Onkyo/Unknown_RC-104C/210,-1.csv
-Onkyo/Unknown_RC-146T/210,13.csv
-Onkyo/Unknown_rc-211s/210,109.csv
-Onkyo/Amplifier/210,109.csv
-Onkyo/Amplifier/210,108.csv
-Onkyo/CD Player/210,44.csv
-Onkyo/CD Player/210,13.csv
-Onkyo/CD Player/132,117.csv
-Onkyo/CD Player/210,109.csv
-Onkyo/Unknown_lircd.conf/210,31.csv
-Onkyo/Unknown/210,44.csv
-Onkyo/Unknown/210,109.csv
-Onkyo/Unknown_RC-184s/210,109.csv
-Onkyo/Cassette Tape/210,13.csv
-Onkyo/Cassette Tape/132,89.csv
-Onkyo/Unknown_rc-252s/210,109.csv
-Onkyo/Unknown_Onkyo/210,44.csv
-Onkyo/Unknown_Onkyo/210,109.csv
-Onkyo/Unknown_Onkyo/160,10.csv
-Onkyo/Unknown_RC-682M/210,43.csv
-Onkyo/Tuner/210,109.csv
-Onkyo/Tuner/210,37.csv
-Xtreamer/Unknown_Xtreamer/0,-1.csv
-KEY DIGITAL/Component Switcher/130,19.csv
-KEY DIGITAL/Video Switcher/27,-1.csv
-KEY DIGITAL/Video Switcher/132,-1.csv
-KEY DIGITAL/Video Switcher/130,19.csv
-KEY DIGITAL/Matrix Switcher/27,-1.csv
-KEY DIGITAL/Matrix Switcher/132,-1.csv
-KEY DIGITAL/Matrix Switcher/130,19.csv
-KEY DIGITAL/Switcher/130,19.csv
-Camera/Camera Multi Plex/133,115.csv
-Integra/Receiver/210,25.csv
-Integra/Receiver/210,172.csv
-Integra/Receiver/210,21.csv
-Integra/Receiver/210,19.csv
-Integra/Receiver/210,109.csv
-Integra/Receiver/210,23.csv
-Integra/Receiver/210,108.csv
-Integra/Receiver/210,20.csv
-Integra/Receiver/210,43.csv
-Integra/Receiver/210,30.csv
-Integra/Receiver/210,2.csv
-Integra/Receiver/210,18.csv
-Integra/Receiver/210,24.csv
-Integra/Receiver/210,17.csv
-Integra/Receiver/210,1.csv
-Integra/Receiver/210,22.csv
-Integra/DVD Player/210,43.csv
-Integra/DVD Player/69,181.csv
-Integra/DVD Player/210,31.csv
-Integra/Media PC/4,15.csv
-Integra/Integrated Amplifier/71,-1.csv
-Integra/Integrated Amplifier/210,109.csv
-Integra/Amplifier/71,-1.csv
-Integra/Amplifier/210,109.csv
-Integra/Digital Audio/210,9.csv
-Integra/Digital Audio/210,3.csv
-Integra/Digital Audio/210,4.csv
-Integra/CD Player/210,44.csv
-Integra/HD DVD/69,181.csv
-Integra/iPod/210,172.csv
-Integra/iPod/210,109.csv
-Integra/iPod/210,108.csv
-Integra/iPod/210,2.csv
-Integra/Pre-Amplifier/210,25.csv
-Integra/Pre-Amplifier/210,172.csv
-Integra/Pre-Amplifier/210,109.csv
-Integra/Pre-Amplifier/210,108.csv
-Integra/Pre-Amplifier/210,30.csv
-Integra/Pre-Amplifier/210,2.csv
-Integra/Tuner/210,109.csv
-Integra/Tuner/210,2.csv
-Integra/Blu-Ray/210,31.csv
-Multi Canal/Unknown_Canal/133,123.csv
-Televes/Unknown_145075/8,-1.csv
-Televes/Unknown_711701/1,-1.csv
-Radio Shack/Unknown_Radioshack2115/5,-1.csv
-Radio Shack/Unknown_RadioShack/3,1.csv
-Radio Shack/Unknown_RS2142/5,-1.csv
-Tesla/Unknown_Tesla/11,11.csv
-Tesla/Unknown_Tesla/5,-1.csv
-Tesla/Unknown_32LCD70WDGHD/1,-1.csv
-Harmony/PS3 Adaptor/11,-1.csv
-Euroconsumers/Unknown_LG-5988/136,-1.csv
-Micromega/DVD Player/4,-1.csv
-Adcom/Receiver/26,232.csv
-Adcom/Receiver/81,0.csv
-Adcom/Receiver/26,-1.csv
-Adcom/Surround Processor/26,-1.csv
-Adcom/CD Player/26,-1.csv
-Adcom/AV Preamplifier/26,-1.csv
-Adcom/Unknown/81,0.csv
-Adcom/Unknown/26,-1.csv
-Adcom/Pre-Amplifier/88,23.csv
-Adcom/Pre-Amplifier/232,26.csv
-Adcom/Pre-Amplifier/26,232.csv
-Adcom/Pre-Amplifier/81,0.csv
-Adcom/Pre-Amplifier/26,-1.csv
-Adcom/Tuner/26,-1.csv
-Teleka/Unknown_STR2060/1,-1.csv
-TiVo/TiVo/133,48.csv
-TiVo/Unknown_Series1/133,48.csv
-TiVo/PVR/26,154.csv
-Aspire Digital/Unknown_Digital/8,-1.csv
-Nikko/Unknown_Nikko/5,-1.csv
-Avex/Unknown_AVEX-AV5609/5,-1.csv
-Avex/Unknown_AVEX-RC501/5,-1.csv
-Technosonic/Unknown_DVD-204/16,237.csv
-NEC/Unknown_RB-DV22/45,45.csv
-NEC/Unknown_RD-409E/24,233.csv
-NEC/Receiver/4,-1.csv
-NEC/Receiver/25,-1.csv
-NEC/Receiver/26,197.csv
-NEC/Receiver/26,231.csv
-NEC/Receiver/26,-1.csv
-NEC/Receiver/26,225.csv
-NEC/Receiver/26,228.csv
-NEC/Unknown_RB-D3A/25,-1.csv
-NEC/Unknown_RC-334E/24,233.csv
-NEC/Monitor/4,-1.csv
-NEC/Monitor/25,-1.csv
-NEC/Unknown_RD-1083E/24,-1.csv
-NEC/Unknown_RD-1078E/24,-1.csv
-NEC/Unknown_RD-348E/24,233.csv
-NEC/Video Projector/24,247.csv
-NEC/Video Projector/24,233.csv
-NEC/Surround Processor/26,228.csv
-NEC/Surround Processor/13,-1.csv
-NEC/Unknown_RB-34P/25,-1.csv
-NEC/VCR/4,-1.csv
-NEC/VCR/25,-1.csv
-NEC/VCR/10,-1.csv
-NEC/Unknown_RD-343E/24,233.csv
-NEC/Unknown_RD-337E/2,-1.csv
-NEC/Unknown_UR-3020/24,247.csv
-NEC/Unknown_RB-73A/25,-1.csv
-NEC/Unknown_RC-1065E/24,-1.csv
-NEC/Unknown_TRB-968A/25,-1.csv
-NEC/Unknown/25,-1.csv
-NEC/Unknown/25,231.csv
-NEC/Unknown_RC-1083E/24,-1.csv
-NEC/Unknown_RU-1220S/24,247.csv
-NEC/Unknown_RC-6010/24,247.csv
-NEC/Unknown_RD-1077E/24,-1.csv
-NEC/TV/4,-1.csv
-NEC/TV/24,-1.csv
-NEC/TV/24,24.csv
-NEC/Unknown_RD-427E/24,233.csv
-NEC/Unknown_TRB-60/49,-1.csv
-United/Unknown_United-DVD4057M/0,-1.csv
-Vivanco/Unknown_UR2/10,-1.csv
-Vivanco/Unknown_ur89/0,-1.csv
-Vivanco/Unknown_DVD/26,73.csv
-dual/Unknown_dual/68,-1.csv
-Bogen/Amplifier/1,-1.csv
-Luxman/Receiver/204,-1.csv
-Luxman/CD Player/204,-1.csv
-Gigabyte/Unknown_TV/134,107.csv
-Slim Art/Unknown_SA-100/0,-1.csv
-Malata/DVD Player/1,-1.csv
-Intervision/Unknown_Intervision/134,107.csv
-Ranex/Unknown_RGB/64,-1.csv
-General Instruments/Unknown_550/-1,-1.csv
-General Instruments/Unknown_XRC-200/0,-1.csv
-SABA/Unknown_SabaTC460/7,-1.csv
-SABA/Unknown_TC3003/7,-1.csv
-Rio/Unknown_Audio/130,19.csv
-Cyron/Lighting Controller/2,189.csv
-MAGIC LIGHTING/Lighting/0,-1.csv
-Tivoli/Unknown_Sirius/0,-1.csv
-MISSION/CD Player/20,-1.csv
-Genius/Unknown_Genius-DVB-T32/5,-1.csv
-remotec/Unknown_remotec1072/5,-1.csv
-remotec/Unknown_TV/0,-1.csv
-remotec/Unknown_MEDIAMASTER/None,None.csv
-remotec/Unknown_rm200/1,-1.csv
-remotec/Unknown_remotec/0,-1.csv
-Interact/Unknown_I-22121/0,-1.csv
-Provision/Unknown_PRDVD2166/0,153.csv
-Provision/Unknown_PR-DVD2.0/1,-1.csv
-D-LINK/Unknown_DSM320/8,230.csv
-D-LINK/MP3 Player/8,230.csv
-D-LINK/MP3 Player/18,37.csv
-D-LINK/Unknown_i2eye/130,19.csv
-D-LINK/Media Center/8,230.csv
-D-LINK/Media Center/8,231.csv
-D-LINK/Unknown_DSM-10/8,230.csv
-Hewlett Packard/Plasma/2,17.csv
-Hewlett Packard/Plasma/18,17.csv
-Hewlett Packard/TV/2,17.csv
-Hewlett Packard/TV/18,17.csv
-Virgin-media/Unknown_VIRGINTIVO/10,-1.csv
-ITT/Unknown_ITT/49,-1.csv
-ITT/Unknown_RC51/49,-1.csv
-ITT/Unknown_ITTNOKIA/49,-1.csv
-ITT/Unknown_RC40/49,-1.csv
-Klipsch/Subwoofer/17,81.csv
-ABIT/DVD_WINDVD/1,-1.csv
-Fagor/Unknown_TEDI100/192,-1.csv
-VocoPro/Karaoke/32,1.csv
-Krell/Receiver/31,-1.csv
-Krell/Receiver/28,-1.csv
-Krell/DVD Player/27,-1.csv
-Krell/Surround Processor/31,-1.csv
-Krell/Surround Processor/25,-1.csv
-Krell/Surround Processor/28,-1.csv
-Krell/Surround Processor/16,-1.csv
-Krell/CD Player/20,-1.csv
-Krell/CD Player/16,-1.csv
-Krell/Pre-Amplifier/25,-1.csv
-Krell/Pre-Amplifier/28,-1.csv
-Krell/Pre-Amplifier/16,-1.csv
-InFocus/Video Projector/135,78.csv
-InFocus/Video Projector/78,135.csv
-InFocus/Video Projector/123,2.csv
-InFocus/Video Projector/131,85.csv
-InFocus/Video Projector/80,79.csv
-InFocus/Video Projector/1,-1.csv
-InFocus/Video Projector/15,-1.csv
-InFocus/Video Projector/2,1.csv
-InFocus/Projector/135,78.csv
-InFocus/Unknown_remote/135,78.csv
-InFocus/Unknown_ScreenPlay/135,78.csv
-InFocus/Plasma/7,-1.csv
-InFocus/DLP Projector/15,-1.csv
-InFocus/Unknown_InFocus-SP8600/49,-1.csv
-rubin/Unknown_rubin/0,-1.csv
-Peekton/Unknown_IR6005/0,-1.csv
-Bluesky/Unknown_DV900/5,-1.csv
-Bang Olufsen/CD Player/26,73.csv
-Guillemot/Unknown_RemoteWizard-GN-263/134,107.csv
-McIntosh/Receiver/202,85.csv
-McIntosh/DVD Player/128,80.csv
-McIntosh/Laser Disc/168,-1.csv
-McIntosh/Control System/202,85.csv
-McIntosh/CD Player/202,149.csv
-McIntosh/Pre-Amplifier/202,85.csv
-Dwin/Video Projector/15,-1.csv
-Dwin/Video Projector/7,0.csv
-Dwin/Projector/15,-1.csv
-Dwin/Video Processor/1,-1.csv
-Dwin/Video Processor/7,0.csv
-Dwin/Line Multiplier/1,-1.csv
-Dwin/Plasma/15,-1.csv
-Dwin/TV/15,-1.csv
-UPC/Unknown_SAT/39,-1.csv
-Humax/Tivo + DVD/133,48.csv
-Humax/Satellite/0,17.csv
-Humax/Satellite/0,73.csv
-Humax/Satellite/0,23.csv
-Humax/Unknown_F1CI/0,16.csv
-Humax/Com Hem Box/0,16.csv
-Humax/Unknown_Humax-RC-536P/2,23.csv
-Humax/HDTV Tuner/0,65.csv
-Humax/HDTV Tuner/0,73.csv
-Humax/HDTV Tuner/0,16.csv
-Humax/HDTV Tuner/0,48.csv
-Humax/Unknown_Humax-5400IRCI/0,16.csv
-Humax/DVD_VCR Combo/0,16.csv
-Humax/DVD_VCR Combo/0,23.csv
-Humax/Unknown_lircd.conf/0,16.csv
-Humax/Unknown_HUMAX/0,16.csv
-Humax/Unknown_RS-521/0,16.csv
-Sonance/System Controller/132,132.csv
-Sonance/Distributed Audio/0,90.csv
-OSRAM/Unknown_OSRAM/1,0.csv
-Kiss/Unknown_DP-1500s/25,-1.csv
-oceanic/Unknown_oceanic/1,-1.csv
-Kaon/Unknown_KSC-i260MCO/32,8.csv
-Kaon/Unknown_KTF-I2001CO/32,8.csv
-Kaon/Unknown_KTF-100CO/32,8.csv
-Cary Audio Design/Receiver/19,-1.csv
-Cary Audio Design/DVD Player/23,-1.csv
-Cary Audio Design/CD Player/4,-1.csv
-Roku/Unknown_Soundbridge/111,-1.csv
-Roku/Unknown_Netflix/190,239.csv
-Roku/Unknown_N1000-04/190,239.csv
-Total Media In Hand/Unknown_Media/2,189.csv
-Yamaha/DVD Receiver/120,-1.csv
-Yamaha/DVD Receiver/124,-1.csv
-Yamaha/Receiver/0,0.csv
-Yamaha/Receiver/4,-1.csv
-Yamaha/Receiver/120,-1.csv
-Yamaha/Receiver/125,-1.csv
-Yamaha/Receiver/6,-1.csv
-Yamaha/Receiver/209,-1.csv
-Yamaha/Receiver/124,-1.csv
-Yamaha/Receiver/122,-1.csv
-Yamaha/Receiver/121,-1.csv
-Yamaha/Receiver/15,-1.csv
-Yamaha/Receiver/0,-1.csv
-Yamaha/Receiver/127,1.csv
-Yamaha/Receiver/8,-1.csv
-Yamaha/Receiver/126,-1.csv
-Yamaha/Unknown_RS-CX600/122,-1.csv
-Yamaha/DSP/4,-1.csv
-Yamaha/DSP/120,-1.csv
-Yamaha/DSP/6,-1.csv
-Yamaha/DSP/80,-1.csv
-Yamaha/DSP/87,-1.csv
-Yamaha/DSP/122,-1.csv
-Yamaha/Unknown_VM70300/122,-1.csv
-Yamaha/Unknown_receiver/122,-1.csv
-Yamaha/DVD Player/4,-1.csv
-Yamaha/DVD Player/124,-1.csv
-Yamaha/DVD Player/176,0.csv
-Yamaha/Unknown_TX-1000/209,-1.csv
-Yamaha/Stereo Receiver/125,-1.csv
-Yamaha/Stereo Receiver/126,-1.csv
-Yamaha/AV Receiver/127,-1.csv
-Yamaha/AV Receiver/122,-1.csv
-Yamaha/AV Receiver/127,1.csv
-Yamaha/AV Receiver/126,-1.csv
-Yamaha/Unknown_YAMAHA/122,-1.csv
-Yamaha/Unknown_VJ59810/121,-1.csv
-Yamaha/Laser Disc/124,-1.csv
-Yamaha/Unknown_RCX660/122,-1.csv
-Yamaha/Unknown_yamaha-rax7/122,-1.csv
-Yamaha/Unknown_JVCDVD/239,-1.csv
-Yamaha/Unknown_RCX/122,-1.csv
-Yamaha/DVD/4,-1.csv
-Yamaha/DVD/124,-1.csv
-Yamaha/DVD/176,0.csv
-Yamaha/Unknown_yamaha-amp/122,-1.csv
-Yamaha/Unknown_RX-450/122,-1.csv
-Yamaha/DVD Changer/4,-1.csv
-Yamaha/Video Projector/209,-1.csv
-Yamaha/Unknown_VP59040/122,-1.csv
-Yamaha/Projector/209,-1.csv
-Yamaha/Projector/240,-1.csv
-Yamaha/Unknown_VQ95010/121,-1.csv
-Yamaha/Unknown_VI77760/127,-1.csv
-Yamaha/iPod Dock/127,1.csv
-Yamaha/Amplifier/120,-1.csv
-Yamaha/Amplifier/125,-1.csv
-Yamaha/Amplifier/122,-1.csv
-Yamaha/Unknown_DVD-RC/32,-1.csv
-Yamaha/Unknown_VK38010/122,-1.csv
-Yamaha/Unknown_vu50620/120,-1.csv
-Yamaha/Unknown_Y-TV-1004/4,-1.csv
-Yamaha/Mini System/120,-1.csv
-Yamaha/Unknown_RX-V850/122,-1.csv
-Yamaha/Unknown_VU71330/121,-1.csv
-Yamaha/Unknown_V499920/122,-1.csv
-Yamaha/CD Player/122,-1.csv
-Yamaha/CD Player/121,-1.csv
-Yamaha/Unknown_VI47320/209,-1.csv
-Yamaha/Unknown_RCX-750/122,-1.csv
-Yamaha/Unknown_RAV-12/122,-1.csv
-Yamaha/Unknown_VK34080/121,-1.csv
-Yamaha/Unknown_RAV14/122,-1.csv
-Yamaha/DVR/120,-1.csv
-Yamaha/DVR/71,-1.csv
-Yamaha/DVR/124,-1.csv
-Yamaha/Unknown_RX-CX800/122,-1.csv
-Yamaha/DAT/128,55.csv
-Yamaha/CD-R/127,-1.csv
-Yamaha/Cassette Tape/127,-1.csv
-Yamaha/Cassette Tape/122,-1.csv
-Yamaha/Unknown_VJI5420/121,-1.csv
-Yamaha/Unknown_RAV16/122,-1.csv
-Yamaha/CD Changer/122,-1.csv
-Yamaha/CD Changer/121,-1.csv
-Yamaha/Unknown_RS-CD5/121,-1.csv
-Yamaha/Plasma/80,-1.csv
-Yamaha/Unknown_RCX2/122,-1.csv
-Yamaha/Unknown_rax9/122,-1.csv
-Yamaha/Sound Projector/120,-1.csv
-Yamaha/Sound Projector/126,-1.csv
-Yamaha/Unknown_VR81350/123,-1.csv
-Yamaha/Unknown_RAV207/122,-1.csv
-Yamaha/Unknown_DVD/69,-1.csv
-Yamaha/CD Jukebox/122,-1.csv
-Yamaha/CD Jukebox/121,-1.csv
-Yamaha/Tuner/209,-1.csv
-Yamaha/Tuner/122,-1.csv
-Yamaha/Music Server/128,55.csv
-Yamaha/Unknown_cdx-493/121,-1.csv
-Yamaha/Unknown_RS-K3/127,-1.csv
-Yamaha/DVD Pre-amp/120,-1.csv
-Yamaha/DVD Pre-amp/124,-1.csv
-Yamaha/Blu-Ray/124,-1.csv
-Yamaha/Unknown_av/122,-1.csv
-Pioneer/Receiver/164,-1.csv
-Pioneer/Receiver/165,-1.csv
-Pioneer/Unknown_AXD-1531/170,-1.csv
-Pioneer/DVD Player/175,-1.csv
-Pioneer/DVD Player/163,-1.csv
-Pioneer/Laser Disc/168,-1.csv
-Pioneer/Laser Disc/175,-1.csv
-Pioneer/Laser Disc/163,-1.csv
-Pioneer/Unknown_CD/162,-1.csv
-Pioneer/Unknown_CU-PD008/162,-1.csv
-Pioneer/DVD Changer/175,-1.csv
-Pioneer/DVD Changer/163,-1.csv
-Pioneer/Unknown_CU-PD089/162,-1.csv
-Pioneer/Unknown_CU-CLD067/168,-1.csv
-Pioneer/Unknown_CU-CLD106/168,-1.csv
-Pioneer/Unknown_Pioneer-CU-XR014/2,1.csv
-Pioneer/Amplifier/162,-1.csv
-Pioneer/Amplifier/164,-1.csv
-Pioneer/Amplifier/165,-1.csv
-Pioneer/Unknown_cu-pd096/162,-1.csv
-Pioneer/CD Player/162,-1.csv
-Pioneer/Unknown_pioneer/168,-1.csv
-Pioneer/Unknown_pioneer/162,-1.csv
-Pioneer/Unknown_VXX2801/163,-1.csv
-Pioneer/Unknown_PD-M650/162,-1.csv
-Pioneer/Cassette Tape/161,-1.csv
-Pioneer/Unknown_CU-PD046/162,-1.csv
-Pioneer/Unknown_DEH-D8850/0,-1.csv
-Pioneer/Unknown_CU-PD038/162,-1.csv
-Pioneer/Unknown_AXD-7306/166,-1.csv
-Pioneer/DVD Jukebox/175,-1.csv
-Pioneer/DVD Jukebox/163,-1.csv
-Pioneer/CD Jukebox/162,-1.csv
-Pioneer/Unknown_CU-XC004/255,255.csv
-Pioneer/TV/170,-1.csv
-Pioneer/TV/175,-1.csv
-Pioneer/Cable Box/170,-1.csv
-Pioneer/Cable Box/172,-1.csv
-Pioneer/Cable Box/168,40.csv
-Pioneer/Unknown_CU-PD085/162,-1.csv
-Pioneer/Unknown_CU-PD069/162,-1.csv
-Makita/Drapery Controller/2,-1.csv
-Goldmund/CD Player/20,-1.csv
-Copland/CD Player/128,114.csv
-Copland/CD Player/129,49.csv
-ENTONE/Unknown_URC-4021ABA1-006-R/230,4.csv
-Jerrold/Unknown_MRC/-1,-1.csv
-Jerrold/Unknown_CFT2000/0,-1.csv
-Jerrold/Unknown_550-osd/0,-1.csv
-Jerrold/Unknown_RC-OSD/0,-1.csv
-Jerrold/Cable Box/1,-1.csv
-Jerrold/Cable Box/0,-1.csv
-Satelco/Sat/24,-1.csv
-DVICO/Unknown_FusionRemote/1,-1.csv
-Chronos/Unknown_Chronos/None,None.csv
-Olevia/Unknown_RC-LTFN/4,-1.csv
-Olevia/Unknown_RC-LTL/4,185.csv
-Rolsen/Unknown_DK5A/1,-1.csv
-Rolsen/Unknown_K10B-C1/14,14.csv
-LEMON/Unknown_LEMON/7,-1.csv
-Aragon/Pre-Amplifier/31,-1.csv
-Aragon/Pre-Amplifier/25,-1.csv
-Aten/Unknown_VS-431/0,-1.csv
-Citation/Surround Processor/132,66.csv
-videologic/Unknown_rm201/134,107.csv
-Macro Image Technology/Unknown_MyHD/48,-1.csv
-Runco/Line Doubler/4,-1.csv
-Runco/Controller_DLP/1,-1.csv
-Runco/Video Controller/1,-1.csv
-Runco/Video Projector/5,1.csv
-Runco/Video Projector/24,247.csv
-Runco/Video Projector/1,-1.csv
-Onida/Unknown_TVE/3,-1.csv
-Onida/Unknown_DFX/0,-1.csv
-Packard Bell/Unknown_PackBell/16,-1.csv
-JENSEN/VCR/1,-1.csv
-Starsat/Unknown_120/64,64.csv
-Trice/Unknown_TR-302/1,254.csv
-STRONG/Unknown_STRONG/128,119.csv
-Apple/Unknown_CD/14,-1.csv
-Apple/Unknown_apple/None,None.csv
-Apple/Unknown_MC377Z/238,135.csv
+Aopen/Media PC/4,-1.csv
+Aopen/Unknown_RC-R470/4,-1.csv
+Apex/DVD Player/4,-1.csv
+Apex/Unknown_AD-600A/4,-1.csv
+Apex/Unknown_DV-R200/0,238.csv
+Apex/Unknown_DV-R383/0,238.csv
+Apex/Unknown_K12B-C2/64,-1.csv
+Apex/Unknown_K12K-C5/64,-1.csv
+Apex/Unknown_RM-1200/4,-1.csv
+Apex/Unknown_RM-2600/1,-1.csv
+Apple/Apple TV/238,135.csv
+Apple/Computer/238,135.csv
+Apple/Digital Jukebox/238,135.csv
+Apple/iPod/238,135.csv
 Apple/MP3 Player/1,222.csv
 Apple/MP3 Player/238,135.csv
-Apple/Unknown_A1294/238,135.csv
-Apple/Unknown_Mac/238,135.csv
-Apple/Computer/238,135.csv
 Apple/Unknown_A1156/238,135.csv
-Apple/iPod/238,135.csv
-Apple/Apple TV/238,135.csv
-Apple/Digital Jukebox/238,135.csv
-Yuan/Unknown_SmartVDO/128,-1.csv
-Aki/Unknown_DVD-838W/0,-1.csv
-Netgem/Unknown_iPlayer/131,51.csv
-Manhattan/Unknown_DVD/29,-1.csv
-Seleco/TV/30,-1.csv
-Seleco/TV/0,-1.csv
-Kanam Accent/Unknown_Accent/None,None.csv
-Re.x/Unknown_SDVD/0,-1.csv
-Napa/Unknown_DAV-309/0,-1.csv
-Philips/Unknown_R-48F01/20,-1.csv
-Philips/Unknown_RC8244/10,-1.csv
-Philips/Unknown_SRM5100/4,15.csv
-Philips/Unknown_digital/0,-1.csv
-Philips/Receiver/17,-1.csv
-Philips/Receiver/5,-1.csv
-Philips/Receiver/20,-1.csv
-Philips/Receiver/16,-1.csv
-Philips/Receiver/0,-1.csv
-Philips/Unknown_TIVO/133,48.csv
-Philips/Unknown_26PFL5604H/0,-1.csv
-Philips/Unknown_SBC/6,-1.csv
-Philips/Unknown_SBC/0,-1.csv
-Philips/Unknown_dvd712/4,-1.csv
-Philips/DSS/39,-1.csv
-Philips/DSS/133,48.csv
-Philips/Unknown_TV/0,-1.csv
-Philips/Unknown_uDigital/0,-1.csv
-Philips/Unknown_RC19042002/0,-1.csv
-Philips/DVD Player/4,-1.csv
-Philips/Unknown_DVP-5982/4,-1.csv
-Philips/Unknown_CD/20,-1.csv
-Philips/Unknown_RC5-BP6/0,-1.csv
-Philips/Unknown_Philips-PMDVD6T-Universal-AUX/64,47.csv
-Philips/Unknown_PM725S/27,-1.csv
-Philips/Unknown_RC-5/5,-1.csv
-Philips/Unknown_RC-5/0,-1.csv
-Philips/Unknown_CD720/20,-1.csv
-Philips/Unknown_95/5,-1.csv
-Philips/Digital Recorder/133,48.csv
-Philips/Unknown_AV5609/5,-1.csv
-Philips/Unknown_8243/10,-1.csv
-Philips/Unknown_01/48,-1.csv
-Philips/Unknown_01/0,-1.csv
-Philips/Unknown_DVD-724/4,-1.csv
-Philips/VCR/5,-1.csv
-Philips/Unknown_RC-7843/0,-1.csv
-Philips/Unknown_VR175/5,-1.csv
-Philips/Unknown_SBC-RU-520/5,-1.csv
-Philips/Unknown_RT150/5,-1.csv
-Philips/Unknown_RC19237006/4,-1.csv
-Philips/Unknown_rd5860.conf/20,-1.csv
-Philips/Unknown_SF172/39,-1.csv
-Philips/Unknown_SRU/0,-1.csv
-Philips/Unknown_RCLE011/0,-1.csv
-Philips/Unknown_RC19335003-01P/0,-1.csv
-Philips/Unknown_32PFL5403D/0,-1.csv
-Philips/Unknown_PHILIPS/0,-1.csv
-Philips/Unknown_PHILIPS/34,-1.csv
-Philips/Unknown_TIVO34/133,48.csv
-Philips/Unknown_17PT1563/0,-1.csv
-Philips/Unknown_RU120/0,-1.csv
-Philips/Unknown_RC2582/39,-1.csv
-Philips/Unknown_STEREO/164,164.csv
-Philips/Unknown_DSX-5500/39,-1.csv
-Philips/Unknown_RC7925/26,-1.csv
-Philips/Unknown_RC2070/0,-1.csv
-Philips/Unknown_DVD711/4,-1.csv
-Philips/CD-R/20,-1.csv
-Philips/CD-R/26,-1.csv
-Philips/Unknown_RC/20,-1.csv
-Philips/Unknown_RC/0,-1.csv
-Philips/Unknown_5373/5,-1.csv
-Philips/Unknown_LV2/20,-1.csv
-Philips/Unknown_RD6834/20,-1.csv
-Philips/Unknown_5260/0,-1.csv
-Philips/Unknown_RC8861/1,-1.csv
-Philips/Unknown_PHDVD5/26,154.csv
-Philips/Unknown_101/5,-1.csv
-Philips/Unknown_FW2104/134,83.csv
-Philips/Unknown_VCR/5,-1.csv
-Philips/Unknown_CD723/20,-1.csv
-Philips/Unknown_RC-2012/4,-1.csv
-Philips/Unknown_130A/138,245.csv
-Philips/Unknown_philips-rc2592-MODE-v1/8,-1.csv
-Philips/Unknown_RC7507/5,-1.csv
-Philips/TV/3,-1.csv
-Philips/TV/0,-1.csv
-Philips/Unknown_DVP-642/4,-1.csv
-Philips/Unknown_MULTI/6,-1.csv
-Philips/Unknown_MULTI/5,-1.csv
-Philips/Unknown_MULTI/0,-1.csv
-Philips/Unknown_5300/0,-1.csv
-Philips/Unknown_RC7843/0,-1.csv
-Philips/Unknown_RC2034302/0,-1.csv
-IntelliNet Controls/Distributed Audio/0,90.csv
-Aiwa/Unknown_RC-X97/134,19.csv
-Aiwa/Receiver/12,-1.csv
-Aiwa/Receiver/16,-1.csv
-Aiwa/Receiver/18,-1.csv
-Aiwa/Receiver/13,-1.csv
-Aiwa/Unknown_RC-TN320EX/110,0.csv
-Aiwa/Unknown_RC-8AT02/110,0.csv
-Aiwa/Unknown_RC-T503/110,0.csv
-Aiwa/Unknown_rc-tz650/110,0.csv
-Aiwa/Unknown_rc-c003/118,0.csv
-Aiwa/Unknown_RC-CAS10/110,0.csv
-Aiwa/VCR/130,111.csv
-Aiwa/VCR/127,0.csv
-Aiwa/Unknown_RC-ZAS02/110,0.csv
-Aiwa/Unknown_HIFI/112,0.csv
-Aiwa/Unknown_RC-ZAS10/110,0.csv
-Aiwa/Unknown_RC-ZVR02/127,0.csv
-Aiwa/Unknown_AWIA-RC-ZVR04/128,123.csv
-Aiwa/Unknown_RC-TD3/112,0.csv
-Aiwa/Unknown_RC-8AS04/110,0.csv
-Aiwa/Unknown_rc-tn380b/110,0.csv
-Aiwa/Unknown_RC-ZAT04/112,0.csv
-Aiwa/Mini System/110,0.csv
-Aiwa/CD Player/118,0.csv
-Aiwa/Unknown_hu/112,0.csv
-Aiwa/Unknown_RC-TN360/110,0.csv
-Aiwa/Unknown_RC-BVR02/110,-1.csv
-Aiwa/Unknown_rc6as14/110,0.csv
-Aiwa/Unknown/127,0.csv
-Aiwa/Unknown_RC-L01/112,0.csv
-Aiwa/Unknown_AIWA-RC-5VP05/127,0.csv
-Aiwa/Cassette Tape/115,0.csv
-Aiwa/Unknown_RC-AVT02/123,0.csv
-Aiwa/Unknown_RC-6AS07/112,0.csv
-Aiwa/Unknown_RC-TN330/110,0.csv
-Aiwa/Unknown_RC-7AS06/110,0.csv
-Aiwa/Unknown_RC-TN520EX/110,0.csv
-Aiwa/Unknown_RC-TN500EX/110,0.csv
-Aiwa/Unknown_RC-L60E/110,0.csv
-Aiwa/Unknown_RC-T504/110,0.csv
-Aiwa/Unknown_RC-XR-MD201/110,0.csv
-Aiwa/Unknown_AIWA/72,0.csv
-Aiwa/Unknown_AIWA/127,0.csv
-Aiwa/Unknown_AIWA/110,0.csv
-Aiwa/Unknown_AIWA/118,0.csv
-Aiwa/Unknown_RC-C105/118,0.csv
-Aiwa/Unknown_S79/72,0.csv
-Dynaudio/Unknown_Sub/1,-1.csv
-media-tech/Unknown_RUMBA/128,-1.csv
-Elenberg/Unknown_RC-404E/0,251.csv
-Architectural Audio/Multi-Zone Receiver/130,130.csv
+Apple/Unknown_A1294/238,135.csv
+Apple/Unknown_apple/None,None.csv
+Apple/Unknown_CD/14,-1.csv
+Apple/Unknown_Mac/238,135.csv
+Apple/Unknown_MC377Z/238,135.csv
+Aragon/Pre-Amplifier/25,-1.csv
+Aragon/Pre-Amplifier/31,-1.csv
+Arcam/CD Player/0,-1.csv
+Arcam/CD Player/16,-1.csv
+Arcam/CD Player/20,-1.csv
+Arcam/DVD Player/16,-1.csv
+Arcam/DVD Player/25,-1.csv
+Arcam/Music System/16,-1.csv
+Arcam/Music System/17,-1.csv
+Arcam/Music System/20,-1.csv
+Arcam/Pre-Amplifier/16,-1.csv
+Arcam/Receiver/0,-1.csv
+Arcam/Receiver/16,-1.csv
+Arcam/Receiver/17,-1.csv
+Arcam/Receiver/19,-1.csv
+Arcam/Receiver/23,-1.csv
+Arcam/Receiver/25,-1.csv
+Arcam/Surround Receiver/0,-1.csv
+Arcam/Surround Receiver/16,-1.csv
+Arcam/Surround Receiver/25,-1.csv
+Arcam/Tuner/17,-1.csv
+Arcam/Unknown_Arcam/16,-1.csv
+Arcam/Unknown_AV200/16,-1.csv
 Architectural Audio/Amplifier/132,132.csv
-GVC/Unknown_RM-RK50/143,-1.csv
-Griffin/iPod/212,190.csv
-Sumvision/Unknown_Sumvision/0,-1.csv
-Gefen Systems/DVI Switcher/11,-1.csv
-Gefen Systems/Matrix Switcher/11,-1.csv
-Gefen Systems/HDMI Switcher/11,-1.csv
-Gefen Systems/Unknown/24,-1.csv
-Revo/Unknown_Blik/0,-1.csv
-Cyberhome/DVD Player/114,205.csv
-Cyberhome/Unknown_300-RMC-300Z/114,205.csv
-Cyberhome/Unknown_cyberhome/114,205.csv
-Cyberhome/Unknown_ADL-528/114,205.csv
-Cyberhome/Unknown_CH-DVD-302/114,205.csv
-Cyberhome/Unknown_CH-DVD/114,205.csv
-Cyberhome/Unknown_504/114,205.csv
-Commodore/Unknown_cdtv/0,-1.csv
-PLU2/Unknown_DVX-345pro/0,-1.csv
-Kawasaki/DVD_Amp/154,-1.csv
-Theta Digital/DVD Player/175,-1.csv
-Theta Digital/DVD Player/163,-1.csv
-Theta Digital/Surround Processor/16,-1.csv
-Magnavox/DSS/128,63.csv
-Magnavox/DVD Player/4,-1.csv
-Magnavox/DVD Player/135,34.csv
-Magnavox/DVD Player/1,-1.csv
-Magnavox/VCR/5,-1.csv
-Magnavox/DVD Recorder/135,34.csv
-Magnavox/Unknown_UNIFIED6TRANS/0,-1.csv
-Magnavox/TV/0,-1.csv
-MCL/Unknown_RemoteController/64,-1.csv
-Konka/Unknown_KK-Y199/25,1.csv
-Konka/Unknown_KK-Y250A/25,1.csv
-ELTASAT/Unknown_SAT170/66,253.csv
+Architectural Audio/Multi-Zone Receiver/130,130.csv
+Aristona/Unknown_5525/0,-1.csv
+Aristona/Unknown_9067/5,-1.csv
+Arrakis Systems/CD Jukebox/103,-1.csv
+Arrakis Systems/CD Jukebox/39,-1.csv
+Arrakis Systems/CD Jukebox/71,-1.csv
+Askey/Unknown_AS-218/134,107.csv
+Aspire Digital/Unknown_Digital/8,-1.csv
 Astro/Satellite/8,-1.csv
 Astro/Unknown_ASR340/0,253.csv
-Leadership/Unknown_GOTEC/0,-1.csv
-Dish Network/Satellite/0,0.csv
-Dish Network/Satellite/1,2.csv
-Dish Network/Satellite/0,2.csv
-Dish Network/Satellite/0,12.csv
-Dish Network/Satellite/1,0.csv
-Dish Network/Satellite/1,7.csv
-Dish Network/Satellite/0,7.csv
-Dish Network/Satellite/1,5.csv
-Dish Network/Satellite/16,0.csv
-Dish Network/Satellite/28,-1.csv
-Dish Network/Satellite/1,4.csv
-Dish Network/Satellite/0,5.csv
-Dish Network/Satellite/0,31.csv
-Dish Network/Satellite/0,6.csv
-Dish Network/Satellite/0,3.csv
-Dish Network/Satellite/1,6.csv
-Dish Network/Satellite/0,4.csv
-Dish Network/Satellite/8,0.csv
-Dish Network/Satellite/4,0.csv
-Dish Network/Satellite/1,1.csv
-Dish Network/Satellite/24,0.csv
-Dish Network/Satellite/15,-1.csv
-Dish Network/Satellite/48,-1.csv
-Dish Network/Satellite/4,5.csv
-Dish Network/Satellite/1,3.csv
-Dish Network/Satellite/1,12.csv
-Dish Network/Satellite/0,1.csv
-Dish Network/Satelite DVR/0,0.csv
-Dish Network/Satelite DVR/1,0.csv
-Dish Network/Satelite DVR/15,-1.csv
-Sirius/Unknown_ST2/0,-1.csv
-Sirius/Unknown_Sportster/1,-1.csv
-Sirius/Unknown_SBKB-3201KR/128,-1.csv
-SVEN/Unknown_IHOO/24,-1.csv
-SVEN/Unknown_HT-475/24,-1.csv
-Barco/Unknown_barcoRC5/0,-1.csv
-Barco/Video Projector/0,-1.csv
-Barco/Video Projector/18,-1.csv
-Channel Plus/Video Switcher/49,235.csv
-Intervideo/VCR/49,-1.csv
-Audio Access/Zone Controller/4,-1.csv
-Audio Access/Zone Controller/133,83.csv
+Asus/Unknown_Digital/0,239.csv
+Asus/Unknown_RC1974502/4,15.csv
+Asus/Unknown_TVBox/134,107.csv
+Asus/Unknown_TV-Box/None,None.csv
+Aten/Unknown_VS-431/0,-1.csv
+Atiusb/Unknown_Ch16/None,None.csv
+Atlanta DTH/Unknown_DTH/5,-1.csv
+Atlantic Technology/Surround Processor/131,95.csv
+Atlantic Technology/Surround Processor/64,64.csv
+Atlantic Technology/Surround Processor/7,-1.csv
+Atlas/Unknown_8776/8,0.csv
+Atlona/Matrix Switcher/0,-1.csv
+Atlona/Matrix Switcher/134,107.csv
+Atlona/Switcher/134,107.csv
 Audio Access/Pre-Amplifier/133,83.csv
-NVIDIA/Unknown_Personal/128,126.csv
-Citizen/Unknown_JX-2022C/0,-1.csv
-Centrum/Unknown_Gemini/29,-1.csv
-Centrum/Unknown_rc5/29,-1.csv
-Bell/Satellite/0,0.csv
-Bell/Satellite/1,2.csv
-Bell/Satellite/0,2.csv
-Bell/Satellite/128,0.csv
-Bell/Satellite/1,0.csv
-Bell/Satellite/16,1.csv
-Bell/Satellite/7,-1.csv
-Bell/Satellite/1,1.csv
-Bell/Satellite/24,0.csv
-Bell/Satellite/0,1.csv
-ByDesign/LCD/71,-1.csv
-cenOmax/Unknown_F702/2,255.csv
+Audio Access/Zone Controller/133,83.csv
+Audio Access/Zone Controller/4,-1.csv
 Audio Authority/HDMI Switcher/134,107.csv
 Audio Authority/IR to Bluetooth/26,218.csv
 Audio Authority/IR to Bluetooth/26,73.csv
 Audio Authority/Switcher/64,159.csv
-Kathrein/Satellite/0,-1.csv
-Kathrein/Satellite/34,144.csv
-Kathrein/Unknown_KathreinUFD400/0,-1.csv
-Kathrein/DVBS-Receiver/34,144.csv
-HB/Unknown_DIGITAL/0,-1.csv
-SAB/Unknown_Explorer/1,-1.csv
-Calypso/Control System/17,-1.csv
-Calypso/Control System/7,-1.csv
-Calypso/Control System/1,-1.csv
-Calypso/Amplifier/17,-1.csv
-Celadon/IR to RS232/123,2.csv
-Cce/Unknown_VCR-CCE/21,-1.csv
-Cce/Unknown_RC-28b/0,-1.csv
-Cce/Unknown_TV-CCE/4,-1.csv
-Cce/Unknown_RC-27/0,-1.csv
-Jamo/DVD Receiver/25,-1.csv
-Lifesat/Unknown_28/128,38.csv
-Curtis Electronics/Unknown_TV/0,-1.csv
-Sigmatek/Unknown_XMB-510-PRO/8,-1.csv
-Sigmatek/Unknown_X100/8,-1.csv
-anysee/Unknown_anysee/8,-1.csv
-Akai/Unknown_RC-Y121G/137,119.csv
-Akai/Unknown_TV/0,-1.csv
-Akai/Unknown_AKAI-RC-AAV2100/160,160.csv
-Akai/Unknown_Akai-RC-V23E/137,119.csv
-Akai/Unknown_akai/139,-1.csv
-Akai/Unknown_akai/131,101.csv
-Akai/Unknown_RC-W152E/137,119.csv
-Akai/CD Player/141,-1.csv
-Akai/Unknown_V425A/137,-1.csv
-Akai/Unknown_RC-W201G/137,119.csv
-Akai/Unknown_RC891/137,-1.csv
-Akai/Unknown_RC-C79/141,-1.csv
-Akai/Unknown_rc-c37/141,-1.csv
-Akai/Unknown_RC-W212F/137,119.csv
-Akai/Unknown_Akai-RC-61A/11,11.csv
-Akai/Unknown_RC-X121E/137,119.csv
-Slim Devices/Unknown_Devices/110,-1.csv
-Topseed/Unknown_Topseed/4,15.csv
-Velodyne/Subwoofer/0,69.csv
-Escient/DVD Player/2,22.csv
-Escient/DVD Player/1,22.csv
-Escient/DVD Player/3,22.csv
-Escient/DVD Player/4,22.csv
-Escient/DVD Player/8,-1.csv
-Escient/DVD Library/1,22.csv
-Escient/DVD Library/8,-1.csv
-Escient/Media Manager/2,22.csv
-Escient/Media Manager/1,22.csv
-Escient/Media Manager/3,22.csv
-Escient/Media Manager/4,22.csv
-Escient/Media Manager/15,0.csv
-Escient/Media Manager/33,184.csv
-Escient/Media Manager/15,-1.csv
-Escient/Media Manager/48,-1.csv
-Escient/MP3 Player/14,-1.csv
-Escient/MP3 Player/1,22.csv
-Escient/MP3 Player/4,22.csv
-Escient/MP3 Player/15,-1.csv
-Escient/MP3 Player/0,-1.csv
-Escient/Hard Drive Recorder/15,0.csv
-Escient/Digital Media Receiver/1,22.csv
-Escient/Digital Media Receiver/15,-1.csv
-Escient/CD Management/0,0.csv
-Escient/CD Management/91,-1.csv
-Escient/CD Management/14,0.csv
-Escient/Media Server/1,22.csv
-Escient/Media Server/4,22.csv
-Escient/CD Jukebox/0,0.csv
-Escient/CD Jukebox/91,-1.csv
-Escient/CD Jukebox/14,0.csv
-Escient/CD Jukebox/15,0.csv
-Escient/CD Jukebox/48,-1.csv
-Escient/Digital Jukebox/15,0.csv
-Free/Unknown_V5/36,12.csv
-Free/Unknown_REMOTE/11,-1.csv
-TRIAX/Unknown_DVB/10,-1.csv
-Sungale/Unknown_JX-2002/0,-1.csv
-Sansui/Unknown_SANSUI-RS-S103/132,77.csv
-Atiusb/Unknown_Ch16/None,None.csv
-Turtle Beach/MP3 Player/1,249.csv
-Turtle Beach/MP3 Player/1,-1.csv
-Crown/Unknown_testinglirc.config/0,-1.csv
-Crown/Unknown_cd-80/202,20.csv
-Contour/Unknown_Contour25/65,0.csv
-Bose/Unknown_WAVERADIO/186,-1.csv
-Bose/CCF Conversion/186,213.csv
-Bose/CCF Conversion/186,85.csv
-Bose/CCF Conversion/186,229.csv
-Bose/CCF Conversion/186,133.csv
-Bose/Receiver/186,75.csv
-Bose/Receiver/186,160.csv
-Bose/AV Switcher/186,71.csv
+Audio Control/Pre-Amplifier/16,-1.csv
+Audio Control/Pre-Amplifier/17,-1.csv
+Audio Control/Pre-Amplifier/23,-1.csv
+Audio Control/Processor/16,-1.csv
+Audio Control/Receiver/16,-1.csv
+Audio Control/Receiver/17,-1.csv
+Audio Control/Receiver/23,-1.csv
+Audiola/DEC654_DVB-T/8,247.csv
+Audio Refinement/Amplifier/20,-1.csv
+Audio Refinement/CD Player/20,-1.csv
+Audio Refinement/Tuner/20,-1.csv
+Audio Research/Pre-Amplifier/7,-1.csv
+audiosonic/Unknown_TXCD-1240/129,129.csv
+AudioSource/Unknown_SS-Three/6,1.csv
+Audiovox/Monitor/128,126.csv
+Audiovox/Unknown_SIR/16,-1.csv
+Audiovox/Unknown_Sirius/16,-1.csv
+Austar/Cable Box/32,224.csv
+AutumnWave/Unknown_Onair/8,-1.csv
+Avermedia/Unknown_Avermedia/64,-1.csv
+Avermedia/Unknown_AVerTV5/0,237.csv
+Avermedia/Unknown_RM-H7/0,237.csv
+Avermedia/Unknown_RM-KV/4,-1.csv
+Avex/Unknown_AVEX-AV5609/5,-1.csv
+Avex/Unknown_AVEX-RC501/5,-1.csv
+Avtoolbox/Unknown_hdswitch/32,-1.csv
+Axion/Unknown_AXN-6075/2,255.csv
+Axonix/DVD Player/17,-1.csv
+Axonix/MediaMax/17,20.csv
+Axonix/Media Server/17,-1.csv
+Ayre/Amplifier/16,-1.csv
+AzBox/Unknown_S700/1,4.csv
+Bang Olufsen/CD Player/26,73.csv
+Barco/Unknown_barcoRC5/0,-1.csv
+Barco/Video Projector/0,-1.csv
+Barco/Video Projector/18,-1.csv
+Barix/CD Jukebox/0,127.csv
+B.A.T./Pre-Amplifier/16,-1.csv
+BBK/Unknown_Popcorn/4,203.csv
+BBK/Unknown_PV400s/80,-1.csv
+BBK/Unknown_RC022-03R/73,-1.csv
+Beko/Unknown_Beko/7,-1.csv
+Beko/Unknown_TV/0,-1.csv
+Belkin/Unknown_F5X019/27,-1.csv
+Bellagio/Unknown_P807/32,-1.csv
+Bell ExpressVu/HD DVR/0,0.csv
+Bell ExpressVu/HD DVR/1,0.csv
+Bell ExpressVu/HD DVR/12,0.csv
+Bell ExpressVu/HD DVR/7,-1.csv
+Bell ExpressVu/Satellite/0,0.csv
+Bell ExpressVu/Satellite/1,0.csv
+Bell ExpressVu/Satellite/16,0.csv
+Bell/Satellite/0,0.csv
+Bell/Satellite/0,1.csv
+Bell/Satellite/0,2.csv
+Bell/Satellite/1,0.csv
+Bell/Satellite/1,1.csv
+Bell/Satellite/128,0.csv
+Bell/Satellite/1,2.csv
+Bell/Satellite/16,1.csv
+Bell/Satellite/24,0.csv
+Bell/Satellite/7,-1.csv
+Bench/Unknown_kh2800/48,-1.csv
+BenQ/DLP Projector/48,-1.csv
+BenQ/Projector/48,-1.csv
+BenQ/Projector/72,80.csv
+BenQ/Unknown_DV3080/96,-1.csv
+BenQ/Unknown_MP620/0,48.csv
+BenQ/Unknown_W1070/0,48.csv
+Big Ben/Game Console/67,164.csv
+Bluesky/Unknown_DV900/5,-1.csv
+BnK Components/2-Channel Preamp/11,-1.csv
+BnK Components/2-Channel Preamp/11,79.csv
+BnK Components/6 Zone Receiver/11,79.csv
+BnK Components/6 Zone Receiver/123,72.csv
+BnK Components/6 Zone Receiver/139,71.csv
+BnK Components/6 Zone Receiver/187,-1.csv
+BnK Components/6 Zone Receiver/203,67.csv
+BnK Components/6 Zone Receiver/219,66.csv
+BnK Components/6 Zone Receiver/242,208.csv
+BnK Components/6 Zone Receiver/243,192.csv
+BnK Components/6 Zone Receiver/251,64.csv
+BnK Components/6 Zone Receiver/27,78.csv
+BnK Components/6 Zone Receiver/43,77.csv
+BnK Components/6 Zone Receiver/59,76.csv
+BnK Components/6 Zone Receiver/75,75.csv
+BnK Components/6 Zone Receiver/91,74.csv
+BnK Components/Matrix Switcher/0,-1.csv
+BnK Components/Matrix Switcher/103,137.csv
+BnK Components/Matrix Switcher/108,57.csv
+BnK Components/Matrix Switcher/111,9.csv
+BnK Components/Matrix Switcher/119,-1.csv
+BnK Components/Matrix Switcher/123,72.csv
+BnK Components/Matrix Switcher/127,8.csv
+BnK Components/Matrix Switcher/128,247.csv
+BnK Components/Matrix Switcher/135,135.csv
+BnK Components/Matrix Switcher/143,7.csv
+BnK Components/Matrix Switcher/15,15.csv
+BnK Components/Matrix Switcher/159,6.csv
+BnK Components/Matrix Switcher/167,133.csv
+BnK Components/Matrix Switcher/172,53.csv
+BnK Components/Matrix Switcher/183,132.csv
+BnK Components/Matrix Switcher/187,-1.csv
+BnK Components/Matrix Switcher/192,243.csv
+BnK Components/Matrix Switcher/199,131.csv
+BnK Components/Matrix Switcher/204,-1.csv
+BnK Components/Matrix Switcher/219,66.csv
+BnK Components/Matrix Switcher/223,2.csv
+BnK Components/Matrix Switcher/23,142.csv
+BnK Components/Matrix Switcher/239,1.csv
+BnK Components/Matrix Switcher/242,208.csv
+BnK Components/Matrix Switcher/243,192.csv
+BnK Components/Matrix Switcher/247,128.csv
+BnK Components/Matrix Switcher/251,64.csv
+BnK Components/Matrix Switcher/255,-1.csv
+BnK Components/Matrix Switcher/31,14.csv
+BnK Components/Matrix Switcher/39,141.csv
+BnK Components/Matrix Switcher/44,61.csv
+BnK Components/Matrix Switcher/55,140.csv
+BnK Components/Matrix Switcher/59,76.csv
+BnK Components/Matrix Switcher/63,12.csv
+BnK Components/Matrix Switcher/64,251.csv
+BnK Components/Matrix Switcher/71,139.csv
+BnK Components/Matrix Switcher/7,143.csv
+BnK Components/Matrix Switcher/76,59.csv
+BnK Components/Matrix Switcher/79,11.csv
+BnK Components/Matrix Switcher/91,74.csv
+BnK Components/Matrix Switcher/95,10.csv
+BnK Components/Multi-Zone Receiver/103,137.csv
+BnK Components/Multi-Zone Receiver/119,-1.csv
+BnK Components/Multi-Zone Receiver/123,72.csv
+BnK Components/Multi-Zone Receiver/135,135.csv
+BnK Components/Multi-Zone Receiver/143,7.csv
+BnK Components/Multi-Zone Receiver/151,134.csv
+BnK Components/Multi-Zone Receiver/15,15.csv
+BnK Components/Multi-Zone Receiver/167,133.csv
+BnK Components/Multi-Zone Receiver/183,132.csv
+BnK Components/Multi-Zone Receiver/187,-1.csv
+BnK Components/Multi-Zone Receiver/199,131.csv
+BnK Components/Multi-Zone Receiver/215,130.csv
+BnK Components/Multi-Zone Receiver/219,66.csv
+BnK Components/Multi-Zone Receiver/231,129.csv
+BnK Components/Multi-Zone Receiver/23,142.csv
+BnK Components/Multi-Zone Receiver/242,208.csv
+BnK Components/Multi-Zone Receiver/243,192.csv
+BnK Components/Multi-Zone Receiver/247,128.csv
+BnK Components/Multi-Zone Receiver/251,64.csv
+BnK Components/Multi-Zone Receiver/31,14.csv
+BnK Components/Multi-Zone Receiver/39,141.csv
+BnK Components/Multi-Zone Receiver/55,140.csv
+BnK Components/Multi-Zone Receiver/59,76.csv
+BnK Components/Multi-Zone Receiver/71,139.csv
+BnK Components/Multi-Zone Receiver/7,143.csv
+BnK Components/Multi-Zone Receiver/79,11.csv
+BnK Components/Multi-Zone Receiver/87,138.csv
+BnK Components/Multi-Zone Receiver/91,74.csv
+BnK Components/Pre-Amplifier/11,-1.csv
+BnK Components/Pre-Amplifier/11,79.csv
+BnK Components/Pre-Amplifier/139,71.csv
+BnK Components/Pre-Amplifier/203,67.csv
+BnK Components/Pre-Amplifier/27,78.csv
+BnK Components/Pre-Amplifier/5,1.csv
+BnK Components/Pre-Amplifier/6,1.csv
+BnK Components/Receiver/139,71.csv
+BnK Components/Receiver/203,67.csv
+BnK Components/Receiver/27,78.csv
+BnK Components/Surround Processor/11,79.csv
+BnK Components/Surround Processor/27,78.csv
+BnK Components/Theater Preamplifier/139,71.csv
+BnK Components/Theater Preamplifier/203,67.csv
+BnK Components/Theater Preamplifier/27,78.csv
+BnK Components/Theater-Zone 2/11,79.csv
+BnK Components/Theater-Zone 2/43,77.csv
+BnK Components/Theater-Zone 2/75,75.csv
+BnK Components/Tuner_preamp/11,-1.csv
+BnK Components/Tuner_preamp/11,79.csv
+Bogen/Amplifier/1,-1.csv
+BORK/Unknown_DV/8,-1.csv
 Bose/3-2-1/186,75.csv
-Bose/Switcher_Amplifier/186,85.csv
-Bose/Music Center/186,213.csv
-Bose/Music Center/186,85.csv
-Bose/Music Center/186,229.csv
-Bose/Music Center/186,133.csv
-Bose/System/186,85.csv
-Bose/Lifestyle/186,170.csv
-Bose/Lifestyle/186,169.csv
-Bose/Lifestyle/186,182.csv
-Bose/Lifestyle/186,162.csv
-Bose/Lifestyle/186,168.csv
-Bose/Lifestyle/186,166.csv
-Bose/Lifestyle/186,174.csv
-Bose/Lifestyle/186,191.csv
-Bose/Lifestyle/186,179.csv
-Bose/Lifestyle/186,172.csv
-Bose/Lifestyle/186,184.csv
-Bose/Lifestyle/186,163.csv
-Bose/Lifestyle/186,185.csv
-Bose/Lifestyle/186,85.csv
-Bose/Lifestyle/186,167.csv
-Bose/Lifestyle/186,188.csv
-Bose/Lifestyle/186,183.csv
-Bose/Lifestyle/186,177.csv
-Bose/Lifestyle/186,181.csv
-Bose/Lifestyle/186,180.csv
-Bose/Lifestyle/186,171.csv
-Bose/Lifestyle/186,161.csv
-Bose/Lifestyle/186,187.csv
-Bose/Lifestyle/186,189.csv
-Bose/Lifestyle/186,164.csv
-Bose/Lifestyle/186,176.csv
-Bose/Lifestyle/186,173.csv
-Bose/Lifestyle/186,186.csv
-Bose/Lifestyle/186,190.csv
-Bose/Lifestyle/186,1.csv
+Bose/AV Switcher/186,71.csv
+Bose/CCF Conversion/186,133.csv
+Bose/CCF Conversion/186,213.csv
+Bose/CCF Conversion/186,229.csv
+Bose/CCF Conversion/186,85.csv
 Bose/Lifestyle/186,136.csv
-Bose/Lifestyle/186,178.csv
-Bose/Lifestyle/186,165.csv
 Bose/Lifestyle/186,160.csv
+Bose/Lifestyle/186,161.csv
+Bose/Lifestyle/186,162.csv
+Bose/Lifestyle/186,163.csv
+Bose/Lifestyle/186,164.csv
+Bose/Lifestyle/186,165.csv
+Bose/Lifestyle/186,166.csv
+Bose/Lifestyle/186,167.csv
+Bose/Lifestyle/186,168.csv
+Bose/Lifestyle/186,169.csv
+Bose/Lifestyle/186,170.csv
+Bose/Lifestyle/186,171.csv
+Bose/Lifestyle/186,172.csv
+Bose/Lifestyle/186,173.csv
+Bose/Lifestyle/186,174.csv
+Bose/Lifestyle/186,176.csv
+Bose/Lifestyle/186,177.csv
+Bose/Lifestyle/186,178.csv
+Bose/Lifestyle/186,179.csv
+Bose/Lifestyle/186,180.csv
+Bose/Lifestyle/186,181.csv
+Bose/Lifestyle/186,182.csv
+Bose/Lifestyle/186,183.csv
+Bose/Lifestyle/186,184.csv
+Bose/Lifestyle/186,185.csv
+Bose/Lifestyle/186,186.csv
+Bose/Lifestyle/186,187.csv
+Bose/Lifestyle/186,188.csv
+Bose/Lifestyle/186,189.csv
+Bose/Lifestyle/186,190.csv
+Bose/Lifestyle/186,191.csv
+Bose/Lifestyle/186,1.csv
+Bose/Lifestyle/186,85.csv
 Bose/Media Center/1,-1.csv
 Bose/Media Center/186,136.csv
-Bose/Unknown_Wave/-1,-1.csv
+Bose/Music Center/186,133.csv
+Bose/Music Center/186,213.csv
+Bose/Music Center/186,229.csv
+Bose/Music Center/186,85.csv
+Bose/Receiver/186,160.csv
+Bose/Receiver/186,75.csv
+Bose/Switcher_Amplifier/186,85.csv
+Bose/System/186,85.csv
 Bose/Tuner/186,85.csv
+Bose/Unknown_Wave/-1,-1.csv
+Bose/Unknown_WAVERADIO/186,-1.csv
+Boxlight/Projector/135,78.csv
+Boxlight/Projector/48,-1.csv
+Boxlight/Projector/48,206.csv
+Broksonic/VCR/128,123.csv
+BTX/Drapery Controller/145,-1.csv
+BTX/Drapery Controller/146,-1.csv
+BTX/Drapery Controller/147,-1.csv
+BTX/Drapery Controller/148,-1.csv
+BTX/Drapery Controller/193,-1.csv
+BTX/Drapery Controller/194,-1.csv
+BTX/Drapery Controller/195,-1.csv
+BTX/Drapery Controller/196,-1.csv
+BTX/Drapery Controller/81,-1.csv
+BTX/Drapery Controller/82,-1.csv
+BTX/Drapery Controller/83,-1.csv
+BTX/Drapery Controller/84,-1.csv
+Busch-Jaeger/Elektro/29,-1.csv
+Busch-Jaeger/Elektro/30,-1.csv
+Bush/Light/29,-1.csv
+Bush/Unknown_4400/0,-1.csv
+Bush/Unknown_DFTA1xi/8,-1.csv
+Bush/Unknown_WS6680/0,-1.csv
+ByDesign/LCD/71,-1.csv
+Cables to Go/VGA Switcher/0,191.csv
+Calrad/Video Switcher/4,-1.csv
+Calypso/Amplifier/17,-1.csv
+Calypso/Control System/1,-1.csv
+Calypso/Control System/17,-1.csv
+Calypso/Control System/7,-1.csv
+Cambridge Audio/Amp_CD/160,160.csv
+Cambridge Audio/Amp_CD/16,-1.csv
+Cambridge Audio/DVD Player/12,-1.csv
+Cambridge Audio/DVD Player/7,-1.csv
+Cambridge Audio/Receiver/16,-1.csv
+Cambridge Audio/Receiver/19,-1.csv
+Cambridge Audio/Receiver/192,192.csv
+Cambridge Audio/Unknown_Audio/192,192.csv
+Cambridge Audio/Unknown_X40A/16,-1.csv
+Camera/Camera Multi Plex/133,115.csv
+Canalsat/Satellite/10,-1.csv
+Canalsat/Unknown_CanalSat/10,-1.csv
+Canalsat/Unknown_CanalSatHD/10,-1.csv
+Canon/Unknown_CAM/133,118.csv
+Canon/Unknown_canon/133,118.csv
+Canon/Unknown_WL-D77/133,118.csv
+Canon/Unknown_WL-D80/133,118.csv
+Canon/Unknown_WL-DC100/202,177.csv
+Canon/Unknown_WL-V1/129,6.csv
+Canon/Video Projector/129,6.csv
+Captain/Unknown_7100usb/4,250.csv
+Carver/Amplifier/135,123.csv
+Carver/Cassette Tape/130,111.csv
+Carver/Cassette Tape/135,126.csv
+Carver/Cassette Tape/18,-1.csv
+Carver/CD Player/135,123.csv
+Carver/CD Player/20,-1.csv
+Carver/CD Player/42,-1.csv
+Carver/CD Player/60,-1.csv
+Carver/CD Player/68,-1.csv
+Carver/CD Player/99,0.csv
+Carver/Laser Disc/102,0.csv
+Carver/Pre-Amplifier/0,-1.csv
+Carver/Pre-Amplifier/12,-1.csv
+Carver/Pre-Amplifier/135,123.csv
+Carver/Pre-Amplifier/16,-1.csv
+Carver/Pre-Amplifier/17,-1.csv
+Carver/Pre-Amplifier/20,-1.csv
+Carver/Pre-Amplifier/21,-1.csv
+Carver/Pre-Amplifier/23,-1.csv
+Carver/Pre-Amplifier/5,-1.csv
+Carver/Receiver/0,-1.csv
+Carver/Receiver/12,-1.csv
+Carver/Receiver/135,123.csv
+Carver/Receiver/16,-1.csv
+Carver/Receiver/17,-1.csv
+Carver/Receiver/20,-1.csv
+Carver/Receiver/5,-1.csv
+Carver/Tuner/135,123.csv
+Carver/Tuner/16,-1.csv
+Carver/Tuner/17,-1.csv
+Carver/Tuner/20,-1.csv
+Cary Audio Design/CD Player/4,-1.csv
+Cary Audio Design/DVD Player/23,-1.csv
+Cary Audio Design/Receiver/19,-1.csv
+Casio/Unknown_CMD-40/170,-1.csv
+CAT/Unknown_CS-907/0,191.csv
+CAT/Unknown_DVD-1122/0,-1.csv
+CAT/Unknown_KF-9816/0,-1.csv
+Cce/Unknown_RC-27/0,-1.csv
+Cce/Unknown_RC-28b/0,-1.csv
+Cce/Unknown_TV-CCE/4,-1.csv
+Cce/Unknown_VCR-CCE/21,-1.csv
+Celadon/IR to RS232/123,2.csv
+cenOmax/Unknown_F702/2,255.csv
+Centrum/Unknown_Gemini/29,-1.csv
+Centrum/Unknown_rc5/29,-1.csv
+Century Concept/Unknown_dvd/0,246.csv
+Channel Master/Satellite/132,99.csv
+Channel Plus/Video Switcher/49,235.csv
+Chaparral/Unknown_11-5315-1/128,103.csv
 Chief Manufacturing/Motorized Lift/130,19.csv
 Chief Manufacturing/Motorized Lift/48,-1.csv
-Pace/Unknown_pace900/8,-1.csv
-Pace/Unknown_DI4001N/10,-1.csv
-Pace/Unknown_DI4010I/10,-1.csv
-Pace/Unknown_DS620/132,60.csv
-Pace/Unknown_PaceMSS/1,-1.csv
-Pace/Unknown_TDS460NNZ/35,128.csv
-Pace/Unknown_Digital/0,0.csv
-Pace/Unknown_pacetwin/34,-1.csv
-Pace/Unknown_xsat/34,-1.csv
-Pace/Unknown_DS420/16,80.csv
-Pace/Unknown_DC551P/27,-1.csv
-Pace/Unknown_RC-17/132,60.csv
-Pace/Unknown_PACE-RC-10/132,60.csv
-Pace/Unknown_RC-30/132,60.csv
-daytron/Unknown_daytron/4,-1.csv
-Denver/Unknown_DVD-228/4,-1.csv
-Amytel/Unknown_ACI-200/0,-1.csv
-Magnum/Unknown_5520VT/1,-1.csv
+CHINON/Unknown_CHINON/64,0.csv
+Chronos/Unknown_Chronos/None,None.csv
+Cinemateq/DVD Player/26,0.csv
+Cinemateq/Video Scaler/27,1.csv
+CIS BOX/CD Player/17,-1.csv
+CIS BOX/DSS/183,-1.csv
+CIS BOX/DVD Changer/26,73.csv
+CIS BOX/DVD Changer/26,98.csv
+CIS BOX/DVD Player/26,122.csv
+CIS BOX/DVD Player/26,73.csv
+CIS BOX/HDTV ALL/1,-1.csv
+CIS BOX/HDTV ALL/151,-1.csv
+CIS BOX/HDTV ALL/164,-1.csv
+CIS BOX/HDTV ALL/26,26.csv
+CIS BOX/LCD Projector/84,-1.csv
+CIS BOX/Plasma/119,-1.csv
+CIS BOX/Plasma/1,-1.csv
+CIS BOX/Plasma/164,-1.csv
+CIS BOX/Receiver/121,-1.csv
+CIS BOX/Receiver/144,-1.csv
+CIS BOX/Receiver/16,-1.csv
+CIS BOX/Receiver/25,107.csv
+CIS BOX/Receiver/25,11.csv
+CIS BOX/Receiver/48,-1.csv
+CIS BOX/Receiver/7,-1.csv
+CIS BOX/TV/1,-1.csv
+CIS BOX/TV/164,-1.csv
+CIS BOX/TV/26,26.csv
+CIS BOX/TV/84,-1.csv
+CIS BOX/VCR/2,-1.csv
+Cisco/DVR/35,64.csv
+Citation/Surround Processor/132,66.csv
+Citizen/Unknown_JX-2022C/0,-1.csv
+Classe Audio/Amplifier/201,-1.csv
+Classe Audio/Amplifier/3,-1.csv
+Classe Audio/Amplifier/7,-1.csv
+Classe Audio/CD_DVD/200,-1.csv
+Classe Audio/CD_DVD/20,-1.csv
+Classe Audio/CD_DVD/4,-1.csv
+Classe Audio/CD Player/134,97.csv
+Classe Audio/CD Player/20,-1.csv
+Classe Audio/CRCD/16,-1.csv
+Classe Audio/CRCD/17,-1.csv
+Classe Audio/CRCD/20,-1.csv
+Classe Audio/DVD Player/12,-1.csv
+Classe Audio/DVD Player/200,-1.csv
+Classe Audio/DVD Player/20,-1.csv
+Classe Audio/DVD Player/25,-1.csv
+Classe Audio/DVD Player/4,-1.csv
+Classe Audio/DVD Player/7,-1.csv
+Classe Audio/Integrated Amplifier/7,-1.csv
+Classe Audio/Pre-Amplifier/16,-1.csv
+Classe Audio/Pre-Amplifier/200,-1.csv
+Classe Audio/Pre-Amplifier/25,-1.csv
+Classe Audio/Pre-Amplifier/3,-1.csv
+Classe Audio/Pre-Amplifier/7,-1.csv
+Classe Audio/SACD/20,-1.csv
+Classe Audio/SACD/7,-1.csv
+Classe Audio/Surround Processor/116,-1.csv
+Classe Audio/Surround Processor/200,-1.csv
+Classe Audio/Surround Processor/25,-1.csv
+Classe Audio/Surround Sound/116,-1.csv
+Classe Audio/Surround Sound/200,-1.csv
+Classe Audio/Tuner/17,-1.csv
+Classe Audio/Tuner/7,-1.csv
+Coby/DVD Player/0,-1.csv
+Coby/TV/0,127.csv
+Colorado Vnet/Music Server/110,146.csv
+COMAG/Unknown_6222-N1/None,None.csv
+Comcast/Cable Box/0,-1.csv
+Comcast/Cable Box/1,-1.csv
+Comcast/Cable Box/14,-1.csv
+Comcast/Cable Box/15,-1.csv
+Comcast/Cable Box/27,-1.csv
+Comcast/Cable Box/62,16.csv
+Comcast/Digital Cable/15,-1.csv
+Comcast/Digital Cable/27,-1.csv
+Comcast/HD Cable with DVR/0,-1.csv
+Comcast/HD Cable with DVR/14,-1.csv
+Commodore/Unknown_cdtv/0,-1.csv
+Compro/Unknown_DVB-T200/128,126.csv
+Compro/Unknown_VideoMate-K300/4,15.csv
+Conrad/Unknown_006/56,-1.csv
+Conrad/Unknown_Promo8/0,-1.csv
+Contour/Unknown_Contour25/65,0.csv
+Cool Sat/Satellite/64,64.csv
+Coolsat/Unknown_Pro/1,-1.csv
+Copland/CD Player/128,114.csv
+Copland/CD Player/129,49.csv
+Corvo/Relaybox/27,-1.csv
+COSMEL/Unknown_COSMEL/2,-1.csv
+Cox/Digital Cable/0,-1.csv
+Cox/Digital Cable/1,-1.csv
+Cph03x/Unknown_AS-218/134,107.csv
+Creative/Unknown_BreakOut-Box/None,None.csv
+Creative/Unknown_DDTS-100/193,68.csv
+Creative/Unknown_INFRA/33,172.csv
+Creative/Unknown_JUKEBOX3/33,172.csv
+Creative/Unknown_rm1000w/193,68.csv
+Creative/Unknown_RM-1500/193,68.csv
+Creative/Unknown_RM-1800/193,68.csv
+Creative/Unknown_RM-850/193,68.csv
+Creative/Unknown_RM900/193,68.csv
+Creek/Line_Volume Control/16,-1.csv
+Crestron/IR Receiver/0,-1.csv
+Crestron/IR Receiver/1,-1.csv
+Crestron/IR Receiver/2,-1.csv
+Crestron/IR Receiver/3,-1.csv
+Crestron/IR Receiver/4,-1.csv
+Crestron/Lighting Controller/30,-1.csv
+Crestron/Music Server/14,-1.csv
+Crown/Unknown_cd-80/202,20.csv
+Crown/Unknown_testinglirc.config/0,-1.csv
+Curtis Electronics/Unknown_TV/0,-1.csv
+Curtis Mathes/VCR/144,0.csv
+Curtis Mathes/VCR/144,1.csv
+Cyberhome/DVD Player/114,205.csv
+Cyberhome/Unknown_300-RMC-300Z/114,205.csv
+Cyberhome/Unknown_504/114,205.csv
+Cyberhome/Unknown_ADL-528/114,205.csv
+Cyberhome/Unknown_CH-DVD/114,205.csv
+Cyberhome/Unknown_CH-DVD-302/114,205.csv
+Cyberhome/Unknown_cyberhome/114,205.csv
+Cypress/Unknown_CR-72/64,175.csv
+Cyron/Lighting Controller/2,189.csv
+Daeumling/Unknown_SR200/128,38.csv
+Daewoo/DVD Player/21,-1.csv
+Daewoo/TV/20,-1.csv
+Daewoo/TV/4,-1.csv
+Daewoo/TV/6,6.csv
+Daewoo/Unknown_14Q3/0,-1.csv
+Daewoo/Unknown_97P04701/21,-1.csv
+Daewoo/Unknown_97P1R2ZDA0/21,-1.csv
+Daewoo/Unknown_97P1RA3AB0/21,-1.csv
+Daewoo/Unknown_DAEWOO/0,-1.csv
+Daewoo/Unknown_DAEWOO/21,-1.csv
+Daewoo/Unknown_DS608P/17,-1.csv
+Daewoo/Unknown_DV-800/21,-1.csv
+Daewoo/Unknown_DVDS150/32,-1.csv
+Daewoo/Unknown_DV-F24D/21,-1.csv
+Daewoo/Unknown_r-22/0,-1.csv
+Daewoo/Unknown_R-40A06/20,-1.csv
+Daewoo/Unknown_R-40A10/20,-1.csv
+Daewoo/Unknown_R-40A15/20,-1.csv
+Daewoo/Unknown_R-43A08/20,-1.csv
+Daewoo/Unknown_VCR/21,-1.csv
+Daewoo/Unknown_VCR/49,-1.csv
+Daewoo/Unknown_Visa/20,-1.csv
+Daewoo/VCR/21,-1.csv
+Da Lite/Screen/0,-1.csv
 Dantax/DVD Player/0,-1.csv
 Dantax/Unknown_RC/0,-1.csv
-imon/Unknown_ultrabay/None,None.csv
-imon/Unknown_lircd.conf.imon-2.4g-lt/None,None.csv
-imon/Unknown_iMON-PAD/None,None.csv
-imon/Unknown_MultiMedian/6,-1.csv
-imon/Unknown_Veris/None,None.csv
-Cox/Digital Cable/1,-1.csv
-Cox/Digital Cable/0,-1.csv
-Monoprice/Unknown_HDX(C)-501E/0,-1.csv
-General Electric/VCR/14,-1.csv
-General Electric/VCR/11,-1.csv
-General Electric/VCR/26,73.csv
-General Electric/TV/15,-1.csv
-Bellagio/Unknown_P807/32,-1.csv
-Beko/Unknown_TV/0,-1.csv
-Beko/Unknown_Beko/7,-1.csv
-Rowa/Unknown_RDVD104/0,-1.csv
-Polaroid/Unknown_DVDP-1000/32,-1.csv
-HQV/Video Processor/128,-1.csv
-Broksonic/VCR/128,123.csv
-Instant Replay/VCR/97,-1.csv
-Instant Replay/VCR/25,-1.csv
-Instant Replay/VCR/96,-1.csv
-Instant Replay/VCR/3,-1.csv
-Instant Replay/VCR/2,-1.csv
-Metronome/CD Player/20,-1.csv
-Zehnder/Unknown_VCR/3,-1.csv
-Yamakawa/DVD Player/32,-1.csv
-Yamakawa/Unknown_dvd285vga/32,-1.csv
-SnapStream/Unknown_Firefly-Mini/0,-1.csv
-Typhoon/Unknown_RC-0718-3/96,1.csv
-Typhoon/Unknown_DTV/0,-1.csv
-Hiteker/DVD Player/0,-1.csv
-GoldStar/Unknown_GOLDSTAR/4,-1.csv
-GoldStar/VCR/110,-1.csv
-GoldStar/Unknown_RN800AW/110,-1.csv
-GoldStar/Unknown_VCR/110,-1.csv
-GoldStar/Unknown_Goldstar-VCR/110,-1.csv
-GoldStar/Unknown_cd/16,16.csv
-IR4PS3/Blu-Ray/26,35.csv
-mStation/Unknown_mStation/64,175.csv
+daytron/Unknown_daytron/4,-1.csv
+DBPower/Projector_T20/2,-1.csv
+Dedicated Micros/Camera Switcher/4,-1.csv
+Dell/TV/0,28.csv
+Dell/Unknown_XPS/43,28.csv
+Dell/Video Projector/79,80.csv
+Delphi/Satellite Receiver/27,-1.csv
+Denon/Amplifier/12,-1.csv
+Denon/Amplifier/2,-1.csv
+Denon/Amplifier/4,-1.csv
+Denon/Amplifier/6,-1.csv
+Denon/Amplifier/8,-1.csv
+Denon/AV Processor/12,-1.csv
+Denon/AV Processor/2,-1.csv
+Denon/AV Processor/4,-1.csv
+Denon/Blu-Ray/2,1.csv
+Denon/Cassette Tape/12,-1.csv
+Denon/Cassette Tape/2,-1.csv
+Denon/Cassette Tape/4,-1.csv
+Denon/Cassette Tape/8,-1.csv
+Denon/CD Jukebox/4,-1.csv
+Denon/CD Jukebox/8,-1.csv
+Denon/CD Player/168,-1.csv
+Denon/CD Player/175,-1.csv
+Denon/CD Player/4,-1.csv
+Denon/CD Player/6,-1.csv
+Denon/CD Player/8,-1.csv
+Denon/CD Receiver/12,-1.csv
+Denon/CD Receiver/4,-1.csv
+Denon/CD Receiver/6,-1.csv
+Denon/CD Receiver/8,-1.csv
+Denon/DAT/4,-1.csv
+Denon/DVD Player/176,0.csv
+Denon/DVD Player/2,-1.csv
+Denon/DVD Player/2,1.csv
+Denon/DVD Player/4,-1.csv
+Denon/DVD Player/6,-1.csv
+Denon/DVD Player/8,-1.csv
+Denon/Laser Disc/168,-1.csv
+Denon/Mini-Disc/6,-1.csv
+Denon/Pre-Amplifier/12,-1.csv
+Denon/Pre-Amplifier/2,-1.csv
+Denon/Processor/12,-1.csv
+Denon/Processor/2,-1.csv
+Denon/Processor/4,-1.csv
+Denon/Processor/4,1.csv
+Denon/Processor/4,3.csv
+Denon/Processor/4,5.csv
+Denon/Receiver/12,-1.csv
+Denon/Receiver/2,-1.csv
+Denon/Receiver/2,3.csv
+Denon/Receiver/4,-1.csv
+Denon/Receiver/4,1.csv
+Denon/Receiver/4,2.csv
+Denon/Receiver/4,3.csv
+Denon/Receiver/4,5.csv
+Denon/Receiver/4,7.csv
+Denon/Receiver/6,-1.csv
+Denon/Receiver/7,4.csv
+Denon/Receiver/7,5.csv
+Denon/Receiver/7,6.csv
+Denon/Receiver/7,7.csv
+Denon/Receiver/7,8.csv
+Denon/Receiver/80,-1.csv
+Denon/Receiver/8,-1.csv
+Denon/Receiver/96,-1.csv
+Denon/Receiver/97,-1.csv
+Denon/Tuner/12,-1.csv
+Denon/Tuner/2,-1.csv
+Denon/Tuner/6,100.csv
+Denon/Tuner/6,101.csv
+Denon/Tuner/6,102.csv
+Denon/Tuner/6,113.csv
+Denon/Tuner/6,114.csv
+Denon/Tuner/6,115.csv
+Denon/Tuner/6,116.csv
+Denon/Tuner/6,117.csv
+Denon/Tuner/6,118.csv
+Denon/Tuner/6,129.csv
+Denon/Tuner/6,130.csv
+Denon/Tuner/6,131.csv
+Denon/Tuner/6,132.csv
+Denon/Tuner/6,133.csv
+Denon/Tuner/6,134.csv
+Denon/Tuner/6,145.csv
+Denon/Tuner/6,146.csv
+Denon/Tuner/6,147.csv
+Denon/Tuner/6,148.csv
+Denon/Tuner/6,149.csv
+Denon/Tuner/6,150.csv
+Denon/Tuner/6,161.csv
+Denon/Tuner/6,162.csv
+Denon/Tuner/6,163.csv
+Denon/Tuner/6,164.csv
+Denon/Tuner/6,165.csv
+Denon/Tuner/6,166.csv
+Denon/Tuner/6,177.csv
+Denon/Tuner/6,178.csv
+Denon/Tuner/6,179.csv
+Denon/Tuner/6,17.csv
+Denon/Tuner/6,180.csv
+Denon/Tuner/6,181.csv
+Denon/Tuner/6,182.csv
+Denon/Tuner/6,18.csv
+Denon/Tuner/6,193.csv
+Denon/Tuner/6,194.csv
+Denon/Tuner/6,195.csv
+Denon/Tuner/6,196.csv
+Denon/Tuner/6,197.csv
+Denon/Tuner/6,198.csv
+Denon/Tuner/6,19.csv
+Denon/Tuner/6,1.csv
+Denon/Tuner/6,209.csv
+Denon/Tuner/6,20.csv
+Denon/Tuner/6,210.csv
+Denon/Tuner/6,211.csv
+Denon/Tuner/6,212.csv
+Denon/Tuner/6,213.csv
+Denon/Tuner/6,214.csv
+Denon/Tuner/6,21.csv
+Denon/Tuner/6,225.csv
+Denon/Tuner/6,226.csv
+Denon/Tuner/6,227.csv
+Denon/Tuner/6,228.csv
+Denon/Tuner/6,229.csv
+Denon/Tuner/6,22.csv
+Denon/Tuner/6,230.csv
+Denon/Tuner/6,241.csv
+Denon/Tuner/6,242.csv
+Denon/Tuner/6,243.csv
+Denon/Tuner/6,244.csv
+Denon/Tuner/6,245.csv
+Denon/Tuner/6,246.csv
+Denon/Tuner/6,2.csv
+Denon/Tuner/6,33.csv
+Denon/Tuner/6,34.csv
+Denon/Tuner/6,35.csv
+Denon/Tuner/6,36.csv
+Denon/Tuner/6,37.csv
+Denon/Tuner/6,38.csv
+Denon/Tuner/6,3.csv
+Denon/Tuner/6,49.csv
+Denon/Tuner/6,4.csv
+Denon/Tuner/6,50.csv
+Denon/Tuner/6,51.csv
+Denon/Tuner/6,52.csv
+Denon/Tuner/6,53.csv
+Denon/Tuner/6,54.csv
+Denon/Tuner/6,5.csv
+Denon/Tuner/6,65.csv
+Denon/Tuner/6,66.csv
+Denon/Tuner/6,67.csv
+Denon/Tuner/6,68.csv
+Denon/Tuner/6,69.csv
+Denon/Tuner/6,6.csv
+Denon/Tuner/6,70.csv
+Denon/Tuner/6,81.csv
+Denon/Tuner/6,82.csv
+Denon/Tuner/6,83.csv
+Denon/Tuner/6,84.csv
+Denon/Tuner/6,85.csv
+Denon/Tuner/6,86.csv
+Denon/Tuner/6,97.csv
+Denon/Tuner/6,98.csv
+Denon/Tuner/6,99.csv
+Denon/Unknown/176,0.csv
+Denon/Unknown_Denon/91,-1.csv
+Denon/Unknown_denon-rc-251/8,-1.csv
+Denon/Unknown_denon-rc-266/8,-1.csv
+Denon/Unknown_RC-220/8,-1.csv
+Denon/Unknown_RC-224/8,-1.csv
+Denon/Unknown_RC-241/8,-1.csv
+Denon/Unknown_RC267/6,-1.csv
+Denon/Unknown_RC-541/176,0.csv
+Denon/Unknown_RC-861/2,2.csv
+Denver/Unknown_DVD-228/4,-1.csv
+devinput/Unknown_devinput/None,None.csv
+DIFRNCE/Unknown_DVD5010S/0,-1.csv
+Digiquest/DGQ-3300_DVB-T/0,191.csv
+Digiquest/DGQ-7600HD_DVB-T/0,191.csv
+Digiquest/DVB-T/1,254.csv
+Digital Music Expres/DMX/38,-1.csv
+Digital Projection/Projector/32,-1.csv
+Digital Projection/Video Projector/32,-1.csv
+Digital Projection/Video Scaler/58,-1.csv
+Digital Stream/HDTV Tuner/4,2.csv
+Digital Stream/Unknown_Stream/18,52.csv
+DigitalView/HDTV Tuner/128,-1.csv
+DirecTV/Basic Satellite/12,-1.csv
+DirecTV/Basic Satellite/7,-1.csv
+DirecTV/DSS/12,-1.csv
+DirecTV/DVR/133,48.csv
+DirecTV/HDTV Tuner/12,-1.csv
+DirecTV/Receiver HD/12,-1.csv
+DirecTV/Receiver HD/12,251.csv
+DirecTV/Receiver HD/13,-1.csv
+DirecTV/Receiver HDDVR/12,-1.csv
+DirecTV/Receiver HDDVR/13,-1.csv
+DirecTV/Receiver HDDVR/15,-1.csv
+DirecTV/Receiver HDDVR/2,-1.csv
+DirecTV/Receiver HDDVR/3,-1.csv
+DirecTV/Receiver HDDVR/64,-1.csv
+DirecTV/Receiver HDDVR/71,-1.csv
+DirecTV/Receiver_HDR/133,48.csv
+DirecTV/Receiver SD/12,-1.csv
+DirecTV/Receiver SD/13,-1.csv
+DirecTV/Receiver SDDVR/12,-1.csv
+DirecTV/Receiver SDDVR/133,48.csv
+DirecTV/Receiver SDDVR/15,-1.csv
+DirecTV/Satellite/12,-1.csv
+DirecTV/Satellite/133,48.csv
+DirecTV/Satellite/4,-1.csv
+DirecTV/Tivo_Sat Reciever/133,48.csv
+DirecTV/Unknown/12,-1.csv
+DirecTV/Unknown/12,251.csv
+DirecTV/Unknown/15,-1.csv
+DirecTV/Unknown_G051204/12,-1.csv
+DirecTV/Unknown_H23/12,-1.csv
+DirecTV/Unknown_HD20-100/12,-1.csv
+DirecTV/Unknown_RC16/12,-1.csv
+DirecTV/Unknown_RC32/12,-1.csv
+DirecTV/Unknown_RC64/12,-1.csv
+Dish Network/Satelite DVR/0,0.csv
+Dish Network/Satelite DVR/1,0.csv
+Dish Network/Satelite DVR/15,-1.csv
+Dish Network/Satellite/0,0.csv
+Dish Network/Satellite/0,12.csv
+Dish Network/Satellite/0,1.csv
+Dish Network/Satellite/0,2.csv
+Dish Network/Satellite/0,31.csv
+Dish Network/Satellite/0,3.csv
+Dish Network/Satellite/0,4.csv
+Dish Network/Satellite/0,5.csv
+Dish Network/Satellite/0,6.csv
+Dish Network/Satellite/0,7.csv
+Dish Network/Satellite/1,0.csv
+Dish Network/Satellite/1,12.csv
+Dish Network/Satellite/1,1.csv
+Dish Network/Satellite/1,2.csv
+Dish Network/Satellite/1,3.csv
+Dish Network/Satellite/1,4.csv
+Dish Network/Satellite/15,-1.csv
+Dish Network/Satellite/1,5.csv
+Dish Network/Satellite/16,0.csv
+Dish Network/Satellite/1,6.csv
+Dish Network/Satellite/1,7.csv
+Dish Network/Satellite/24,0.csv
+Dish Network/Satellite/28,-1.csv
+Dish Network/Satellite/4,0.csv
+Dish Network/Satellite/4,5.csv
+Dish Network/Satellite/48,-1.csv
+Dish Network/Satellite/8,0.csv
+DK digital/DVD Player/0,-1.csv
+DK Digital/Unknown_Digital/0,-1.csv
+D-LINK/Media Center/8,230.csv
+D-LINK/Media Center/8,231.csv
+D-LINK/MP3 Player/18,37.csv
+D-LINK/MP3 Player/8,230.csv
+D-LINK/Unknown_DSM-10/8,230.csv
+D-LINK/Unknown_DSM320/8,230.csv
+D-LINK/Unknown_i2eye/130,19.csv
+DLO/HomeDock/238,135.csv
+Domland/Unknown_domland-MH10CA/131,101.csv
+Draper/Dropdown Screen/0,-1.csv
+Draper/Electric Screen/0,-1.csv
+Draper/Screen/0,-1.csv
+Draper/Screen/2,-1.csv
+Dream Multimedia/Unknown_URC7562/0,-1.csv
+Dream/Satellite/0,-1.csv
+Dream/Satellite/10,0.csv
+Dream/Satellite/11,0.csv
+Dream/Satellite/25,0.csv
+Dream/Satellite/26,0.csv
+Dream/Satellite/41,0.csv
+Dream Vision/DLP Projector/135,78.csv
+DSE/Unknown_G1605/5,-1.csv
+DSE/Unknown_G1928/0,-1.csv
+DSE/Unknown_G7659/0,-1.csv
+dual/Unknown_dual/68,-1.csv
+Durabrand/Unknown_PTV141/128,99.csv
+DVDO/Scaler/0,45.csv
+DVDO/Scaler/132,32.csv
+DVDO/Video Processor/0,45.csv
+DVDO/Video Processor/132,32.csv
+DVICO/Unknown_FusionRemote/1,-1.csv
+Dwin/Line Multiplier/1,-1.csv
+Dwin/Plasma/15,-1.csv
+Dwin/Projector/15,-1.csv
+Dwin/TV/15,-1.csv
+Dwin/Video Processor/1,-1.csv
+Dwin/Video Processor/7,0.csv
+Dwin/Video Projector/15,-1.csv
+Dwin/Video Projector/7,0.csv
+Dynaudio/Unknown_Sub/1,-1.csv
+Dynex/Unknown_DX-CVS4/2,-1.csv
+Eagle Aspen/Unknown_Aspen/120,-1.csv
+Echostar/Dish Network/0,0.csv
+Echostar/DSS/0,0.csv
+Echostar/DVR/0,0.csv
+Echostar/DVR/1,0.csv
+Echostar/PVR SAT/0,0.csv
+Echostar/PVR SAT/1,0.csv
+Echostar/Satelite DVR/0,0.csv
+Echostar/Satelite DVR/0,4.csv
+Echostar/Satelite DVR/1,0.csv
+Echostar/Satelite DVR/1,4.csv
+Echostar/Satelite DVR/2,-1.csv
+Echostar/Satellite/0,0.csv
+Echostar/Satellite/1,0.csv
+Echostar/Satellite/16,0.csv
+Echostar/Satellite/4,-1.csv
+Echostar/Sat_PVR Recorder Box/0,4.csv
+Echostar/Sat_PVR Recorder Box/1,4.csv
+Echostar/Unknown_AD3000IP/4,0.csv
+Echostar/Unknown_DSB-616/5,-1.csv
+Echostar/Unknown_DSB-636/4,0.csv
 Elan/AV Distributor/0,-1.csv
-Elan/Video Switcher/1,-1.csv
-Elan/Video Switcher/0,-1.csv
-Elan/Volume Control/255,15.csv
-Elan/Volume Control/1,241.csv
-Elan/Volume Control/0,-1.csv
-Elan/HD/4,-1.csv
-Elan/HD/5,-1.csv
-Elan/HD/2,-1.csv
-Elan/HD/1,-1.csv
-Elan/HD/0,-1.csv
-Elan/Video Controller/0,-1.csv
-Elan/DVD Manager/15,-1.csv
-Elan/Master Controller/5,-1.csv
-Elan/Master Controller/1,-1.csv
-Elan/Master Controller/0,-1.csv
-Elan/IR Router/2,-1.csv
-Elan/IR Router/1,-1.csv
+Elan/Camera Switcher/0,-1.csv
 Elan/DMX/100,-1.csv
 Elan/DMX/14,-1.csv
 Elan/DMX/96,-1.csv
 Elan/DMX/99,-1.csv
+Elan/DVD Manager/15,-1.csv
+Elan/HD/0,-1.csv
+Elan/HD/1,-1.csv
+Elan/HD/2,-1.csv
+Elan/HD/4,-1.csv
+Elan/HD/5,-1.csv
+Elan/IR Router/1,-1.csv
+Elan/IR Router/2,-1.csv
 Elan/Jukebox/96,-1.csv
-Elan/Camera Switcher/0,-1.csv
-Elan/Satellite Radio/26,-1.csv
+Elan/Master Controller/0,-1.csv
+Elan/Master Controller/1,-1.csv
+Elan/Master Controller/5,-1.csv
 Elan/Pre-Amplifier/0,-1.csv
+Elan/Satellite Radio/26,-1.csv
 Elan/Tuner/129,115.csv
-Philco/Unknown_PCR-111/80,-1.csv
-Kyocera/CD Player/119,-1.csv
+Elan/Video Controller/0,-1.csv
+Elan/Video Switcher/0,-1.csv
+Elan/Video Switcher/1,-1.csv
+Elan/Volume Control/0,-1.csv
+Elan/Volume Control/1,241.csv
+Elan/Volume Control/255,15.csv
+Electrocompaniet/CD Player/20,-1.csv
+Electrocompaniet/Integrated Amplifier/16,-1.csv
+Electrokinetics/Plasma Lift/0,-1.csv
+Elenberg/Unknown_RC-404E/0,251.csv
+Elitron/Unknown_utk/7,-1.csv
+Elmo/Camera/128,-1.csv
+Elmo/CAMERA_PRC-100S/32,-1.csv
+Elmo/Video Projector/132,132.csv
+Elmo/Video Projector/134,134.csv
+ELTASAT/Unknown_SAT170/66,253.csv
+eltax/Unknown_corniche/0,246.csv
+E Max/DVD Player/0,223.csv
+Emerson/TV/0,-1.csv
+Emerson/TV/135,34.csv
+Emerson/Unknown_emerson/134,5.csv
+Emerson/Unknown_emerson-cd/3,1.csv
+Emerson/Unknown_Emerson-NB050-DVD/135,34.csv
+Emerson/Unknown_emersontv/22,22.csv
+Emerson/VCR/21,-1.csv
+Emerson/VCR/40,-1.csv
+Emerson/VCR/4,-1.csv
+ENTONE/Unknown_URC-4021ABA1-006-R/230,4.csv
+Epson/Projector/131,85.csv
+Epson/Unknown_12807990/131,85.csv
+Epson/Unknown_ELPST12/131,85.csv
+Epson/Video Projector/131,85.csv
+Escient/CD Jukebox/0,0.csv
+Escient/CD Jukebox/14,0.csv
+Escient/CD Jukebox/15,0.csv
+Escient/CD Jukebox/48,-1.csv
+Escient/CD Jukebox/91,-1.csv
+Escient/CD Management/0,0.csv
+Escient/CD Management/14,0.csv
+Escient/CD Management/91,-1.csv
+Escient/Digital Jukebox/15,0.csv
+Escient/Digital Media Receiver/1,22.csv
+Escient/Digital Media Receiver/15,-1.csv
+Escient/DVD Library/1,22.csv
+Escient/DVD Library/8,-1.csv
+Escient/DVD Player/1,22.csv
+Escient/DVD Player/2,22.csv
+Escient/DVD Player/3,22.csv
+Escient/DVD Player/4,22.csv
+Escient/DVD Player/8,-1.csv
+Escient/Hard Drive Recorder/15,0.csv
+Escient/Media Manager/1,22.csv
+Escient/Media Manager/15,0.csv
+Escient/Media Manager/15,-1.csv
+Escient/Media Manager/2,22.csv
+Escient/Media Manager/3,22.csv
+Escient/Media Manager/33,184.csv
+Escient/Media Manager/4,22.csv
+Escient/Media Manager/48,-1.csv
+Escient/Media Server/1,22.csv
+Escient/Media Server/4,22.csv
+Escient/MP3 Player/0,-1.csv
+Escient/MP3 Player/1,22.csv
+Escient/MP3 Player/14,-1.csv
+Escient/MP3 Player/15,-1.csv
+Escient/MP3 Player/4,22.csv
+Esoteric Audio/DVD Player/133,32.csv
+E-tech/Unknown_FLY98/96,1.csv
+Euroconsumers/Unknown_LG-5988/136,-1.csv
+Expressvu/Unknown_3100/0,0.csv
+Extron/Switcher/0,-1.csv
+Extron/Switcher/128,84.csv
+Fagor/Unknown_TEDI100/192,-1.csv
+Falcon/Unknown_VT-1000/16,47.csv
+Faroudja/DVD Player/163,-1.csv
+Faroudja/DVD Player/175,-1.csv
+Faroudja/Line Doubler/1,-1.csv
+Faroudja/Line Quadrupler/1,-1.csv
+Faroudja/Processor/1,-1.csv
+Faroudja/Video Processor/1,-1.csv
+Faroudja/Video Processor/27,-1.csv
+Faroudja/Video Projector/0,-1.csv
+Faroudja/Video Projector/1,-1.csv
+Faroudja/Video Projector/13,-1.csv
+Faroudja/Video Projector/135,78.csv
+Faroudja/Video Projector/24,-1.csv
+Faroudja/Video Projector/24,24.csv
+Faroudja/Video Projector/30,-1.csv
+Fast/TV/28,-1.csv
+Fast/TVS/28,-1.csv
+Fedders/Air Conditioner/32,-1.csv
+fenner/Unknown_fenner/95,0.csv
+Fisher/Surround Processor/48,48.csv
+Fisher/Surround Processor/54,200.csv
+Fisher/TV/0,-1.csv
+Fisher/TV/56,-1.csv
+Fisher/Unknown_ra/60,-1.csv
+Fisher/Unknown_RC720F/104,-1.csv
+Fisher/Unknown_RCA-9060/54,-1.csv
+Fisher/Unknown_REM-1500/162,162.csv
+Fortec/Unknown_Lifetime/32,-1.csv
+Fortec/Unknown_Mercury2/1,253.csv
+Fosgate/Pre-Amplifier/131,69.csv
+Fosgate/Pre-Amplifier/131,95.csv
+Fosgate/Pre-Amplifier/64,64.csv
+Fosgate/Surround Processor/132,66.csv
+Foxtel/Set Top Box/33,160.csv
+Foxtel/Unknown_Digital/0,0.csv
+Foxtel/Unknown_foxtel/33,160.csv
+Freecom/Unknown_MP35/128,-1.csv
+Freecom/Unknown_usb/128,-1.csv
+Free/Unknown_REMOTE/11,-1.csv
+Free/Unknown_V5/36,12.csv
+Fresat/Unknown_SER-3000PL/8,64.csv
+Friedrich/Air Conditioner/1,-1.csv
+Friedrich/Air Conditioner/16,-1.csv
+FSC/DVD Player/4,15.csv
+FTE Maximal/Unknown_FTE/73,-1.csv
+FUBA/Unknown_ALPS/134,75.csv
+FUBA/Unknown_FUBA/134,75.csv
+Fujitsu/Monitor/132,138.csv
+Fujitsu/Monitor/132,139.csv
+Fujitsu/Monitor/132,140.csv
+Fujitsu/Monitor/132,-1.csv
+Fujitsu/Plasma/132,129.csv
+Fujitsu/Plasma/132,130.csv
+Fujitsu/Plasma/132,134.csv
+Fujitsu/Plasma/132,136.csv
+Fujitsu/Plasma/132,138.csv
+Fujitsu/Plasma/132,139.csv
+Fujitsu/Plasma/132,140.csv
+Fujitsu/Plasma/132,141.csv
+Fujitsu/Plasma/132,-1.csv
+Fujitsu/Plasma/140,132.csv
+Fujitsu Siemens/Unknown_RC1-1241-21/32,176.csv
+Fujitsu Siemens/Unknown_RC811/4,15.csv
+Fujitsu/TV/132,-1.csv
+Fujitsu/Unknown_CP300375-01/4,15.csv
+Fujtech/Unknown_DVB-T/3,-1.csv
+FUNAI/Unknown_NF021RD/132,224.csv
+Fusion Research/DVD Server/17,-1.csv
+Galaxis/Satellite/13,80.csv
+Galaxis/Unknown_GALAXIS-RC5/0,-1.csv
+Galaxis/Unknown_Galaxis-RCMM/13,80.csv
+Galaxis/Unknown_Galaxis.sat/81,175.csv
+Galaxis/Unknown_rc1/7,-1.csv
+GAMEFACTORY/Unknown_PS2DVD/0,246.csv
+Gefen Systems/DVI Switcher/11,-1.csv
+Gefen Systems/HDMI Switcher/11,-1.csv
+Gefen Systems/Matrix Switcher/11,-1.csv
+Gefen Systems/Unknown/24,-1.csv
+General Electric/TV/15,-1.csv
+General Electric/VCR/11,-1.csv
+General Electric/VCR/14,-1.csv
+General Electric/VCR/26,73.csv
+General Instrument/Cable Box/0,-1.csv
+General Instrument/Cable Box/1,-1.csv
+General Instrument/Cable Box/122,-1.csv
+General Instrument/Cable Box/144,0.csv
+General Instrument/Cable Box/15,-1.csv
+General Instrument/Cable Box/64,-1.csv
+General Instrument/Cable Box/87,-1.csv
+General Instrument/Satellite/1,-1.csv
+General Instrument/Satellite/130,110.csv
+General Instruments/Unknown_550/-1,-1.csv
+General Instruments/Unknown_XRC-200/0,-1.csv
+General/Unknown_VCR/22,-1.csv
+Generic/Unknown_DENON/None,None.csv
+Generic/Unknown_MOTOROLA/-1,-1.csv
+Generic/Unknown_NEC/None,None.csv
+Generic/Unknown_RC-5/None,None.csv
+Generic/Unknown_RC-6/None,None.csv
+Generic/Unknown_RCMM-32/None,None.csv
+Generic/Unknown_RECS80/None,None.csv
+Generic/Unknown_Sanyo/None,None.csv
+Generic/Unknown_SONY/None,None.csv
+Generic/Unknown_XMP/None,None.csv
+Genesis/Theater in Box/0,-1.csv
+Geniatech/Unknown_Supera/0,-1.csv
+Genius/Unknown_Genius-DVB-T32/5,-1.csv
+Genus/Unknown_DU1/128,-1.csv
+Gericom/Plasma/3,-1.csv
+Get/Unknown_gethdpvr/72,36.csv
+GE/TV/15,-1.csv
+GE/VCR/11,-1.csv
+GE/VCR/14,-1.csv
+GE/VCR/26,73.csv
+GE/VCR_VKFS0938/14,-1.csv
+Gigabyte/Unknown_TV/134,107.csv
+Golden Interstar/Sat/128,255.csv
+Golden Interstar/Unknown_Interstar/4,16.csv
+Goldmund/CD Player/20,-1.csv
+GoldStar/Unknown_cd/16,16.csv
+GoldStar/Unknown_GOLDSTAR/4,-1.csv
+GoldStar/Unknown_Goldstar-VCR/110,-1.csv
+GoldStar/Unknown_RN800AW/110,-1.csv
+GoldStar/Unknown_VCR/110,-1.csv
+GoldStar/VCR/110,-1.csv
+Goodmans/Unknown_GDB/8,-1.csv
+Goodmans/Unknown_GDVD124/0,-1.csv
+Goodmans/Unknown_md305/135,108.csv
+Goodmans/Unknown_RC-BM/128,123.csv
+Go Video/DVD Recorder/10,247.csv
+Govideo/Unknown_GoVideoD2730/8,230.csv
+Go Video/VCR/132,98.csv
+Go Video/VCR/5,5.csv
+Go Video/VCR/7,7.csv
+Go Video/VCR_DVD Combo/110,-1.csv
+Go Video/VCR_DVD Combo/21,-1.csv
+Go Video/VCR_DVD Combo/33,-1.csv
+Go Video/VCR_DVD Combo/45,45.csv
+Go Video/VCR_DVD Combo/5,-1.csv
+Go Video/VCR_DVD Combo/5,5.csv
+Gradiente/Unknown_D-10/5,-1.csv
+Gradiente/Unknown_GSD-100/132,60.csv
+Grand Tech/Cable Box/2,-1.csv
+Gran Prix/Unknown_prix/0,-1.csv
+Griffin/iPod/212,190.csv
+Grundig/Satellite/1,-1.csv
+Grundig/Satellite/2,-1.csv
+Grundig/Satellite/8,-1.csv
+Grundig/TV/0,-1.csv
+Grundig/Unknown_2500S/10,-1.csv
+Grundig/Unknown_84D/128,-1.csv
+Grundig/Unknown_CDM700.cfg/162,162.csv
+Grundig/Unknown_Grundig/None,None.csv
+Grundig/Unknown_Grundig-TP660/0,-1.csv
+Grundig/Unknown_RC8400CD/20,-1.csv
+Grundig/Unknown_RC-TP3/8,-1.csv
+Grundig/Unknown_RP25/None,None.csv
+Grundig/Unknown_RP/5,-1.csv
+Grundig/Unknown_rp700/5,-1.csv
+Grundig/Unknown_TP/0,-1.csv
+Grundig/Unknown_tp621/1,-1.csv
+Grundig/Unknown_TP-750C/0,-1.csv
+Grundig/Unknown_UMS9V/162,162.csv
+Grundig/Video Recorder/127,-1.csv
+Gryphon/Integrated Amplifier/16,-1.csv
+Guillemot/Unknown_RemoteWizard-GN-263/134,107.csv
+GVC/Unknown_RM-RK50/143,-1.csv
+Hama/Unknown_Internet/0,-1.csv
+Hama/Unknown_PhotoPlayer/134,107.csv
+Hampton Bay/Unknown_Bay/129,102.csv
+Harman Kardon/Amplifier/128,112.csv
+Harman Kardon/Amplifier/130,114.csv
+Harman Kardon/Blu-Ray/132,116.csv
+Harman Kardon/Cassette Tape/130,114.csv
+Harman Kardon/CD Changer/128,112.csv
+Harman Kardon/CD Player/0,-1.csv
+Harman Kardon/CD Player/128,112.csv
+Harman Kardon/CD Player/131,74.csv
+Harman Kardon/CD-R/128,112.csv
+Harman Kardon/DVD Player/130,114.csv
+Harman Kardon/iPod/130,114.csv
+Harman Kardon/Pre-Amplifier/128,112.csv
+Harman Kardon/Pre-Amplifier/130,114.csv
+Harman Kardon/Receiver/128,112.csv
+Harman Kardon/Receiver/130,114.csv
+Harman Kardon/Receiver/132,116.csv
+Harman Kardon/Receiver/132,66.csv
+Harman Kardon/Receiver/134,118.csv
+Harman Kardon/Receiver/161,-1.csv
+Harman Kardon/Receiver/164,-1.csv
+Harman Kardon/Receiver/40,-1.csv
+Harman Kardon/Receiver/4,-1.csv
+Harman Kardon/Receiver/7,-1.csv
+Harman Kardon/Surround Processor/0,-1.csv
+Harman Kardon/Surround Processor/12,-1.csv
+Harman Kardon/Surround Processor/128,112.csv
+Harman Kardon/Surround Processor/130,114.csv
+Harman Kardon/Surround Processor/16,-1.csv
+Harman Kardon/Surround Processor/17,-1.csv
+Harman Kardon/Surround Processor/18,-1.csv
+Harman Kardon/Surround Processor/20,-1.csv
+Harman Kardon/Surround Processor/23,-1.csv
+Harman Kardon/Surround Processor/5,-1.csv
+Harman Kardon/Surround Processor/6,-1.csv
+Harman Kardon/Surround Processor/64,-1.csv
+Harman Kardon/Surround Receiver/128,112.csv
+Harman Kardon/Surround Receiver/130,114.csv
+Harman Kardon/Tuner/0,-1.csv
+Harman Kardon/Tuner/128,112.csv
+Harman Kardon/Tuner/130,114.csv
+Harman Kardon/Unknown/130,114.csv
+Harman Kardon/Unknown_DVD/130,114.csv
+Harman Kardon/Unknown_harmankardon/128,112.csv
+Harman Kardon/Unknown_HD730/131,74.csv
+Harman Kardon/Unknown_Kardon-DVD/130,114.csv
+Harman Kardon/Video Projector/0,-1.csv
+Harman Kardon/Video Projector/1,-1.csv
+Harman Kardon/Video Projector/30,-1.csv
+Harman Kardon/Video Projector/7,0.csv
+Harman Video/Video Projector/1,-1.csv
+Harman Video/Video Projector/7,0.csv
+Harmony/PS3 Adaptor/11,-1.csv
+Hauppauge/Unknown_DSR-0095/29,-1.csv
+Hauppauge/Unknown_hauppauge-stb/5,-1.csv
+Hauppauge/Unknown_MVP/3,-1.csv
+Hauppauge/Unknown_R808/30,-1.csv
+Hauppauge/Unknown_WinTV-HVR/4,15.csv
+Hauppauge/Unknown_WinTV-HVR-950Q/29,-1.csv
+HB/Unknown_DIGITAL/0,-1.csv
+Hello Kitty/Unknown_Kitty/0,-1.csv
+HERCULES/Unknown_SMARTTV/None,None.csv
 Herma/Dipper/5,-1.csv
-Daeumling/Unknown_SR200/128,38.csv
-ANIMAX/MOUSE/0,-1.csv
-JVC/Unknown_rm-c241/3,-1.csv
-JVC/Satellite/0,0.csv
-JVC/Satellite/16,0.csv
-JVC/Satellite/8,0.csv
-JVC/Satellite/24,0.csv
-JVC/Unknown_PQ10543/83,-1.csv
-JVC/Receiver/159,-1.csv
-JVC/Receiver/34,84.csv
-JVC/Receiver/175,-1.csv
-JVC/Receiver/147,-1.csv
-JVC/Receiver/3,-1.csv
-JVC/Receiver/131,-1.csv
-JVC/Receiver/179,-1.csv
-JVC/Receiver/83,-1.csv
-JVC/Receiver/67,-1.csv
-JVC/Receiver/1,-1.csv
-JVC/Receiver/121,-1.csv
-JVC/Receiver/163,-1.csv
-JVC/Receiver/191,-1.csv
-JVC/Receiver/239,-1.csv
-JVC/Monitor/3,-1.csv
-JVC/Monitor/67,-1.csv
-JVC/Video Switcher/243,-1.csv
-JVC/DVD Player/179,-1.csv
-JVC/DVD Player/26,-1.csv
-JVC/DVD Player/239,-1.csv
-JVC/Unknown_sw/243,-1.csv
-JVC/Unknown_RM-V718U/211,-1.csv
-JVC/LCD TV/3,-1.csv
-JVC/Unknown_JvcDishPlayer500/3,0.csv
-JVC/Unknown_RM-C462/3,-1.csv
-JVC/Unknown_RM-SX263U/179,-1.csv
-JVC/Unknown_RM-C678/3,-1.csv
-JVC/Unknown_RM-V1E/67,-1.csv
-JVC/Unknown_RM-RX130/159,-1.csv
-JVC/Video Projector/115,-1.csv
-JVC/Video Projector/131,85.csv
-JVC/Unknown_RM-RK60/143,-1.csv
-JVC/VCR DVD Combo/111,-1.csv
-JVC/VCR DVD Combo/3,-1.csv
-JVC/VCR DVD Combo/67,-1.csv
-JVC/Unknown_SXV037J/239,-1.csv
-JVC/HD-ILA Projection/115,-1.csv
-JVC/HD-ILA Projection/3,-1.csv
-JVC/HD-ILA Projection/67,-1.csv
-JVC/HD-ILA Projection/15,-1.csv
-JVC/Projector/115,-1.csv
-JVC/VCR/0,14.csv
-JVC/VCR/5,1.csv
-JVC/VCR/3,-1.csv
-JVC/VCR/131,-1.csv
-JVC/VCR/1,14.csv
-JVC/VCR/80,-1.csv
-JVC/VCR/179,-1.csv
-JVC/VCR/83,-1.csv
-JVC/VCR/67,-1.csv
-JVC/VCR/1,-1.csv
-JVC/VCR/163,-1.csv
-JVC/VCR/64,-1.csv
-JVC/VCR/8,14.csv
-JVC/Unknown_RM-C410/3,-1.csv
-JVC/DVD Recorder/111,-1.csv
-JVC/Unknown_RM-SXVS40A/239,-1.csv
-JVC/Unknown_JVC/159,-1.csv
-JVC/Unknown_jvc-lp20465-005-vcr/67,-1.csv
-JVC/Unknown_440/179,-1.csv
-JVC/Unknown_RM-C670/3,-1.csv
-JVC/Unknown_RM-V730U/223,-1.csv
-JVC/DVD_VCR Combo/67,-1.csv
-JVC/Mini System/31,-1.csv
-JVC/Mini System/159,-1.csv
-JVC/Mini System/175,-1.csv
-JVC/Mini System/131,-1.csv
-JVC/Mini System/179,-1.csv
-JVC/Mini System/163,-1.csv
-JVC/CD Player/179,0.csv
-JVC/CD Player/34,33.csv
-JVC/CD Player/179,-1.csv
-JVC/CD Player/34,48.csv
-JVC/Unknown_JVC-RM-C475W/3,-1.csv
-JVC/Unknown_remote/159,-1.csv
-JVC/VCR_MiniDV/67,-1.csv
-JVC/Unknown_LP20106-002/67,-1.csv
-JVC/Unknown_RM-C530/3,-1.csv
-JVC/Unknown_RM-C1251G/3,-1.csv
+Hermstedt/Unknown_Hifidelio/16,-1.csv
+Hewlett Packard/Plasma/18,17.csv
+Hewlett Packard/Plasma/2,17.csv
+Hewlett Packard/TV/18,17.csv
+Hewlett Packard/TV/2,17.csv
+Hinen Electronics/Unknown_Electronics/0,-1.csv
+Hip Interactive/Unknown_GE1002/0,246.csv
+Hirschmann/Satellite/32,255.csv
+Hirschmann/Unknown_RC426/54,-1.csv
+Hitachi/Cable Box/80,-1.csv
+Hitachi/CD Player/168,-1.csv
+Hitachi/Display/80,-1.csv
+Hitachi/DSS/12,251.csv
+Hitachi/DSS/184,0.csv
+Hitachi/DSS/3,-1.csv
+Hitachi/DSS/4,-1.csv
+Hitachi/DSS/80,-1.csv
+Hitachi/DSS/96,-1.csv
+Hitachi/DSS/97,-1.csv
+Hitachi/DVD Player/102,0.csv
+Hitachi/DVD_VCR Combo/128,35.csv
+Hitachi/DVD_VCR Combo/40,-1.csv
+Hitachi/DVD_VCR Combo/44,-1.csv
+Hitachi/LCD/86,171.csv
+Hitachi/Monitor/144,0.csv
+Hitachi/Monitor/80,-1.csv
+Hitachi/Monitor/96,158.csv
+Hitachi/Monitor/96,-1.csv
+Hitachi/Monitor/97,-1.csv
+Hitachi/Plasma/80,173.csv
+Hitachi/Plasma/80,-1.csv
+Hitachi/TV/12,251.csv
+Hitachi/TV/80,143.csv
+Hitachi/TV/80,173.csv
+Hitachi/TV/80,-1.csv
+Hitachi/TV/96,-1.csv
+Hitachi/Unknown_CLE-941/80,-1.csv
+Hitachi/Unknown_CLE-947/80,-1.csv
+Hitachi/Unknown_CP-X345/135,69.csv
+Hitachi/Unknown_DV-RM335E/128,35.csv
+Hitachi/Unknown_FX7/91,-1.csv
+Hitachi/Unknown_HFTV/71,-1.csv
+Hitachi/Unknown_Hitachi/1,-1.csv
+Hitachi/Unknown_Hitachi/80,-1.csv
+Hitachi/Unknown_hitachi.conf/91,-1.csv
+Hitachi/Unknown_RM-613a/96,159.csv
+Hitachi/VCR/0,-1.csv
+Hitachi/VCR/40,-1.csv
+Hitachi/VCR/44,-1.csv
+Hitachi/VCR/5,1.csv
+Hitachi/VCR/80,-1.csv
+Hitachi/VCR/83,-1.csv
+Hitachi/VCR/96,158.csv
+Hitachi/VCR/96,-1.csv
+Hitachi/VCR/97,159.csv
+Hitachi/VCR/97,-1.csv
+Hitachi/Video Projector/135,69.csv
+Hitachi/Video Projector/80,-1.csv
+Hiteker/DVD Player/0,-1.csv
+Hivion/Unknown_SAT/64,64.csv
+Hokkaido/Unknown_Airconditioner/77,178.csv
+Homecast/Satellite Receiver/1,-1.csv
+Homecast/Unknown_DVB-S/32,32.csv
+Homecast/Unknown_DVB-T/64,64.csv
+HP/Unknown_465539-002/4,15.csv
+HP/Unknown_DV4-1125NR/4,15.csv
+HP/Unknown_DV6331/4,17.csv
+HP/Unknown_Pavilion/4,15.csv
+HP/Unknown_RC172308-01B/4,15.csv
+HP/Unknown_RC1762302-00/4,17.csv
+HP/Unknown_RC1762307-01/4,15.csv
+HP/Unknown_RC2234302-01B/4,15.csv
+HQ/Unknown_RC/0,-1.csv
+HQV/Video Processor/128,-1.csv
+Hughes/DSS/1,-1.csv
+Hughes/DSS/12,-1.csv
+Hughes/DSS/12,251.csv
+Hughes/DSS/133,48.csv
+Hughes/DSS/136,-1.csv
+Hughes/DSS/4,-1.csv
+Hughes/DSS/60,178.csv
+Hughes/DSS/71,-1.csv
+Hughes/DVR/12,-1.csv
+Hughes/DVR/133,48.csv
+Hughes/HD Satellite HD Tivo/133,48.csv
+Hughes/HD with TiVo/133,48.csv
+Hughes/Satellite/1,-1.csv
+Hughes/Satellite/12,-1.csv
+Hughes/Satellite/12,251.csv
+Hughes/Satellite/133,48.csv
+Hughes/Satellite/136,-1.csv
+Hughes/Satellite/4,-1.csv
+Hughes/Satellite/60,178.csv
+Hughes/Satellite/71,-1.csv
+Hughes/Sat_TiVo/133,48.csv
+Hughes/Sat_TiVo/210,109.csv
+Hughes/TiVo/133,48.csv
+Hughes/Unknown_b2/12,251.csv
+Hughes/Unknown_DSS/12,251.csv
+Hughes/Unknown_HRMC-8/12,251.csv
+Hughes/VCR/96,-1.csv
+Hughes/VCR/97,-1.csv
+Humax/Com Hem Box/0,16.csv
+Humax/DVD_VCR Combo/0,16.csv
+Humax/DVD_VCR Combo/0,23.csv
+Humax/HDTV Tuner/0,16.csv
+Humax/HDTV Tuner/0,48.csv
+Humax/HDTV Tuner/0,65.csv
+Humax/HDTV Tuner/0,73.csv
+Humax/Satellite/0,17.csv
+Humax/Satellite/0,23.csv
+Humax/Satellite/0,73.csv
+Humax/Tivo + DVD/133,48.csv
+Humax/Unknown_F1CI/0,16.csv
+Humax/Unknown_HUMAX/0,16.csv
+Humax/Unknown_Humax-5400IRCI/0,16.csv
+Humax/Unknown_Humax-RC-536P/2,23.csv
+Humax/Unknown_lircd.conf/0,16.csv
+Humax/Unknown_RS-521/0,16.csv
+huth/Unknown_prof/15,1.csv
+Hyundai/Unknown_H-DVD5038N/0,251.csv
+Hyundai/Unknown_l17t/170,3.csv
+I24/Unknown_I24/0,-1.csv
+Illusion/Unknown_M3/22,-1.csv
+Imerge/Digital Jukebox/14,-1.csv
+Imerge/Digital Jukebox/161,-1.csv
+Imerge/Digital Jukebox/162,-1.csv
+Imerge/Digital Jukebox/163,-1.csv
+Imerge/Digital Jukebox/164,-1.csv
+Imerge/Digital Jukebox/165,-1.csv
+Imerge/Digital Jukebox/166,-1.csv
+Imerge/Digital Jukebox/191,-1.csv
+Imerge/Digital Jukebox/255,-1.csv
+imon/Unknown_iMON-PAD/None,None.csv
+imon/Unknown_lircd.conf.imon-2.4g-lt/None,None.csv
+imon/Unknown_MultiMedian/6,-1.csv
+imon/Unknown_ultrabay/None,None.csv
+imon/Unknown_Veris/None,None.csv
+InFocus/DLP Projector/15,-1.csv
+InFocus/Plasma/7,-1.csv
+InFocus/Projector/135,78.csv
+InFocus/Unknown_InFocus-SP8600/49,-1.csv
+InFocus/Unknown_remote/135,78.csv
+InFocus/Unknown_ScreenPlay/135,78.csv
+InFocus/Video Projector/1,-1.csv
+InFocus/Video Projector/123,2.csv
+InFocus/Video Projector/131,85.csv
+InFocus/Video Projector/135,78.csv
+InFocus/Video Projector/15,-1.csv
+InFocus/Video Projector/2,1.csv
+InFocus/Video Projector/78,135.csv
+InFocus/Video Projector/80,79.csv
+Insignia/Blu-Ray/133,237.csv
+Insignia/Blu-Ray/135,34.csv
+Insignia/DVD Player/135,34.csv
+Insignia/DVD_VCR Combo/110,-1.csv
+Insignia/DVD_VCR Combo/45,45.csv
+Insignia/TV/134,5.csv
+Insignia/Unknown_WIR147002-8301/67,71.csv
+Instant Replay/VCR/2,-1.csv
+Instant Replay/VCR/25,-1.csv
+Instant Replay/VCR/3,-1.csv
+Instant Replay/VCR/96,-1.csv
+Instant Replay/VCR/97,-1.csv
+Integra/Amplifier/210,109.csv
+Integra/Amplifier/71,-1.csv
+Integra/Blu-Ray/210,31.csv
+Integra/CD Player/210,44.csv
+Integra/Digital Audio/210,3.csv
+Integra/Digital Audio/210,4.csv
+Integra/Digital Audio/210,9.csv
+Integra/DVD Player/210,31.csv
+Integra/DVD Player/210,43.csv
+Integra/DVD Player/69,181.csv
+Integra/HD DVD/69,181.csv
+Integra/Integrated Amplifier/210,109.csv
+Integra/Integrated Amplifier/71,-1.csv
+Integra/iPod/210,108.csv
+Integra/iPod/210,109.csv
+Integra/iPod/210,172.csv
+Integra/iPod/210,2.csv
+Integra/Media PC/4,15.csv
+Integra/Pre-Amplifier/210,108.csv
+Integra/Pre-Amplifier/210,109.csv
+Integra/Pre-Amplifier/210,172.csv
+Integra/Pre-Amplifier/210,25.csv
+Integra/Pre-Amplifier/210,2.csv
+Integra/Pre-Amplifier/210,30.csv
+Integra/Receiver/210,108.csv
+Integra/Receiver/210,109.csv
+Integra/Receiver/210,172.csv
+Integra/Receiver/210,17.csv
+Integra/Receiver/210,18.csv
+Integra/Receiver/210,19.csv
+Integra/Receiver/210,1.csv
+Integra/Receiver/210,20.csv
+Integra/Receiver/210,21.csv
+Integra/Receiver/210,22.csv
+Integra/Receiver/210,23.csv
+Integra/Receiver/210,24.csv
+Integra/Receiver/210,25.csv
+Integra/Receiver/210,2.csv
+Integra/Receiver/210,30.csv
+Integra/Receiver/210,43.csv
+Integra/Tuner/210,109.csv
+Integra/Tuner/210,2.csv
+IntelliNet Controls/Distributed Audio/0,90.csv
+Interact/Unknown_I-22121/0,-1.csv
+Intervideo/VCR/49,-1.csv
+Intervision/Unknown_Intervision/134,107.csv
+I-O Data/DVD Player/8,230.csv
+ione/Unknown_remote/0,-1.csv
+iPort/iPod/1,222.csv
+iPort/iPort/1,222.csv
+iPort/MP3 Player/1,222.csv
+IR4PS3/Blu-Ray/26,35.csv
+Irradio/3331_DVB-T/1,254.csv
+Irradio/Unknown_IrradioHIFI1300V/162,162.csv
+italtel/Unknown_italtel/1,-1.csv
+ITT/Unknown_ITT/49,-1.csv
+ITT/Unknown_ITTNOKIA/49,-1.csv
+ITT/Unknown_RC40/49,-1.csv
+ITT/Unknown_RC51/49,-1.csv
+Jamo/DVD Receiver/25,-1.csv
+JBL/Receiver/64,47.csv
+JBL/Surround Processor/130,11.csv
+JBL/Surround Processor/132,66.csv
+JBL/Surround Processor/28,-1.csv
+JENSEN/VCR/1,-1.csv
+Jerrold/Cable Box/0,-1.csv
+Jerrold/Cable Box/1,-1.csv
+Jerrold/Unknown_550-osd/0,-1.csv
+Jerrold/Unknown_CFT2000/0,-1.csv
+Jerrold/Unknown_MRC/-1,-1.csv
+Jerrold/Unknown_RC-OSD/0,-1.csv
 JVC/Camcorder/211,-1.csv
 JVC/Camcorder/67,-1.csv
 JVC/Cassette Tape/131,-1.csv
-JVC/LCD/3,-1.csv
-JVC/LCD/35,-1.csv
-JVC/LCD/67,-1.csv
-JVC/LCD/15,-1.csv
-JVC/Unknown_RM-SMXJ100E/0,4.csv
-JVC/Plasma/31,-1.csv
-JVC/Unknown_RM-RX250/159,-1.csv
-JVC/Unknown_RM-RXUA4/159,-1.csv
-JVC/Karaoke/3,-1.csv
-JVC/Karaoke/179,-1.csv
-JVC/Karaoke/191,-1.csv
-JVC/S-VHS/67,-1.csv
-JVC/Switcher/243,-1.csv
 JVC/CD Jukebox/179,0.csv
 JVC/CD Jukebox/34,33.csv
 JVC/CD Jukebox/34,48.csv
+JVC/CD Player/179,0.csv
+JVC/CD Player/179,-1.csv
+JVC/CD Player/34,33.csv
+JVC/CD Player/34,48.csv
+JVC/DVD Player/179,-1.csv
+JVC/DVD Player/239,-1.csv
+JVC/DVD Player/26,-1.csv
+JVC/DVD Recorder/111,-1.csv
+JVC/DVD_VCR Combo/67,-1.csv
+JVC/D-VHS/67,-1.csv
+JVC/HD-ILA Projection/115,-1.csv
+JVC/HD-ILA Projection/15,-1.csv
+JVC/HD-ILA Projection/3,-1.csv
+JVC/HD-ILA Projection/67,-1.csv
+JVC/Karaoke/179,-1.csv
+JVC/Karaoke/191,-1.csv
+JVC/Karaoke/3,-1.csv
+JVC/LCD/15,-1.csv
+JVC/LCD/3,-1.csv
+JVC/LCD/35,-1.csv
+JVC/LCD/67,-1.csv
+JVC/LCD TV/3,-1.csv
+JVC/Mini System/131,-1.csv
+JVC/Mini System/159,-1.csv
+JVC/Mini System/163,-1.csv
+JVC/Mini System/175,-1.csv
+JVC/Mini System/179,-1.csv
+JVC/Mini System/31,-1.csv
+JVC/Monitor/3,-1.csv
+JVC/Monitor/67,-1.csv
+JVC/Plasma/31,-1.csv
+JVC/Projector/115,-1.csv
+JVC/Receiver/1,-1.csv
+JVC/Receiver/121,-1.csv
+JVC/Receiver/131,-1.csv
+JVC/Receiver/147,-1.csv
+JVC/Receiver/159,-1.csv
+JVC/Receiver/163,-1.csv
+JVC/Receiver/175,-1.csv
+JVC/Receiver/179,-1.csv
+JVC/Receiver/191,-1.csv
+JVC/Receiver/239,-1.csv
+JVC/Receiver/3,-1.csv
+JVC/Receiver/34,84.csv
+JVC/Receiver/67,-1.csv
+JVC/Receiver/83,-1.csv
+JVC/Satellite/0,0.csv
+JVC/Satellite/16,0.csv
+JVC/Satellite/24,0.csv
+JVC/Satellite/8,0.csv
+JVC/S-VHS/67,-1.csv
+JVC/Switcher/243,-1.csv
+JVC/Tuner/131,-1.csv
+JVC/Tuner/147,-1.csv
+JVC/Tuner/163,-1.csv
+JVC/Tuner/179,-1.csv
+JVC/Tuner/3,-1.csv
+JVC/Tuner/67,-1.csv
+JVC/TV/15,-1.csv
 JVC/TV/31,-1.csv
 JVC/TV/3,-1.csv
 JVC/TV/67,-1.csv
-JVC/TV/15,-1.csv
-JVC/Unknown_RM-RXU1/159,-1.csv
-JVC/Tuner/147,-1.csv
-JVC/Tuner/3,-1.csv
-JVC/Tuner/131,-1.csv
-JVC/Tuner/179,-1.csv
-JVC/Tuner/67,-1.csv
-JVC/Tuner/163,-1.csv
+JVC/Unknown_440/179,-1.csv
+JVC/Unknown_JVC/159,-1.csv
+JVC/Unknown_JvcDishPlayer500/3,0.csv
+JVC/Unknown_jvc-lp20465-005-vcr/67,-1.csv
+JVC/Unknown_JVC-RM-C475W/3,-1.csv
+JVC/Unknown_LP20106-002/67,-1.csv
+JVC/Unknown_PQ10543/83,-1.csv
+JVC/Unknown_remote/159,-1.csv
+JVC/Unknown_RM-C1251G/3,-1.csv
+JVC/Unknown_rm-c241/3,-1.csv
 JVC/Unknown_RM-C360/3,-1.csv
-JVC/Unknown_RM-RXUT200R/159,-1.csv
-JVC/D-VHS/67,-1.csv
+JVC/Unknown_RM-C410/3,-1.csv
+JVC/Unknown_RM-C462/3,-1.csv
+JVC/Unknown_RM-C530/3,-1.csv
+JVC/Unknown_RM-C670/3,-1.csv
+JVC/Unknown_RM-C678/3,-1.csv
 JVC/Unknown_RM-RK50/143,-1.csv
-Uniden/Satellite/1,-1.csv
-AzBox/Unknown_S700/1,4.csv
+JVC/Unknown_RM-RK60/143,-1.csv
+JVC/Unknown_RM-RX130/159,-1.csv
+JVC/Unknown_RM-RX250/159,-1.csv
+JVC/Unknown_RM-RXU1/159,-1.csv
+JVC/Unknown_RM-RXUA4/159,-1.csv
+JVC/Unknown_RM-RXUT200R/159,-1.csv
+JVC/Unknown_RM-SMXJ100E/0,4.csv
+JVC/Unknown_RM-SX263U/179,-1.csv
+JVC/Unknown_RM-SXVS40A/239,-1.csv
+JVC/Unknown_RM-V1E/67,-1.csv
+JVC/Unknown_RM-V718U/211,-1.csv
+JVC/Unknown_RM-V730U/223,-1.csv
+JVC/Unknown_sw/243,-1.csv
+JVC/Unknown_SXV037J/239,-1.csv
+JVC/VCR/0,14.csv
+JVC/VCR/1,14.csv
+JVC/VCR/1,-1.csv
+JVC/VCR/131,-1.csv
+JVC/VCR/163,-1.csv
+JVC/VCR/179,-1.csv
+JVC/VCR/3,-1.csv
+JVC/VCR/5,1.csv
+JVC/VCR/64,-1.csv
+JVC/VCR/67,-1.csv
+JVC/VCR/80,-1.csv
+JVC/VCR/8,14.csv
+JVC/VCR/83,-1.csv
+JVC/VCR DVD Combo/111,-1.csv
+JVC/VCR DVD Combo/3,-1.csv
+JVC/VCR DVD Combo/67,-1.csv
+JVC/VCR_MiniDV/67,-1.csv
+JVC/Video Projector/115,-1.csv
+JVC/Video Projector/131,85.csv
+JVC/Video Switcher/243,-1.csv
+Kaleidescape/Distributed/69,-1.csv
+Kaleidescape/DVD Player/69,-1.csv
+Kanam Accent/Unknown_Accent/None,None.csv
+Kaon/Unknown_KSC-i260MCO/32,8.csv
+Kaon/Unknown_KTF-100CO/32,8.csv
+Kaon/Unknown_KTF-I2001CO/32,8.csv
+Kathrein/DVBS-Receiver/34,144.csv
+Kathrein/Satellite/0,-1.csv
+Kathrein/Satellite/34,144.csv
+Kathrein/Unknown_KathreinUFD400/0,-1.csv
+Kawasaki/DVD_Amp/154,-1.csv
+KAWA/Unknown_TV/11,11.csv
+kendo/Unknown_RC-610/134,124.csv
+KENMORE/Unknown_253-79081/8,245.csv
+Kensington/iPod Dock/51,170.csv
+Kensington/MP3 Player/51,170.csv
+Kenwood/Amplifier/184,0.csv
+Kenwood/Amplifier/184,1.csv
+Kenwood/Amplifier/184,2.csv
+Kenwood/Amplifier/184,4.csv
+Kenwood/Amplifier/184,7.csv
+Kenwood/Cassette Tape/184,-1.csv
+Kenwood/CD Changer/182,-1.csv
+Kenwood/CD Changer/182,72.csv
+Kenwood/CD Changer/184,-1.csv
+Kenwood/CD_DVD_MP-3/182,12.csv
+Kenwood/CD Player/182,0.csv
+Kenwood/CD Player/182,-1.csv
+Kenwood/CD Player/184,-1.csv
+Kenwood/DVD Changer/182,0.csv
+Kenwood/DVD Changer/182,12.csv
+Kenwood/DVD Player/182,0.csv
+Kenwood/DVD Player/182,12.csv
+Kenwood/DVD Player/182,88.csv
+Kenwood/DVD Player/184,0.csv
+Kenwood/Laser Disc/182,75.csv
+Kenwood/Pre-Amplifier/182,75.csv
+Kenwood/Pre-Amplifier/184,-1.csv
+Kenwood/Pre-Amplifier/184,1.csv
+Kenwood/Receiver/1,-1.csv
+Kenwood/Receiver/12,-1.csv
+Kenwood/Receiver/182,75.csv
+Kenwood/Receiver/184,0.csv
+Kenwood/Receiver/184,-1.csv
+Kenwood/Receiver/184,1.csv
+Kenwood/Receiver/184,2.csv
+Kenwood/Receiver/184,3.csv
+Kenwood/Receiver/184,4.csv
+Kenwood/Receiver/184,5.csv
+Kenwood/Receiver/184,6.csv
+Kenwood/Receiver/184,7.csv
+Kenwood/Receiver/25,-1.csv
+Kenwood/Receiver/40,-1.csv
+Kenwood/Receiver/4,-1.csv
+Kenwood/Satellite Radio/2,255.csv
+Kenwood/Sirius/2,255.csv
+Kenwood/Tuner/182,75.csv
+Kenwood/Tuner/184,-1.csv
+Kenwood/Tuner/184,1.csv
+Kenwood/Unknown_RC-160/184,-1.csv
+Kenwood/Unknown_RC-A0400/184,-1.csv
+Kenwood/Unknown_RC-D0705.conf/182,12.csv
+Kenwood/Unknown_RC-M0301/182,4.csv
+Kenwood/Unknown_RC-M0701/182,4.csv
+Kenwood/Unknown_RC-P030/182,-1.csv
+Kenwood/Unknown_RC-P0400/182,-1.csv
+Kenwood/Unknown_RC-P070/182,-1.csv
+Kenwood/Unknown_RC-P0702/182,-1.csv
+Kenwood/Unknown_RC-P0715/182,-1.csv
+Kenwood/Unknown_RC-P2030/182,-1.csv
+Kenwood/Unknown_RC-P600/182,-1.csv
+Kenwood/Unknown_rc-p800/182,-1.csv
+Kenwood/Unknown_rc-p87/182,-1.csv
+Kenwood/Unknown_RC-R0311E/44,44.csv
+Kenwood/Unknown_RC-RO503/184,-1.csv
+Kenwood/VCR/184,-1.csv
+Kenwood/VCR/184,1.csv
+KEY DIGITAL/Component Switcher/130,19.csv
+KEY DIGITAL/Matrix Switcher/130,19.csv
+KEY DIGITAL/Matrix Switcher/132,-1.csv
+KEY DIGITAL/Matrix Switcher/27,-1.csv
+KEY DIGITAL/Switcher/130,19.csv
+KEY DIGITAL/Video Switcher/130,19.csv
+KEY DIGITAL/Video Switcher/132,-1.csv
+KEY DIGITAL/Video Switcher/27,-1.csv
+Khl/Unknown_REC-R3000/65,-1.csv
+Kinergetics Research/Pre-Amplifier/28,-1.csv
+Kinergetics Research/Receiver/0,-1.csv
+Kinergetics Research/Surround Processor/7,-1.csv
+Kiss/Unknown_DP-1500s/25,-1.csv
+Klipsch/Subwoofer/17,81.csv
+Knoll/Video Projector/24,233.csv
+konig/Unknown_konig/128,99.csv
+Konka/Unknown_KK-Y199/25,1.csv
+Konka/Unknown_KK-Y250A/25,1.csv
+kosmos/Unknown_kosmos/8,-1.csv
+Krell/CD Player/16,-1.csv
+Krell/CD Player/20,-1.csv
+Krell/DVD Player/27,-1.csv
+Krell/Pre-Amplifier/16,-1.csv
+Krell/Pre-Amplifier/25,-1.csv
+Krell/Pre-Amplifier/28,-1.csv
+Krell/Receiver/28,-1.csv
+Krell/Receiver/31,-1.csv
+Krell/Surround Processor/16,-1.csv
+Krell/Surround Processor/25,-1.csv
+Krell/Surround Processor/28,-1.csv
+Krell/Surround Processor/31,-1.csv
+Kworld/Unknown_ATSC/0,251.csv
+Kworld/Unknown_DVB-T/134,107.csv
+Kworld/Unknown_KWorld-DVBT-220/0,251.csv
+Kworld/Unknown_KWorld-DVBT-PE310/0,251.csv
+Kworld/Unknown_VS-PRV-TV/134,107.csv
+Kyocera/CD Player/119,-1.csv
+Lacie/Unknown_Lacie/64,64.csv
+Lacie/Unknown_PNE-N1SS/0,127.csv
+Lasonic/Unknown_LasonicR2000/16,-1.csv
+Leadership/Unknown_GOTEC/0,-1.csv
+LeadTek/Unknown_PVR2000/None,None.csv
+LeadTek/Unknown_RM-0007/3,-1.csv
+LeadTek/Unknown_Y0400046/3,-1.csv
+LeadTek/Unknown_Y0400052/3,-1.csv
+LeadTek/Unknown_Y04G0004/3,-1.csv
+LEMON/Unknown_LEMON/7,-1.csv
+Lenovo/Unknown_Y530/4,69.csv
+Lexicon/DVD Player/4,-1.csv
+Lexicon/Receiver/130,11.csv
+Lexicon/Surround Processor/130,11.csv
+Lexicon/Surround Processor/133,2.csv
+Lexicon/Surround Processor/28,-1.csv
+LG/Blu-Ray/45,45.csv
+LG/DVD Player/16,16.csv
+LG/DVD Player/44,44.csv
+LG/DVD Player/45,45.csv
+LG/DVD_VCR Combo/45,45.csv
+LG/DVR/45,45.csv
+LG/HDTV Tuner/247,-1.csv
+LG/LCD_DVD/4,-1.csv
+LG/LCD_DVD/45,45.csv
+LG/Plasma/1,1.csv
+LG/Plasma/4,-1.csv
+LG/Satellite/247,-1.csv
+LG/Sound Bar/44,44.csv
+LG/TV/1,1.csv
+LG/TV/4,-1.csv
+LG/Unknown_42H3000/4,-1.csv
+LG/Unknown_6710CDAP01B/44,44.csv
+LG/Unknown_6710T00009B/4,-1.csv
+LG/Unknown_6710V00067G/0,-1.csv
+LG/Unknown_6710V00070A/0,-1.csv
+LG/Unknown_6710V00090D/0,-1.csv
+LG/Unknown_6710V00090N/4,-1.csv
+LG/Unknown_6710V00091N/4,-1.csv
+LG/Unknown_6710V00133A/4,-1.csv
+LG/Unknown_AKB69680403/4,-1.csv
+LG/Unknown_AKB72915207/4,-1.csv
+LG/Unknown_AKB73715601/4,-1.csv
+LG/Unknown_BC205P/110,-1.csv
+LG/Unknown_BD300/45,45.csv
+LG/Unknown_CC470TW/110,-1.csv
+LG/Unknown_LG/110,-1.csv
+LG/Unknown_LG.6710V00005G/110,-1.csv
+LG/Unknown_LG.6710V00008K/4,-1.csv
+LG/Unknown_LG-AKB69680403/4,-1.csv
+LG/Unknown_LG-EV230/110,-1.csv
+LG/Unknown_MKJ40653807/4,-1.csv
+LG/Unknown_MKJ61842704/4,-1.csv
+LG/Unknown_PBAFA0189A/110,-1.csv
+Lifesat/Unknown_28/128,38.csv
+Lifetec/Unknown_LT9096/128,123.csv
+Lifetec/Unknown_RC2000/5,-1.csv
+Lifetec/Unknown_remote/164,164.csv
+Life-view/Unknown_3000/96,1.csv
+Life-view/Unknown_flyvideo/96,1.csv
+Lightolier/Lighting Controller/0,-1.csv
+Linksys/Media Adapter/134,107.csv
+Linksys/Unknown_WMA11B-R/134,107.csv
+Linn/CD Player/20,-1.csv
+Linn/Classic music/16,-1.csv
+Linn/Classic music/17,-1.csv
+Linn/Classic music/20,-1.csv
+Linn/Surround Processor/16,-1.csv
+Linn/Surround Processor/23,-1.csv
+Linn/Surround Processor/4,-1.csv
+LiteOn/DVD Recorder/10,247.csv
+LiteTouch/Lighting Controller/129,-1.csv
+LiteTouch/Lighting Controller/130,-1.csv
+LiteTouch/Lighting Controller/131,-1.csv
+LiteTouch/Lighting Controller/132,-1.csv
+LiteTouch/Lighting Controller/133,-1.csv
+LiteTouch/Lighting Controller/134,-1.csv
+LiteTouch/Lighting Controller/135,-1.csv
+LiteTouch/Lighting Controller/136,-1.csv
+LiteTouch/Lighting Controller/137,-1.csv
+LiteTouch/Lighting Controller/144,-1.csv
+LiteTouch/Lighting Controller/145,-1.csv
+LiteTouch/Lighting Controller/146,-1.csv
+LiteTouch/Lighting Controller/147,-1.csv
+LiteTouch/Lighting Controller/148,-1.csv
+LiteTouch/Lighting Controller/149,-1.csv
+LiteTouch/Lighting Controller/150,-1.csv
+LiteTouch/Lighting Controller/151,-1.csv
+LiteTouch/Lighting Controller/152,-1.csv
+LiteTouch/Lighting Controller/153,-1.csv
+LiteTouch/Lighting Controller/255,-1.csv
+Loewe/DVD Player/0,-1.csv
+Loewe/DVD Player/32,-1.csv
+Loewe/DVD Player/33,-1.csv
+Loewe/DVD Player/4,-1.csv
+Loewe/DVD Player/45,45.csv
+Loewe/TV/0,-1.csv
+Loewe/TV/27,-1.csv
+Loewe/TV/31,-1.csv
+Loewe/TV/33,-1.csv
+Loewe/TV/5,-1.csv
+Loewe/TV/6,-1.csv
+Loewe/Unknown_150/255,255.csv
+Loewe/Unknown_8500H/110,-1.csv
+Loewe/Unknown_control/0,-1.csv
+Loewe/VCR/144,0.csv
+Loewe/VCR/144,1.csv
+Loewe/VCR/5,-1.csv
+Logitech/Unknown_HarmonyOne/30,-1.csv
+Logitech/Unknown_z5500/8,-1.csv
+Lpi/Unknown_PCremote/71,-1.csv
+LP Morgan/Screen/0,-1.csv
+L+S/Unknown_30755/5,-1.csv
+L+S/Unknown_LS/164,164.csv
+Lumagen/Scaler/2,-1.csv
+Luxman/CD Player/204,-1.csv
+Luxman/Receiver/204,-1.csv
+Luxor/Unknown_DV405/67,71.csv
+LXI/TV/4,-1.csv
+M3 Electronic/Unknown_DVD-209/0,-1.csv
+Macro Image Technology/Unknown_MyHD/48,-1.csv
+Madrigal/CD Player/0,-1.csv
+Madrigal/CD Player/2,-1.csv
+Madrigal/CD Player/7,-1.csv
+Madrigal/Receiver/5,-1.csv
+MAGIC LIGHTING/Lighting/0,-1.csv
+MAGNASONIC/Unknown_TV/131,122.csv
+Magnavox/DSS/128,63.csv
+Magnavox/DVD Player/1,-1.csv
+Magnavox/DVD Player/135,34.csv
+Magnavox/DVD Player/4,-1.csv
+Magnavox/DVD Recorder/135,34.csv
+Magnavox/TV/0,-1.csv
+Magnavox/Unknown_UNIFIED6TRANS/0,-1.csv
+Magnavox/VCR/5,-1.csv
+Magnum Dynalab/Tuner/7,-1.csv
+Magnum/Unknown_5520VT/1,-1.csv
+Majestic/Unknown_DVX377USB/0,-1.csv
+Makita/Drapery Controller/2,-1.csv
+Malata/DVD Player/1,-1.csv
+Manhattan/Unknown_DVD/29,-1.csv
+Manta/Unknown_DVD-002/0,-1.csv
+Manta/Unknown_DVD-007/0,-1.csv
+Marantz/AM-FM Tuner/16,-1.csv
+Marantz/AM-FM Tuner/17,-1.csv
+Marantz/Amplifier/16,-1.csv
+Marantz/Amplifier/17,-1.csv
+Marantz/Amplifier/18,-1.csv
+Marantz/Amplifier/20,-1.csv
+Marantz/Amplifier/21,-1.csv
+Marantz/Amplifier/23,-1.csv
+Marantz/Amplifier/26,-1.csv
+Marantz/Cassette Tape/18,-1.csv
+Marantz/Cassette Tape/23,-1.csv
+Marantz/CD Changer/20,-1.csv
+Marantz/CD Jukebox/20,-1.csv
+Marantz/CD Player/20,-1.csv
+Marantz/DVD/4,-1.csv
+Marantz/DVD/69,-1.csv
+Marantz/DVD Player/20,-1.csv
+Marantz/DVD Player/41,-1.csv
+Marantz/DVD Player/4,-1.csv
+Marantz/DVD Player/69,-1.csv
+Marantz/D-VHS/3,-1.csv
+Marantz/D-VHS/67,-1.csv
+Marantz/iPod Dock/14,-1.csv
+Marantz/iPod Dock/16,-1.csv
+Marantz/MP3 Player/14,-1.csv
+Marantz/MP3 Player/16,-1.csv
+Marantz/Plasma/0,-1.csv
+Marantz/Plasma/24,-1.csv
+Marantz/Plasma/24,247.csv
+Marantz/Plasma/24,24.csv
+Marantz/Plasma/80,-1.csv
+Marantz/Plasma Displays/24,-1.csv
+Marantz/Plasma Displays/24,24.csv
+Marantz/Pre-Amplifier/0,-1.csv
+Marantz/Pre-Amplifier/11,-1.csv
+Marantz/Pre-Amplifier/17,-1.csv
+Marantz/Pre-Amplifier/23,-1.csv
+Marantz/Projector/0,-1.csv
+Marantz/Receiver/0,-1.csv
+Marantz/Receiver/12,-1.csv
+Marantz/Receiver/16,-1.csv
+Marantz/Receiver/17,-1.csv
+Marantz/Receiver/176,-1.csv
+Marantz/Receiver/18,-1.csv
+Marantz/Receiver/20,-1.csv
+Marantz/Receiver/21,-1.csv
+Marantz/Receiver/23,-1.csv
+Marantz/Receiver/26,-1.csv
+Marantz/Receiver/39,-1.csv
+Marantz/Receiver/4,-1.csv
+Marantz/Receiver/5,-1.csv
+Marantz/Receiver/6,-1.csv
+Marantz/Receiver/7,-1.csv
+Marantz/Receiver/8,-1.csv
+Marantz/Tuner/16,-1.csv
+Marantz/Tuner/17,-1.csv
+Marantz/Tuner/20,-1.csv
+Marantz/Tuner Section/17,-1.csv
+Marantz/TV/0,-1.csv
+Marantz/TV/144,0.csv
+Marantz/TV/24,-1.csv
+Marantz/TV/24,247.csv
+Marantz/TV/24,24.csv
+Marantz/TV/80,-1.csv
+Marantz/Unknown_Marantz-RC-63CD/20,-1.csv
+Marantz/Unknown_RC-1400/4,-1.csv
+Marantz/Unknown_RC1400-MD/255,255.csv
+Marantz/Unknown_RC4000CD/20,-1.csv
+Marantz/Unknown_rc/4,-1.csv
+Marantz/Unknown_RC4300CC/20,-1.csv
+Marantz/Unknown_RC-65CD/20,-1.csv
+Marantz/Unknown_RC-72CD/20,-1.csv
+Marantz/VCR/134,97.csv
+Marantz/VCR/23,-1.csv
+Marantz/VCR/5,-1.csv
+Marantz/Video Projector/0,-1.csv
+Marantz/Video Projector/13,-1.csv
+Mark Levinson/CD Player/1,-1.csv
+Mark Levinson/CD Player/16,-1.csv
+Mark Levinson/CD Player/2,-1.csv
+Mark Levinson/CD Player/3,-1.csv
+Mark Levinson/Pre-Amplifier/4,-1.csv
+Mark Levinson/Pre-Amplifier/7,-1.csv
+Mark/Unknown_rc5/0,-1.csv
+Mas/Unknown_HSD-303/0,-1.csv
+Mas/Unknown_HSD-400/0,-1.csv
+Mas/Unknown_RC-0135/6,-1.csv
+Maxx/Plasma/32,64.csv
+Maxx/Plasma/96,-1.csv
+McIntosh/CD Player/202,149.csv
+McIntosh/Control System/202,85.csv
+McIntosh/DVD Player/128,80.csv
+McIntosh/Laser Disc/168,-1.csv
+McIntosh/Pre-Amplifier/202,85.csv
+McIntosh/Receiver/202,85.csv
+MCL/Unknown_RemoteController/64,-1.csv
+media-tech/Unknown_RUMBA/128,-1.csv
+Medion/Unknown_JX-2006B/0,-1.csv
+Medion/Unknown_MD-5410/5,-1.csv
+Medion/Unknown_MD81035/23,105.csv
+Medion/Unknown_MD81880/23,105.csv
+Medion/Unknown_medion/128,123.csv
+Medion/Unknown_rc2000/5,-1.csv
+MEGATRON/Unknown_MEGATRON/255,255.csv
+Melectronic/Unknown_PP3600/2,-1.csv
+Meliconi/Unknown_Facile/0,-1.csv
+Meliconi/Unknown_MeliconiSpeedy2/5,-1.csv
+Meliconi/Unknown_MELICONI-U3/10,-1.csv
+Meliconi/Unknown_Speedy/7,7.csv
+Memorex/DVD Player/0,-1.csv
+Memorex/TV/4,-1.csv
+Meridian/800 System Remote/19,-1.csv
+Meridian/CD Player/19,-1.csv
+Meridian/CD-R/19,-1.csv
+Meridian/DVD/19,-1.csv
+Meridian/DVD Player/19,-1.csv
+Meridian/DVD Player/69,-1.csv
+Meridian/Pre-Amplifier/19,-1.csv
+Meridian/Pre-Amplifier/26,73.csv
+Meridian/Processor/19,-1.csv
+Meridian/Remote Control/19,-1.csv
+Meridian/Surround Processor/19,-1.csv
+Meridian/System Remote/19,-1.csv
+METRONIC/Unknown_060501/0,127.csv
+METRONIC/Unknown_SAT/134,-1.csv
+Metronome/CD Player/20,-1.csv
+MGA/VCR/87,-1.csv
+Micromega/DVD Player/4,-1.csv
+Microsoft/DVD Player/5,-1.csv
+Microsoft/Game Console/116,15.csv
+Microsoft/Game Console/4,15.csv
+Microsoft/Game Console/5,-1.csv
+Microsoft/Home Media PC/4,15.csv
+Microsoft/Unknown_MCE/5,-1.csv
+Microsoft/Unknown_xbox/10,-1.csv
+Microsoft/Unknown_Xbox360/116,15.csv
+Microsoft/Unknown_XboxDVDDongle/None,None.csv
+Microsoft/Windows Media Center/4,15.csv
+Midiland/Digital Decoder/81,175.csv
+Minolta/Unknown_RC3/52,202.csv
+Mintek/DVD Player/0,153.csv
+MIRO/Unknown_MIRO/134,107.csv
+MISSION/CD Player/20,-1.csv
+Mitochiba/Unknown_JX-9902/134,107.csv
+Mitochiba/Unknown_KF220100/134,107.csv
+Mitsubishi/Cable Box/0,-1.csv
+Mitsubishi/Cassette Tape/119,-1.csv
+Mitsubishi/Cassette Tape/138,-1.csv
+Mitsubishi/Cassette Tape/141,-1.csv
+Mitsubishi/CD Player/119,-1.csv
+Mitsubishi/CD Player Laser Disc/168,-1.csv
+Mitsubishi/DSS/12,251.csv
+Mitsubishi/DSS/64,-1.csv
+Mitsubishi/DSS/71,-1.csv
+Mitsubishi/DVD/103,-1.csv
+Mitsubishi/DVD Player/103,-1.csv
+Mitsubishi/DVD Player/71,-1.csv
+Mitsubishi/DVD Player/87,-1.csv
+Mitsubishi/HDTV Receiver/12,251.csv
+Mitsubishi/HDTV Receiver/71,-1.csv
+Mitsubishi/Laser Disc/168,-1.csv
+Mitsubishi/Laser Disc/175,-1.csv
+Mitsubishi/Monitor/119,-1.csv
+Mitsubishi/Monitor/1,-1.csv
+Mitsubishi/Monitor/130,100.csv
+Mitsubishi/Monitor/2,-1.csv
+Mitsubishi/Monitor/4,-1.csv
+Mitsubishi/Monitor/71,-1.csv
+Mitsubishi/Monitor/87,-1.csv
+Mitsubishi/Receiver/119,-1.csv
+Mitsubishi/Receiver/168,-1.csv
+Mitsubishi/Receiver/71,-1.csv
+Mitsubishi/Receiver/87,-1.csv
+Mitsubishi/Satellite/12,251.csv
+Mitsubishi/TV/119,-1.csv
+Mitsubishi/TV/1,-1.csv
+Mitsubishi/TV/71,-1.csv
+Mitsubishi/TV/87,-1.csv
+Mitsubishi/Unknown/119,-1.csv
+Mitsubishi/Unknown/71,-1.csv
+Mitsubishi/Unknown_75501/87,-1.csv
+Mitsubishi/Unknown/87,-1.csv
+Mitsubishi/Unknown_HD1000/240,-1.csv
+Mitsubishi/Unknown_HS-349/87,-1.csv
+Mitsubishi/Unknown_mitsubishi/71,-1.csv
+Mitsubishi/Unknown_tv/71,-1.csv
+Mitsubishi/VCR/119,-1.csv
+Mitsubishi/VCR/23,-1.csv
+Mitsubishi/VCR/3,-1.csv
+Mitsubishi/VCR/71,-1.csv
+Mitsubishi/VCR/7,-1.csv
+Mitsubishi/VCR/87,-1.csv
+Mitsubishi/Video Projector/71,-1.csv
+mivar/Unknown_mivar/7,-1.csv
+Monoprice/Unknown_HDX(C)-501E/0,-1.csv
+Morgans Daytona/Unknown_T15/128,38.csv
+Morgans Daytona/Unknown_Tornado/202,165.csv
+Motorola/Cable Box/0,-1.csv
+Motorola/Cable Box/1,-1.csv
+Motorola/Cable Box/15,-1.csv
+Motorola/Cable Box/170,-1.csv
+Motorola/Cable Box/18,0.csv
+Motorola/Cable Box/3,-1.csv
+Motorola/Cable Box/4,-1.csv
+Motorola/Cable Box/5,-1.csv
+Motorola/Cable Box/5,1.csv
+Motorola/Cable Box/64,-1.csv
+Motorola/Cable Box/68,-1.csv
+Motorola/Cable Box/9,-1.csv
+Motorola/Cox/0,-1.csv
+Motorola/Cox/64,-1.csv
+Motorola/DSS/1,-1.csv
+Motorola/DVR/0,-1.csv
+Motorola/IP box/16,0.csv
+Motorola/Remote/0,-1.csv
+Motorola/Remote/3,-1.csv
+Motorola/Unknown_4dtv/0,-1.csv
+Motorola/Unknown_Cable/0,-1.csv
+Motorola/Unknown_DCH3416/0,-1.csv
+Motorola/Unknown_DCT2000/0,-1.csv
+Motorola/Unknown_DCT2244/0,-1.csv
+Motorola/Unknown_DCT2524/0,-1.csv
+Motorola/Unknown_DRC800/0,-1.csv
+Motorola/Unknown_DTH320-4/134,47.csv
+Motorola/Unknown_DTH355/134,47.csv
+Motorola/Unknown_DVi2030/0,-1.csv
+Motorola/Unknown_MOTOROLA/0,-1.csv
+Motorola/Unknown_QIP2500/0,-1.csv
+Motorola/Unknown_RC1445302-00B-REV2/0,-1.csv
+Motorola/Unknown_VIP/35,64.csv
+MSI/Unknown_lircd.conf/134,107.csv
+MSI/Unknown_MegaPC/134,107.csv
+MSI/Unknown_PC/134,107.csv
+MSI/Unknown_test/134,107.csv
+mStation/Unknown_mStation/64,175.csv
+MS-Tech/Unknown_HTPC/0,95.csv
+MS-Tech/Unknown_MS-Tech/0,95.csv
+Multi Canal/Unknown_Canal/133,123.csv
+Multichoice/Unknown_DSD910/24,-1.csv
+multiTEC/Unknown_multiTEC/7,-1.csv
+Mustek/Unknown_DVD/16,237.csv
+Mustek/Unknown_MustekDVD/16,237.csv
+Mustek/Unknown_RMC-V300/16,237.csv
+Mvision/Unknown_FCIS7000E+/64,64.csv
+Myryad/Pre-Amplifier/0,-1.csv
+Myryad/Pre-Amplifier/16,-1.csv
+Myryad/Pre-Amplifier/17,-1.csv
+Myryad/Pre-Amplifier/18,-1.csv
+Myryad/Pre-Amplifier/20,-1.csv
+Myryad/Pre-Amplifier/21,-1.csv
+Myryad/Pre-Amplifier/23,-1.csv
+Myryad/Receiver/0,-1.csv
+Myryad/Receiver/16,-1.csv
+Myryad/Receiver/17,-1.csv
+Myryad/Receiver/18,-1.csv
+Myryad/Receiver/20,-1.csv
+Myryad/Receiver/21,-1.csv
+Myryad/Receiver/23,-1.csv
+NAD/Amplifier/135,124.csv
+NAD/Cassette Tape/135,124.csv
+NAD/CD Player/133,111.csv
+NAD/CD Player/135,124.csv
+NAD/CD Player/42,-1.csv
+NAD/Monitor/64,-1.csv
+NAD/Receiver/135,124.csv
+NAD/Receiver_CD/135,124.csv
+NAD/Surround Processor/135,124.csv
+NAD/Surround Processor/93,-1.csv
+NAD/Tuner/135,124.csv
+NAD/Unknown/135,124.csv
+NAD/Unknown_451/135,124.csv
+NAD/Unknown_NAD/17,-1.csv
+NAD/Unknown_RC512/135,124.csv
+NAD/Unknown_SR6/135,124.csv
+NAD/Unknown_SR712/135,124.csv
+Nagra/Unknown_TVA/8,-1.csv
+Nakamichi/Amplifier/87,-1.csv
+Nakamichi/CD Player/103,-1.csv
+Nakamichi/CD Player/92,-1.csv
+Nakamichi/DVD Player/92,162.csv
+Nakamichi/Receiver/103,-1.csv
+Nakamichi/Receiver/130,93.csv
+Nakamichi/Receiver/186,-1.csv
+Nakamichi/Receiver/92,161.csv
+Nakamichi/Receiver/92,-1.csv
+Nakamichi/Tuner/103,-1.csv
+Nakamichi/Tuner/92,-1.csv
+Nakamichi/Unknown_lirc.config/103,-1.csv
+Napa/Unknown_DAV-309/0,-1.csv
+Nebula Electronics/Unknown_DVB/0,-1.csv
+NEC/Monitor/25,-1.csv
+NEC/Monitor/4,-1.csv
+NEC/Receiver/25,-1.csv
+NEC/Receiver/26,197.csv
+NEC/Receiver/26,-1.csv
+NEC/Receiver/26,225.csv
+NEC/Receiver/26,228.csv
+NEC/Receiver/26,231.csv
+NEC/Receiver/4,-1.csv
+NEC/Surround Processor/13,-1.csv
+NEC/Surround Processor/26,228.csv
+NEC/TV/24,-1.csv
+NEC/TV/24,24.csv
+NEC/TV/4,-1.csv
+NEC/Unknown/25,-1.csv
+NEC/Unknown/25,231.csv
+NEC/Unknown_RB-34P/25,-1.csv
+NEC/Unknown_RB-73A/25,-1.csv
+NEC/Unknown_RB-D3A/25,-1.csv
+NEC/Unknown_RB-DV22/45,45.csv
+NEC/Unknown_RC-1065E/24,-1.csv
+NEC/Unknown_RC-1083E/24,-1.csv
+NEC/Unknown_RC-334E/24,233.csv
+NEC/Unknown_RC-6010/24,247.csv
+NEC/Unknown_RD-1077E/24,-1.csv
+NEC/Unknown_RD-1078E/24,-1.csv
+NEC/Unknown_RD-1083E/24,-1.csv
+NEC/Unknown_RD-337E/2,-1.csv
+NEC/Unknown_RD-343E/24,233.csv
+NEC/Unknown_RD-348E/24,233.csv
+NEC/Unknown_RD-409E/24,233.csv
+NEC/Unknown_RD-427E/24,233.csv
+NEC/Unknown_RU-1220S/24,247.csv
+NEC/Unknown_TRB-60/49,-1.csv
+NEC/Unknown_TRB-968A/25,-1.csv
+NEC/Unknown_UR-3020/24,247.csv
+NEC/VCR/10,-1.csv
+NEC/VCR/25,-1.csv
+NEC/VCR/4,-1.csv
+NEC/Video Projector/24,233.csv
+NEC/Video Projector/24,247.csv
+Netgem/Unknown_iPlayer/131,51.csv
+NET TV/TV/2,-1.csv
+Nextwave/Unknown_EX300/4,16.csv
+Nikko/Unknown_Nikko/5,-1.csv
+Niles Audio/Unknown/128,93.csv
+Niles Audio/Unknown/132,18.csv
+No Brand/Unknown_YK-001/0,-1.csv
+Nokia/Satellite/24,-1.csv
+Nokia/Satellite/6,-1.csv
+Nokia/Unknown_624/74,-1.csv
+Nokia/Unknown_MM9780S/14,0.csv
+Nokia/Unknown_Nokia/14,0.csv
+Nokia/Unknown_NokiaVC620/3,-1.csv
+Nokia/Unknown_RCN610/74,-1.csv
+Nokia/Unknown_VCN620/3,-1.csv
+Nokia/Unknown_VCR/137,119.csv
+Norcent/Unknown_DP/0,-1.csv
+NorthQ/Unknown_6400/8,-1.csv
+Novaplex/Cable Box/27,-1.csv
+Now Broadband TV/Unknown_Broadband/128,110.csv
+Now Broadband TV/Unknown_Broadband/64,64.csv
+NTL/Unknown_DI4001N/10,-1.csv
+NVIDIA/Unknown_Personal/128,126.csv
+oceanic/Unknown_oceanic/1,-1.csv
+Olevia/Unknown_RC-LTFN/4,-1.csv
+Olevia/Unknown_RC-LTL/4,185.csv
+Olympus/Unknown_RM-1/134,59.csv
+Olympus/Unknown_RM-2/134,59.csv
+One For All/Unknown_7720/0,-1.csv
+One For All/Unknown_control-Philips-0081d/0,-1.csv
+One For All/Unknown_For/0,-1.csv
+One For All/Unknown_For/8,-1.csv
+One For All/Unknown_ofa-urc-7550-vcr0150/5,-1.csv
+One For All/Unknown_One-For-All/0,-1.csv
+One For All/Unknown_Phillips/5,-1.csv
+One For All/Unknown_SAT/32,8.csv
+One For All/Unknown_URC-2510(12341)/71,-1.csv
+One For All/Unknown_URC-3021B00-VCR-0081/5,-1.csv
+One For All/Unknown_URC-3440/5,-1.csv
+One For All/Unknown_URC-5550/11,-1.csv
+One For All/Unknown_URC-6012w/2,-1.csv
+One For All/Unknown_URC-7020/5,-1.csv
+One For All/Unknown_URC-7240/5,-1.csv
+One For All/Unknown_URC-7530/7,-1.csv
+One For All/Unknown_URC-7555/0,-1.csv
+One For All/Unknown_urc7562/0,-1.csv
+One For All/Unknown_URC-7562/68,-1.csv
+One For All/Unknown_URC-7710/0,-1.csv
+One For All/Unknown_urc7730/0,-1.csv
+One For All/Unknown_URC-8204.1300/32,8.csv
+One For All/Unknown_URC-8910/7,-1.csv
+One For All/Unknown_VCR/113,-1.csv
+Onida/Unknown_DFX/0,-1.csv
+Onida/Unknown_TVE/3,-1.csv
+Onkyo/Amplifier/210,108.csv
+Onkyo/Amplifier/210,109.csv
+Onkyo/Cassette Tape/132,89.csv
+Onkyo/Cassette Tape/210,13.csv
+Onkyo/CD Player/132,117.csv
+Onkyo/CD Player/210,109.csv
+Onkyo/CD Player/210,13.csv
+Onkyo/CD Player/210,44.csv
+Onkyo/DVD Player/210,43.csv
+Onkyo/DVD Player/69,-1.csv
+Onkyo Integra/DVD Changer/210,43.csv
+Onkyo Integra/Receiver/210,108.csv
+Onkyo Integra/Receiver/210,109.csv
+Onkyo/Laser Disc/168,-1.csv
+Onkyo/Receiver/210,108.csv
+Onkyo/Receiver/210,109.csv
+Onkyo/Tuner/210,109.csv
+Onkyo/Tuner/210,37.csv
+Onkyo/Unknown/210,109.csv
+Onkyo/Unknown/210,44.csv
+Onkyo/Unknown_CR-70R/210,109.csv
+Onkyo/Unknown_lircd.conf/210,31.csv
+Onkyo/Unknown_Onkyo/160,10.csv
+Onkyo/Unknown_Onkyo/210,109.csv
+Onkyo/Unknown_Onkyo/210,44.csv
+Onkyo/Unknown_RC-104C/210,-1.csv
+Onkyo/Unknown_RC-146T/210,13.csv
+Onkyo/Unknown_RC-184s/210,109.csv
+Onkyo/Unknown_rc-211s/210,109.csv
+Onkyo/Unknown_rc-252s/210,109.csv
+Onkyo/Unknown_RC-425DV/210,43.csv
+Onkyo/Unknown_RC-50/210,-1.csv
+Onkyo/Unknown_RC-682M/210,43.csv
+Optex/Unknown_ORT/0,-1.csv
+orion/Unknown_orion/128,123.csv
+orion/Unknown_orion-RC57/128,126.csv
+orion/Unknown_RC-CB/128,88.csv
+orion/Unknown_TV-713/0,-1.csv
+OSRAM/Unknown_OSRAM/1,0.csv
+Pace/Unknown_DC551P/27,-1.csv
+Pace/Unknown_DI4001N/10,-1.csv
+Pace/Unknown_DI4010I/10,-1.csv
+Pace/Unknown_Digital/0,0.csv
+Pace/Unknown_DS420/16,80.csv
+Pace/Unknown_DS620/132,60.csv
+Pace/Unknown_pace900/8,-1.csv
+Pace/Unknown_PaceMSS/1,-1.csv
+Pace/Unknown_PACE-RC-10/132,60.csv
+Pace/Unknown_pacetwin/34,-1.csv
+Pace/Unknown_RC-17/132,60.csv
+Pace/Unknown_RC-30/132,60.csv
+Pace/Unknown_TDS460NNZ/35,128.csv
+Pace/Unknown_xsat/34,-1.csv
+Packard Bell/Unknown_PackBell/16,-1.csv
+Palcom/Unknown_DSL-6/192,-1.csv
+palmbutler/Unknown_palmbutler/7,-1.csv
+Panasonic/DVD Player/128,0.csv
+Panasonic/DVD Player/160,0.csv
+Panasonic/DVD Player/160,16.csv
+Panasonic/DVD Player/160,18.csv
+Panasonic/DVD Player/160,28.csv
+Panasonic/DVD Player/160,34.csv
+Panasonic/DVD Player/160,4.csv
+Panasonic/DVD Player/176,0.csv
+Panasonic/HDTV Tuner/128,2.csv
+Panasonic/Laser Disc/144,64.csv
+Panasonic/Receiver/160,0.csv
+Panasonic/Receiver/160,28.csv
+Panasonic/Receiver/160,4.csv
+Panasonic/TV/128,0.csv
+Panasonic/TV/128,1.csv
+Panasonic/TV/128,4.csv
+Panasonic/TV/128,9.csv
+Panasonic/Unknown_AMP/2,32.csv
+Panasonic/Unknown_CARC60EX/129,106.csv
+Panasonic/Unknown_cd/160,194.csv
+Panasonic/Unknown_DSS/2,32.csv
+Panasonic/Unknown_DVD/2,32.csv
+Panasonic/Unknown_EUR57510/144,0.csv
+Panasonic/Unknown_EUR642162/160,194.csv
+Panasonic/Unknown_EUR642195/160,194.csv
+Panasonic/Unknown_EUR643820/160,194.csv
+Panasonic/Unknown_EUR643826/160,194.csv
+Panasonic/Unknown_EUR7617010/176,0.csv
+Panasonic/Unknown_EUR7621010/176,0.csv
+Panasonic/Unknown_EUR7631010/176,0.csv
+Panasonic/Unknown_EUR7914Z20/128,72.csv
+Panasonic/Unknown_N2QADC000006/128,72.csv
+Panasonic/Unknown_N2QAHB0048/160,194.csv
+Panasonic/Unknown_N2QAYB000064/128,72.csv
+Panasonic/Unknown_NV-F65/144,0.csv
+Panasonic/Unknown_panas928/160,194.csv
+Panasonic/Unknown_PANASONIC/0,-1.csv
+Panasonic/Unknown_PANASONIC/176,0.csv
+Panasonic/Unknown_panasonic.conf/144,0.csv
+Panasonic/Unknown_Panasonic-EUR571100/144,0.csv
+Panasonic/Unknown_Panasonic-RAK-RX314W/160,194.csv
+Panasonic/Unknown_panasonic-RAX-RX318W/160,194.csv
+Panasonic/Unknown_RAK-RX309W/160,194.csv
+Panasonic/Unknown_RC4346-01B/0,-1.csv
+Panasonic/Unknown_RX-ED70/160,194.csv
+Panasonic/Unknown_TV/0,-1.csv
+Panasonic/Unknown_VCR/144,1.csv
+Panasonic/Unknown_VCR/2,32.csv
+Panasonic/Unknown_VEQ0910/144,0.csv
+Panasonic/Unknown_VEQ1309/144,0.csv
+Panasonic/Unknown_VEQ1697/112,8.csv
+Panasonic/Unknown_veq2249/176,0.csv
+Panasonic/Unknown_VEQ2380/176,0.csv
+Panasonic/Unknown_vi/2,32.csv
+Panasonic/Unknown_VSQS0531/2,-1.csv
+Panasonic/VCR/144,0.csv
+Panasonic/VCR/144,1.csv
+Panasonic/VCR/144,5.csv
+Panasonic/VCR/2,-1.csv
+Panda/Unknown_DVD-6838/0,-1.csv
+Pansat/Unknown_2500a/0,249.csv
+Pansat/Unknown_2700/8,-1.csv
+Pansat/Unknown_2700a/8,-1.csv
+Parasound/Receiver/134,97.csv
+Parasound/Receiver/27,-1.csv
+Parasound/Receiver/3,240.csv
+Parasound/Surround Processor/3,240.csv
+Peekton/Unknown_IR6005/0,-1.csv
+PHAST/PLR-IR1/85,-1.csv
+Philco/Unknown_PCR-111/80,-1.csv
+Philips/CD-R/20,-1.csv
+Philips/CD-R/26,-1.csv
+Philips/Digital Recorder/133,48.csv
+Philips/DSS/133,48.csv
+Philips/DSS/39,-1.csv
+Philips/DVD Player/4,-1.csv
+Philips/Receiver/0,-1.csv
+Philips/Receiver/16,-1.csv
+Philips/Receiver/17,-1.csv
+Philips/Receiver/20,-1.csv
+Philips/Receiver/5,-1.csv
+Philips/TV/0,-1.csv
+Philips/TV/3,-1.csv
+Philips/Unknown_01/0,-1.csv
+Philips/Unknown_01/48,-1.csv
+Philips/Unknown_101/5,-1.csv
+Philips/Unknown_130A/138,245.csv
+Philips/Unknown_17PT1563/0,-1.csv
+Philips/Unknown_26PFL5604H/0,-1.csv
+Philips/Unknown_32PFL5403D/0,-1.csv
+Philips/Unknown_5260/0,-1.csv
+Philips/Unknown_5300/0,-1.csv
+Philips/Unknown_5373/5,-1.csv
+Philips/Unknown_8243/10,-1.csv
+Philips/Unknown_95/5,-1.csv
+Philips/Unknown_AV5609/5,-1.csv
+Philips/Unknown_CD/20,-1.csv
+Philips/Unknown_CD720/20,-1.csv
+Philips/Unknown_CD723/20,-1.csv
+Philips/Unknown_digital/0,-1.csv
+Philips/Unknown_DSX-5500/39,-1.csv
+Philips/Unknown_DVD711/4,-1.csv
+Philips/Unknown_dvd712/4,-1.csv
+Philips/Unknown_DVD-724/4,-1.csv
+Philips/Unknown_DVP-5982/4,-1.csv
+Philips/Unknown_DVP-642/4,-1.csv
+Philips/Unknown_FW2104/134,83.csv
+Philips/Unknown_LV2/20,-1.csv
+Philips/Unknown_MULTI/0,-1.csv
+Philips/Unknown_MULTI/5,-1.csv
+Philips/Unknown_MULTI/6,-1.csv
+Philips/Unknown_PHDVD5/26,154.csv
+Philips/Unknown_PHILIPS/0,-1.csv
+Philips/Unknown_PHILIPS/34,-1.csv
+Philips/Unknown_Philips-PMDVD6T-Universal-AUX/64,47.csv
+Philips/Unknown_philips-rc2592-MODE-v1/8,-1.csv
+Philips/Unknown_PM725S/27,-1.csv
+Philips/Unknown_R-48F01/20,-1.csv
+Philips/Unknown_RC/0,-1.csv
+Philips/Unknown_RC19042002/0,-1.csv
+Philips/Unknown_RC19237006/4,-1.csv
+Philips/Unknown_RC19335003-01P/0,-1.csv
+Philips/Unknown_RC-2012/4,-1.csv
+Philips/Unknown_RC/20,-1.csv
+Philips/Unknown_RC2034302/0,-1.csv
+Philips/Unknown_RC2070/0,-1.csv
+Philips/Unknown_RC2582/39,-1.csv
+Philips/Unknown_RC-5/0,-1.csv
+Philips/Unknown_RC-5/5,-1.csv
+Philips/Unknown_RC5-BP6/0,-1.csv
+Philips/Unknown_RC7507/5,-1.csv
+Philips/Unknown_RC-7843/0,-1.csv
+Philips/Unknown_RC7843/0,-1.csv
+Philips/Unknown_RC7925/26,-1.csv
+Philips/Unknown_RC8244/10,-1.csv
+Philips/Unknown_RC8861/1,-1.csv
+Philips/Unknown_RCLE011/0,-1.csv
+Philips/Unknown_rd5860.conf/20,-1.csv
+Philips/Unknown_RD6834/20,-1.csv
+Philips/Unknown_RT150/5,-1.csv
+Philips/Unknown_RU120/0,-1.csv
+Philips/Unknown_SBC/0,-1.csv
+Philips/Unknown_SBC/6,-1.csv
+Philips/Unknown_SBC-RU-520/5,-1.csv
+Philips/Unknown_SF172/39,-1.csv
+Philips/Unknown_SRM5100/4,15.csv
+Philips/Unknown_SRU/0,-1.csv
+Philips/Unknown_STEREO/164,164.csv
+Philips/Unknown_TIVO/133,48.csv
+Philips/Unknown_TIVO34/133,48.csv
+Philips/Unknown_TV/0,-1.csv
+Philips/Unknown_uDigital/0,-1.csv
+Philips/Unknown_VCR/5,-1.csv
+Philips/Unknown_VR175/5,-1.csv
+Philips/VCR/5,-1.csv
+Phonotrend/Unknown_Prestige/4,-1.csv
+Pinnacle Systems/Unknown_300i/17,20.csv
+Pinnacle Systems/Unknown_800i/7,-1.csv
+Pinnacle Systems/Unknown_PCTV/7,-1.csv
+Pinnacle Systems/Unknown_RC-42D/7,-1.csv
+Pioneer/Amplifier/162,-1.csv
+Pioneer/Amplifier/164,-1.csv
+Pioneer/Amplifier/165,-1.csv
+Pioneer/Cable Box/168,40.csv
+Pioneer/Cable Box/170,-1.csv
+Pioneer/Cable Box/172,-1.csv
+Pioneer/Cassette Tape/161,-1.csv
+Pioneer/CD Jukebox/162,-1.csv
+Pioneer/CD Player/162,-1.csv
+Pioneer/DVD Changer/163,-1.csv
+Pioneer/DVD Changer/175,-1.csv
+Pioneer/DVD Jukebox/163,-1.csv
+Pioneer/DVD Jukebox/175,-1.csv
+Pioneer/DVD Player/163,-1.csv
+Pioneer/DVD Player/175,-1.csv
+Pioneer/Laser Disc/163,-1.csv
+Pioneer/Laser Disc/168,-1.csv
+Pioneer/Laser Disc/175,-1.csv
+Pioneer/Receiver/164,-1.csv
+Pioneer/Receiver/165,-1.csv
+Pioneer/TV/170,-1.csv
+Pioneer/TV/175,-1.csv
+Pioneer/Unknown_AXD-1531/170,-1.csv
+Pioneer/Unknown_AXD-7306/166,-1.csv
+Pioneer/Unknown_CD/162,-1.csv
+Pioneer/Unknown_CU-CLD067/168,-1.csv
+Pioneer/Unknown_CU-CLD106/168,-1.csv
+Pioneer/Unknown_CU-PD008/162,-1.csv
+Pioneer/Unknown_CU-PD038/162,-1.csv
+Pioneer/Unknown_CU-PD046/162,-1.csv
+Pioneer/Unknown_CU-PD069/162,-1.csv
+Pioneer/Unknown_CU-PD085/162,-1.csv
+Pioneer/Unknown_CU-PD089/162,-1.csv
+Pioneer/Unknown_cu-pd096/162,-1.csv
+Pioneer/Unknown_CU-XC004/255,255.csv
+Pioneer/Unknown_DEH-D8850/0,-1.csv
+Pioneer/Unknown_PD-M650/162,-1.csv
+Pioneer/Unknown_pioneer/162,-1.csv
+Pioneer/Unknown_pioneer/168,-1.csv
+Pioneer/Unknown_Pioneer-CU-XR014/2,1.csv
+Pioneer/Unknown_VXX2801/163,-1.csv
+PixelView/Unknown_2000/63,-1.csv
+PixelView/Unknown_PlayTV/134,107.csv
+PLU2/Unknown_DVX-345pro/0,-1.csv
+Polaroid/Unknown_DVDP-1000/32,-1.csv
+Pragmatic/Router/172,-1.csv
+Proceed/Surround Processor/5,-1.csv
+ProPlay/Unknown_PS2/0,246.csv
+Proscan/DVD Player/15,-1.csv
+Proscan/DVD Player/5,-1.csv
+Proscan/TV/15,-1.csv
+Proscan/Unknown_proscan-vcr/14,-1.csv
+Protek/Unknown_Protek/1,-1.csv
+Proton/TV/17,-1.csv
+Proton/TV/2,-1.csv
+Proton/TV/3,-1.csv
+Proton/TV/4,-1.csv
+Provideo/Unknown_PV951/134,107.csv
+Provision/Unknown_PR-DVD2.0/1,-1.csv
+Provision/Unknown_PRDVD2166/0,153.csv
+PS Audio/CD Player/20,-1.csv
+QUADRAL/Unknown_RC-804/19,1.csv
+Quasar/TV/128,0.csv
+Radio Shack/Unknown_Radioshack2115/5,-1.csv
+Radio Shack/Unknown_RadioShack/3,1.csv
+Radio Shack/Unknown_RS2142/5,-1.csv
+Radix/Unknown_Alpha/138,245.csv
+Radix/Unknown_DTR-9000-Twin/0,127.csv
+Radix/Unknown_DT-X1/0,127.csv
+Radix/Unknown_lircd.conf/0,127.csv
+Radix/Unknown_radix/138,245.csv
+Radix/Unknown_SAT/138,245.csv
+Raite/Unknown_RaiteDVD-7xx/32,-1.csv
+Ranex/Unknown_RGB/64,-1.csv
+RCA/DSS/15,-1.csv
+RCA/DSS/7,-1.csv
+RCA/DVD Player/5,-1.csv
+RCA/Laser Disc/13,-1.csv
+RCA/TV/14,-1.csv
+RCA/TV/15,-1.csv
+RCA/TV/7,-1.csv
+RCA/Unknown_BR-RCA/39,-1.csv
+RCA/Unknown_DTA800b/7,-1.csv
+RCA/Unknown_R130A1/15,-1.csv
+RCA/Unknown_RCA-F20507CP/15,-1.csv
+RCA/Unknown_RCZ/135,94.csv
+RCA/Unknown_TV/15,-1.csv
+RCA/VCR/14,-1.csv
+RCA/VCR/15,-1.csv
+Recor/Unknown_IRC-1304/7,-1.csv
+Rega/Receiver/110,-1.csv
+Rega/Receiver/135,124.csv
+Rega/Receiver/16,-1.csv
+remotec/Unknown_MEDIAMASTER/None,None.csv
+remotec/Unknown_remotec/0,-1.csv
+remotec/Unknown_remotec1072/5,-1.csv
+remotec/Unknown_rm200/1,-1.csv
+remotec/Unknown_TV/0,-1.csv
+Replay Networks/Digital Recorder/1,0.csv
+ReplayTV/Unknown_5000/1,0.csv
+Revo/Unknown_Blik/0,-1.csv
+Revoy/Unknown_Revoy2200/0,153.csv
+Re.x/Unknown_SDVD/0,-1.csv
+Rio/Unknown_Audio/130,19.csv
+roadstar/Unknown_dvd/136,-1.csv
+Roku/Unknown_N1000-04/190,239.csv
+Roku/Unknown_Netflix/190,239.csv
+Roku/Unknown_Soundbridge/111,-1.csv
+Rolsen/Unknown_DK5A/1,-1.csv
+Rolsen/Unknown_K10B-C1/14,14.csv
+Rotel/CD Player/20,-1.csv
+Rotel/Tuner/82,0.csv
+Rotel/Unknown_RR-925/131,18.csv
+Rowa/Unknown_RDVD104/0,-1.csv
+RSQ/Karaoke/179,-1.csv
+RSQ/Karaoke/191,-1.csv
+RSQ/Karaoke/3,-1.csv
+rubin/Unknown_rubin/0,-1.csv
+Runco/Controller_DLP/1,-1.csv
+Runco/Line Doubler/4,-1.csv
+Runco/Video Controller/1,-1.csv
+Runco/Video Projector/1,-1.csv
+Runco/Video Projector/24,247.csv
+Runco/Video Projector/5,1.csv
+Russound/Music Server/10,-1.csv
+SABA/Unknown_SabaTC460/7,-1.csv
+SABA/Unknown_TC3003/7,-1.csv
+SAB/Unknown_Explorer/1,-1.csv
+Sagem/Unknown_DVB-T-Receiver/135,94.csv
+Sagem/Unknown_HD103-C/135,94.csv
+Sagem/Unknown_Sagem/135,94.csv
+Salora/Unknown_SV6700/49,-1.csv
+Samsung/Air Conditioner/1,8.csv
+Samsung/Rear Projection DLP TV/7,7.csv
+Samsung/TV/7,7.csv
+Samsung/Unknown_00011k/102,0.csv
+Samsung/Unknown_00021c/5,5.csv
+Samsung/Unknown_00054d/102,0.csv
+Samsung/Unknown_00056A/102,0.csv
+Samsung/Unknown_00077A/7,7.csv
+Samsung/Unknown_00092b/102,0.csv
+Samsung/Unknown_00092M/102,0.csv
+Samsung/Unknown_00104J/7,7.csv
+Samsung/Unknown_00104K/7,7.csv
+Samsung/Unknown_00198f/7,7.csv
+Samsung/Unknown_00225A/7,7.csv
+Samsung/Unknown_01043A/102,0.csv
+Samsung/Unknown_10107N/0,-1.csv
+Samsung/Unknown_10116A/0,-1.csv
+Samsung/Unknown_10420A/5,5.csv
+Samsung/Unknown_528Z/2,-1.csv
+Samsung/Unknown_AA59-00316b/7,7.csv
+Samsung/Unknown_AA59-00332D/7,7.csv
+Samsung/Unknown_AA59-00370A/7,7.csv
+Samsung/Unknown_AA59-00382A/7,7.csv
+Samsung/Unknown_AA59-00600A/7,7.csv
+Samsung/Unknown_AA59-10026E/5,5.csv
+Samsung/Unknown_AA64-50236A/7,7.csv
+Samsung/Unknown_AH59-00043E/67,83.csv
+Samsung/Unknown_AH59-01527F/67,83.csv
+Samsung/Unknown_AH59-02345A/7,7.csv
+Samsung/Unknown_ARH-700/1,8.csv
+Samsung/Unknown_BN59-00507A/7,7.csv
+Samsung/Unknown_BN59-00538A/7,7.csv
+Samsung/Unknown_BN59-00603A/7,7.csv
+Samsung/Unknown_BN59-00609A/7,7.csv
+Samsung/Unknown_BN59-00634A/9,9.csv
+Samsung/Unknown_BN59-00678A/7,7.csv
+Samsung/Unknown_BN59-00683A/7,7.csv
+Samsung/Unknown_BN59-00685A/7,7.csv
+Samsung/Unknown_BN59-00856A/7,7.csv
+Samsung/Unknown_BN59-00861A/7,7.csv
+Samsung/Unknown_BN59-00865A/7,7.csv
+Samsung/Unknown_BN59-00869A/7,7.csv
+Samsung/Unknown_BN59-00940A/7,7.csv
+Samsung/Unknown_BRM-E1E/33,33.csv
+Samsung/Unknown_hifi/0,1.csv
+Samsung/Unknown_HLN507W/7,7.csv
+Samsung/Unknown_MF59-00242B/9,9.csv
+Samsung/Unknown_MF59-00291a/32,0.csv
+Samsung/Unknown_MF59/0,-1.csv
+Samsung/Unknown_PR3914/5,5.csv
+Samsung/Unknown_RCD-M70/0,4.csv
+Samsung/Unknown_samsung-10095T/7,7.csv
+Samsung/Unknown_SAMSUNG/102,0.csv
+Samsung/Unknown_SAMSUNG/5,5.csv
+Samsung/Unknown_SAMSUNG/7,7.csv
+Samsung/Unknown_SAT/21,-1.csv
+Samsung/Unknown_SFT-702E/64,-1.csv
+Samsung/Unknown_SMT-1000T/64,64.csv
+Samsung/Unknown_SMT-H3050/27,-1.csv
+Samsung/Unknown_SV-411X/5,5.csv
+Samsung/Unknown_SV-610X/5,5.csv
+Samsung/Unknown_SV-651B/5,5.csv
+Samsung/Unknown_SV-DVD3E/5,5.csv
+Samsung/Unknown_test/0,-1.csv
+Samsung/Unknown_TV/7,7.csv
+Samsung/Unknown_VCR/5,5.csv
+Samsung/Unknown_VXK-336/5,5.csv
+Samsung/VCR/2,2.csv
+Samsung/VCR/5,5.csv
+Samy/Unknown_SDX1100/8,230.csv
+Sansonic/Unknown_FT-300A/0,-1.csv
+Sansui/Unknown_SANSUI-RS-S103/132,77.csv
+Sanyo/TV/56,-1.csv
+Sanyo/Unknown_A05800/49,-1.csv
+Sanyo/Unknown_B01004/49,-1.csv
+Sanyo/Unknown_B01007/49,-1.csv
+Sanyo/Unknown_B12628/49,-1.csv
+Sanyo/Unknown_B13540/49,-1.csv
+Sanyo/Unknown_RB-DA300/60,-1.csv
+Sanyo/Unknown_RB-SL22/60,196.csv
+Sanyo/Unknown_RC-105C/54,-1.csv
+Sanyo/Unknown_RC700/56,-1.csv
+Sanyo/Unknown_Sanyo/49,-1.csv
+Sanyo/Unknown_Sanyo/56,-1.csv
+Sanyo/Unknown_Sanyo-B13509/49,-1.csv
+Sanyo/Unknown_sanyoB13537/49,-1.csv
+Sanyo/Unknown_Sanyo-JXZB/56,-1.csv
+Sanyo/Unknown_sanyo-tv01/56,-1.csv
+Sanyo/Unknown_TV/56,-1.csv
+Sanyo/Unknown_VCR/49,-1.csv
+Sanyo/Video Projector/48,-1.csv
+Satelco/Sat/24,-1.csv
+Schneider/Unknown_FB2000/5,-1.csv
+Schneider/Unknown_RC-193/154,-1.csv
+Schneider/Unknown_RC202/11,11.csv
+Schneider/Unknown_RC901/28,-1.csv
+Schneider/Unknown_RC902/0,-1.csv
+Schwaiger/Unknown_DSR/0,-1.csv
+Scientific Atlanta/Cable Box/27,-1.csv
+Scientific Atlanta/Cable Box/71,-1.csv
+Scientific Atlanta/Unknown_Atlanta-1840/27,-1.csv
+Scientific Atlanta/Unknown_IV/27,-1.csv
+Scientific Atlanta/Unknown_RM9834/27,-1.csv
+Scientific Atlanta/Unknown_SAE8000/27,-1.csv
+Scott/Unknown_DVD-838/8,-1.csv
+Scott/Unknown_scott-dvd/4,-1.csv
+SEG/Unknown_E6900-X020A/2,-1.csv
+SEG/Unknown_SEG-DVD-430/32,-1.csv
+SEG/Unknown_SEG-VCR4300/21,-1.csv
+SEG/Unknown_SR-040/133,115.csv
+SEG/Unknown_SR-201/66,253.csv
+SEG/Unknown_SR800/4,-1.csv
+SEG/Unknown_VCR2000/134,124.csv
+SEG/Unknown_VCR/21,-1.csv
+Seleco/TV/0,-1.csv
+Seleco/TV/30,-1.csv
+Sencor/Unknown_SFN9011SL/0,252.csv
+Sgi/Unknown_SGIMON/26,9.csv
+SHANNON/Unknown_SHANNON/None,None.csv
+Sharp/DTV Decoder/1,-1.csv
+Sharp/Monitor/1,-1.csv
+Sharpsat/Unknown_T28/128,38.csv
+Sharp/TV/1,-1.csv
+Sharp/Unknown_CV-2131CK1/1,-1.csv
+Sharp/Unknown_G0048TA/19,-1.csv
+Sharp/Unknown_G0412GE/3,-1.csv
+Sharp/Unknown_G0938CESA/1,-1.csv
+Sharp/Unknown_G1014BMSA/1,-1.csv
+Sharp/Unknown_G1044BMSA/1,-1.csv
+Sharp/Unknown_GJ210/0,189.csv
+Sharp/Unknown_RRMCGA030WJSA/8,48.csv
+Sharp/Unknown_SHARP/1,-1.csv
+Sharp/Unknown_sharp1781/1,-1.csv
+Sharp/VCR/3,-1.csv
+Sharp/Video Projector/13,-1.csv
+Sherwood/Receiver/131,69.csv
+Sherwood/Unknown_CD/255,255.csv
+Sherwood/Unknown_GC-1285/129,114.csv
+Sherwood/Unknown_GC-1285/255,255.csv
+Sherwood/Unknown_RM-101/69,131.csv
+Sherwood/Unknown_RM-636/131,68.csv
+Sherwood/Unknown_RM-RV-N25/131,68.csv
+Sherwood/Unknown_sherwood/129,122.csv
+Sherwood/Unknown_sherwood/131,69.csv
+Sherwood/Unknown_Sherwood-S2770R-CP-II/129,123.csv
+Shinco/Unknown_RC-1730/0,153.csv
+Shuttle/Unknown_mceusb/4,15.csv
+Siemens/Unknown_fb405/134,84.csv
+Siemens/Unknown_siemens1/49,-1.csv
+Siemens/Unknown_siemens-fb400/131,89.csv
+Sigma Designs/DVD Player/128,-1.csv
+Sigma Designs/Unknown_SIR/128,-1.csv
+Sigmatek/Unknown_X100/8,-1.csv
+Sigmatek/Unknown_XMB-510-PRO/8,-1.csv
+Silvercrest/Unknown_RCH7S52/32,-1.csv
+Silvercrest/Unknown_URC-801/4,15.csv
+Sirius/Unknown_SBKB-3201KR/128,-1.csv
+Sirius/Unknown_Sportster/1,-1.csv
+Sirius/Unknown_ST2/0,-1.csv
+Sitronics/Unknown_RC-D010E/0,251.csv
+Skymaster/Unknown_2421/2,-1.csv
+Skymaster/Unknown_2424/37,250.csv
+Skymaster/Unknown_DCI/5,-1.csv
+Skymaster/Unknown_skymaster/19,1.csv
+Skymaster/Unknown_SkymasterXLS99/19,1.csv
+Skymaster/Unknown_XL10/6,-1.csv
+Sky/Unknown_DVB-S/0,12.csv
+Sky/Unknown_rev.4/0,0.csv
+Slim Art/Unknown_SA-100/0,-1.csv
+Slim Devices/Unknown_Devices/110,-1.csv
+SnapStream/Unknown_Firefly-Mini/0,-1.csv
+Snazio/Unknown_Net/8,230.csv
+Snell/Speaker/80,0.csv
+Sonance/Distributed Audio/0,90.csv
+Sonance/System Controller/132,132.csv
+Sonicview/Unknown_SV-360/15,-1.csv
+Sony/Boombox/100,-1.csv
+Sony/Boombox/68,-1.csv
+Sony/Cassette Tape/14,-1.csv
+Sony/Cassette Tape/16,-1.csv
+Sony/CD Changer/17,-1.csv
+Sony/CD Jukebox/1,-1.csv
+Sony/CD Jukebox/17,-1.csv
+Sony/CD Jukebox/23,-1.csv
+Sony/CD Jukebox/26,153.csv
+Sony/CD Jukebox/36,-1.csv
+Sony/CD Jukebox/57,-1.csv
+Sony/CD Jukebox/81,-1.csv
+Sony/CD Player/1,-1.csv
+Sony/CD Player/17,-1.csv
+Sony/CD Player/57,-1.csv
+Sony/CD Player/81,-1.csv
+Sony/DAT/28,-1.csv
+Sony/Digital Recorder/1,-1.csv
+Sony/Digital Recorder/26,154.csv
+Sony/Digital Recorder/26,73.csv
+Sony/Digital Recorder/26,98.csv
+Sony/DSP/26,233.csv
+Sony/DSS/11,-1.csv
+Sony/DSS/1,-1.csv
+Sony/DSS/183,-1.csv
+Sony/DSS/23,133.csv
+Sony/DSS/3,-1.csv
+Sony/DSS/5,1.csv
+Sony/DSS/64,-1.csv
+Sony/DV Cam/185,-1.csv
+Sony/DV Cam/217,-1.csv
+Sony/DV Cam/7,-1.csv
+Sony/DVD Player/1,-1.csv
+Sony/DVD Player/164,-1.csv
+Sony/DVD Player/26,218.csv
+Sony/DVD Player/26,73.csv
+Sony/DVD Player/26,83.csv
+Sony/DVD Player/26,98.csv
+Sony/DVD Player/4,-1.csv
+Sony/Laser Disc/6,-1.csv
+Sony/Mini-Disc/15,-1.csv
+Sony/Mini-Disc/17,-1.csv
+Sony/Pre-Amplifier/11,-1.csv
+Sony/Pre-Amplifier/12,-1.csv
+Sony/Pre-Amplifier/144,-1.csv
+Sony/Pre-Amplifier/15,-1.csv
+Sony/Pre-Amplifier/16,-1.csv
+Sony/Pre-Amplifier/17,-1.csv
+Sony/Pre-Amplifier/18,-1.csv
+Sony/Pre-Amplifier/183,-1.csv
+Sony/Pre-Amplifier/20,-1.csv
+Sony/Pre-Amplifier/2,-1.csv
+Sony/Pre-Amplifier/23,-1.csv
+Sony/Pre-Amplifier/26,66.csv
+Sony/Pre-Amplifier/26,73.csv
+Sony/Pre-Amplifier/36,-1.csv
+Sony/Pre-Amplifier/6,-1.csv
+Sony/Pre-Amplifier/7,-1.csv
+Sony/Receiver/11,-1.csv
+Sony/Receiver/1,-1.csv
+Sony/Receiver/121,-1.csv
+Sony/Receiver/12,-1.csv
+Sony/Receiver/13,-1.csv
+Sony/Receiver/144,-1.csv
+Sony/Receiver/15,-1.csv
+Sony/Receiver/16,-1.csv
+Sony/Receiver/17,-1.csv
+Sony/Receiver/176,-1.csv
+Sony/Receiver/18,-1.csv
+Sony/Receiver/20,-1.csv
+Sony/Receiver/2,-1.csv
+Sony/Receiver/23,-1.csv
+Sony/Receiver/26,66.csv
+Sony/Receiver/26,73.csv
+Sony/Receiver/36,-1.csv
+Sony/Receiver/4,-1.csv
+Sony/Receiver/48,-1.csv
+Sony/Receiver/6,-1.csv
+Sony/Receiver/7,-1.csv
+Sony/Receiver/8,-1.csv
+Sony/Surround Processor/26,233.csv
+Sony/TiVo/183,-1.csv
+Sony/TiVo/23,133.csv
+Sony/TiVo/26,154.csv
+Sony/TV/119,-1.csv
+Sony/TV/1,-1.csv
+Sony/TV/151,-1.csv
+Sony/TV/164,-1.csv
+Sony/TV/183,-1.csv
+Sony/TV/26,42.csv
+Sony/TV/3,-1.csv
+Sony/TV/84,-1.csv
+Sony/Unknown_870/1,-1.csv
+Sony/Unknown_CD/17,-1.csv
+Sony/Unknown_CDIR/17,-1.csv
+Sony/Unknown_CDP-790/17,-1.csv
+Sony/Unknown_D1000/89,-1.csv
+Sony/Unknown_DAT/28,-1.csv
+Sony/Unknown_DVD/26,18.csv
+Sony/Unknown_DVD/26,73.csv
+Sony/Unknown_lircd.conf/17,-1.csv
+Sony/Unknown_RM-687C/1,-1.csv
+Sony/Unknown_RM-860/1,-1.csv
+Sony/Unknown_RM-861/1,-1.csv
+Sony/Unknown_RM-873/1,-1.csv
+Sony/Unknown_rm-d10p/26,97.csv
+Sony/Unknown_RM-D190/17,-1.csv
+Sony/Unknown_RM-D270/17,-1.csv
+Sony/Unknown_RM-D295/17,-1.csv
+Sony/Unknown_rm-d29m/15,-1.csv
+Sony/Unknown_RM-D302/17,-1.csv
+Sony/Unknown_RM-D320/17,-1.csv
+Sony/Unknown_RM-D325/17,-1.csv
+Sony/Unknown_RM-D391/17,-1.csv
+Sony/Unknown_rm-d5/17,-1.csv
+Sony/Unknown_RM-D520/17,-1.csv
+Sony/Unknown_RM-D55/17,-1.csv
+Sony/Unknown_RM-D690/17,-1.csv
+Sony/Unknown_RM-D706/17,-1.csv
+Sony/Unknown_RM-D797/17,-1.csv
+Sony/Unknown_RM-D7M/15,-1.csv
+Sony/Unknown_RM-D820/17,-1.csv
+Sony/Unknown_RM-D90/17,-1.csv
+Sony/Unknown_RM-D921/17,-1.csv
+Sony/Unknown_RM-D991/17,-1.csv
+Sony/Unknown_RM-DM7/17,-1.csv
+Sony/Unknown_rm-dm9/223,-1.csv
+Sony/Unknown_RM-DX740/17,-1.csv
+Sony/Unknown_RM-ED019/26,73.csv
+Sony/Unknown_RM-PJP1/26,42.csv
+Sony/Unknown_RM-SG20/131,0.csv
+Sony/Unknown_RM-SG5/131,0.csv
+Sony/Unknown_RM-SG7/131,0.csv
+Sony/Unknown_RMT-136/2,-1.csv
+Sony/Unknown_RMT-506/7,-1.csv
+Sony/Unknown_RMT-B101A/26,226.csv
+Sony/Unknown_RMT-CF1A/26,19.csv
+Sony/Unknown_RMT-CS33R/255,255.csv
+Sony/Unknown_RMT-D115P/26,73.csv
+Sony/Unknown_RMT-D126A/26,73.csv
+Sony/Unknown_RMT-D126E/26,73.csv
+Sony/Unknown_RMT-D129A/26,73.csv
+Sony/Unknown_RMT-DSC2/26,241.csv
+Sony/Unknown_RMT-V107/11,-1.csv
+Sony/Unknown_RMT-V108-VTR/255,255.csv
+Sony/Unknown_RMT-V270/11,-1.csv
+Sony/Unknown_RMT-V501A/26,83.csv
+Sony/Unknown_RM-U302/255,255.csv
+Sony/Unknown_rm-v10t/1,-1.csv
+Sony/Unknown_RM-V211T/2,-1.csv
+Sony/Unknown_RM-W101/1,-1.csv
+Sony/Unknown_RM-X30/132,-1.csv
+Sony/Unknown_RM-X40/132,-1.csv
+Sony/Unknown_RM-X42/132,-1.csv
+Sony/Unknown_RM-X47/132,-1.csv
+Sony/Unknown_rm-x95/132,-1.csv
+Sony/Unknown_RM-Y155B/1,-1.csv
+Sony/Unknown_RM-Y173/1,-1.csv
+Sony/Unknown_RM-Y180/1,-1.csv
+Sony/Unknown_RM-Y800/183,-1.csv
+Sony/Unknown_RM-Y812/183,-1.csv
+Sony/Unknown_SCPH-10150.irman/255,255.csv
+Sony/Unknown_SONY/1,-1.csv
+Sony/Unknown_SONY/17,-1.csv
+Sony/Unknown_sony-cd/17,-1.csv
+Sony/Unknown_sonyRM-sep303/4,-1.csv
+Sony/Unknown_sonytv/1,-1.csv
+Sony/Unknown_TUNER/13,-1.csv
+Sony/Unknown_tv/1,-1.csv
+Sony/Unknown_tv/2,-1.csv
+Sony/Unknown_VaioRemote/4,15.csv
+Sony/Unknown_VPL-W400/84,-1.csv
+Sony/VCR/0,-1.csv
+Sony/VCR/11,-1.csv
+Sony/VCR/1,-1.csv
+Sony/VCR/180,-1.csv
+Sony/VCR/185,-1.csv
+Sony/VCR/186,-1.csv
+Sony/VCR/2,-1.csv
+Sony/VCR/25,37.csv
+Sony/VCR/25,69.csv
+Sony/VCR/5,-1.csv
+Sony/VCR/7,-1.csv
+Sony/VCR/9,-1.csv
+Sony/Video Projector/26,42.csv
+Sony/Video Projector/84,-1.csv
+Speed-link/Unknown_SL-6399/0,-1.csv
+starhub/Unknown_starhub/33,144.csv
+Starsat/Unknown_120/64,64.csv
+Starview/Unknown_Starview/0,249.csv
+Streamzap/Unknown_PC/35,-1.csv
+Strong/8821_DVB-T/2,2.csv
+STRONG/Unknown_STRONG/128,119.csv
+ST/Unknown_DTTRC-4/1,-1.csv
+ST/Unknown_HMP/8,-1.csv
+Sumvision/Unknown_Sumvision/0,-1.csv
+Sunfire/Surround Processor/184,0.csv
+Sunfire/Surround Processor/184,1.csv
+Sunfire/Surround Processor/184,3.csv
+Sungale/Unknown_JX-2002/0,-1.csv
+sun/Unknown_sun/26,9.csv
+Supermax/Unknown_Supermax/128,38.csv
+SUPERSQNY/Unknown_KM-168/0,-1.csv
 Supportplus/Unknown_SP-URC-LCD-F15/10,-1.csv
+SVEN/Unknown_HT-475/24,-1.csv
+SVEN/Unknown_IHOO/24,-1.csv
+Syabas/Unknown_A-100/4,203.csv
+Symphonic/TV/41,-1.csv
+Symphonic/VCR/40,-1.csv
+Symphonic/VCR/44,-1.csv
+Tab Electronics/Unknown_Kit/0,-1.csv
+TCM/Unknown_212845-CD/5,-1.csv
+TCM/Unknown_218681/5,5.csv
+TCM/Unknown_225925/24,233.csv
+TCM/Unknown_225926/35,-1.csv
+TCM/Unknown_96518/0,-1.csv
+TCM/Unknown_TCM/176,0.csv
+TCUAG/Unknown_TVBOX/6,-1.csv
+TEAC/DVD Player/163,-1.csv
+TEAC/DVD Player/175,-1.csv
+TEAC/Unknown_CD/134,97.csv
+TEAC/Unknown_DMP/255,255.csv
+TEAC/Unknown_RC-547/3,1.csv
+TEAC/Unknown_RC-548/128,114.csv
+TEAC/Unknown_RC-558/130,120.csv
+TEAC/Unknown_RC-614/0,-1.csv
+TEAC/Unknown_RC-909/34,1.csv
+TECHNICS/Unknown_cd/160,10.csv
+TECHNICS/Unknown_EUR643880/160,10.csv
+TECHNICS/Unknown_EUR64798/160,10.csv
+TECHNICS/Unknown_EUR64799/160,10.csv
+TECHNICS/Unknown_EURXP300/160,10.csv
+TECHNICS/Unknown_sl-ps670a/160,10.csv
+TECHNISAT/Unknown_100TS035/10,-1.csv
+TECHNISAT/Unknown_FBPNA35/10,-1.csv
+TECHNISAT/Unknown_FBPVR335A/10,-1.csv
+TECHNISAT/Unknown_ST3002S/1,-1.csv
+TECHNISAT/Unknown_ST3004S/1,-1.csv
+TECHNISAT/Unknown_st-6000e/131,121.csv
+TECHNISAT/Unknown_TECHNISAT/1,-1.csv
+TECHNISAT/Unknown_TTS35AI/10,-1.csv
+TECHNISAT/Unknown_TTS35AI.conf/10,-1.csv
+Technosonic/Unknown_DVD-204/16,237.csv
+Technotrend/Unknown_DVB/21,-1.csv
+Technotrend/Unknown_Micro/21,-1.csv
+Technotrend/Unknown_remote/21,-1.csv
+Technotrend/Unknown_S2400/21,-1.csv
+Technotrend/Unknown_Technotrend/21,-1.csv
+Tekram/Unknown_M230/None,None.csv
+TELEFUNKEN/AUDIO_IR3000/0,1.csv
+TELEFUNKEN/TV_1127/7,-1.csv
+TELEFUNKEN/TV_RC-1345/5,-1.csv
+TELEFUNKEN/VCR_FB1550/67,-1.csv
+TELEFUNKEN/VCR_RC1323-Video-B/8,-1.csv
+Teleka/Unknown_STR2060/1,-1.csv
+Telemann/PC HDTV Tuner Card/8,-1.csv
+Televes/Unknown_145075/8,-1.csv
+Televes/Unknown_711701/1,-1.csv
+Tensai/Unknown_5340fb/134,124.csv
+Terratec/Internet Radio/4,243.csv
+Terratec/Unknown_1400/4,235.csv
+Terratec/Unknown_Cinergy/134,107.csv
+Terratec/Unknown_Cinergy/20,-1.csv
+Terratec/Unknown_Cinergy/4,235.csv
+Terratec/Unknown_home/1,-1.csv
+Terratec/Unknown_M3PO/10,-1.csv
+Tesla/Unknown_32LCD70WDGHD/1,-1.csv
+Tesla/Unknown_Tesla/11,11.csv
+Tesla/Unknown_Tesla/5,-1.csv
+TeVii/Unknown_S650/0,255.csv
+Tevion/Unknown_3830/1,-1.csv
+Tevion/Unknown_41666/131,69.csv
+Tevion/Unknown_DFA/0,-1.csv
+Tevion/Unknown_DVD/67,71.csv
+Tevion/Unknown_MD/23,105.csv
+Tevion/Unknown_MD/48,-1.csv
+Tevion/Unknown_MD-5410/5,-1.csv
+Tevion/Unknown_MDC-982PLL/162,162.csv
+Tevion/Unknown_RS20536/67,71.csv
+Tevion/Unknown_SAT928/5,-1.csv
+Tevion/Unknown_TDR-250HD/0,159.csv
+Tevion/Unknown_TDR51DV/0,159.csv
+Tevion/Unknown_TE-0603/64,63.csv
+Tevion/Unknown_TEV1020/0,-1.csv
+Tevion/Unknown_TevionMd3607/7,-1.csv
+Tevion/Unknown_Tevion-MD80383/5,5.csv
+Tevion/Unknown_Tevion-MD81035-ASAT-Code-0905/23,105.csv
+Theta Digital/DVD Player/163,-1.csv
+Theta Digital/DVD Player/175,-1.csv
+Theta Digital/Surround Processor/16,-1.csv
+Thinkgeek/Unknown_Lightbulb/64,-1.csv
+Thompson/Unknown_THOMPSON/133,48.csv
+Thomson/Unknown_230/0,-1.csv
+Thomson/Unknown_RCS615TCLM1/5,-1.csv
+Thomson/Unknown_TM9258/128,255.csv
+Thomson/Unknown_TV/7,-1.csv
+Tivoli/Unknown_Sirius/0,-1.csv
+TiVo/PVR/26,154.csv
+TiVo/TiVo/133,48.csv
+TiVo/Unknown_Series1/133,48.csv
+Tokai/Unknown_DVD-715/32,-1.csv
+Topfield/Unknown_PVR/32,-1.csv
+Topfield/Unknown_TF4000Fi/4,255.csv
+Topfield/Unknown_TF4000PVR/32,-1.csv
+Topseed/Unknown_Topseed/4,15.csv
+Toshiba/DVD Player/69,-1.csv
+Toshiba/TV/64,-1.csv
+Toshiba/Unknown_CT-816/64,-1.csv
+Toshiba/Unknown_CT-826/64,-1.csv
+Toshiba/Unknown_CT-832/64,-1.csv
+Toshiba/Unknown_CT-859/64,-1.csv
+Toshiba/Unknown_CT-90038/231,10.csv
+Toshiba/Unknown_CT-90205/231,10.csv
+Toshiba/Unknown_CT-90298/64,-1.csv
+Toshiba/Unknown_CT-90326/64,-1.csv
+Toshiba/Unknown_CT-9573/64,-1.csv
+Toshiba/Unknown_CT-9784/64,-1.csv
+Toshiba/Unknown_CT-9881/134,107.csv
+Toshiba/Unknown_CT-9952/64,-1.csv
+Toshiba/Unknown_G83C0008A110/4,15.csv
+Toshiba/Unknown_RM-614Q/5,5.csv
+Toshiba/Unknown_SE-R0031/69,-1.csv
+Toshiba/Unknown_SE-R0049/69,-1.csv
+Toshiba/Unknown_SE-R0058/69,-1.csv
+Toshiba/Unknown_SE-R0127/69,-1.csv
+Toshiba/Unknown_SE-R0313/69,186.csv
+Toshiba/Unknown_TOSHIBA/64,-1.csv
+Toshiba/Unknown_TOSHIBA/68,-1.csv
+Toshiba/Unknown_toshiba-RM-A210/42,-1.csv
+Toshiba/Unknown_Toshiba-SE-R0047/69,-1.csv
+Toshiba/Unknown_Toshiba-SE-R0090/69,-1.csv
+Toshiba/Unknown_toshiba-tv/255,255.csv
+Toshiba/Unknown_TOSHTV/64,-1.csv
+Toshiba/Unknown_TSR-101R/66,187.csv
+Toshiba/Unknown_VC-642T/68,-1.csv
+Toshiba/Unknown_VC-90B/68,-1.csv
+Toshiba/Unknown_VT-11/68,-1.csv
+Toshiba/Unknown_VT-204G/68,-1.csv
+Toshiba/Unknown_VT-209W/68,-1.csv
+Toshiba/Unknown_VT-75F/68,-1.csv
+Toshiba/VCR/68,-1.csv
+Total Control/Unknown_Control/7,-1.csv
+Total Media In Hand/Unknown_Media/2,189.csv
+Traxis/Unknown_3500/4,-1.csv
+TRIAX/Unknown_DVB/10,-1.csv
+Trice/Unknown_TR-302/1,254.csv
+trio/Unknown_xms007/8,-1.csv
+Trust/Unknown_RC-2400/52,15.csv
+Trutech/Unknown_TV/0,1.csv
+Turtle Beach/MP3 Player/1,-1.csv
+Turtle Beach/MP3 Player/1,249.csv
+Turtlebeach/Unknown_Audiotron/1,249.csv
+Twinhan/Unknown_AD-SP200/0,-1.csv
+Twinhan/Unknown_DTV/0,-1.csv
+Twinhan/Unknown_MagicBox/None,None.csv
+Typhoon/Unknown_DTV/0,-1.csv
+Typhoon/Unknown_RC-0718-3/96,1.csv
+UEC/Unknown_DVB/24,-1.csv
+Ultrawave/Unknown_3500PFTA/2,2.csv
+Umax/Unknown_D-701/0,240.csv
+Uniden/Satellite/1,-1.csv
+United/Unknown_United-DVD4057M/0,-1.csv
+Universal/Unknown_001/4,15.csv
+Universal/Unknown_006/56,-1.csv
+Universal/Unknown_089/6,-1.csv
+Universal/Unknown_101/6,-1.csv
+Universal/Unknown_111/135,124.csv
+Universal/Unknown_cme/7,-1.csv
+Universal/Unknown_Knopex/7,-1.csv
+Universal/Unknown_lircd.conf/0,-1.csv
+Universal/Unknown_lircd.conf/128,123.csv
+Universal/Unknown_lt3607-aux599/135,124.csv
+Universal/Unknown_MC-10/5,-1.csv
+Universal/Unknown_Powerhouse/166,-1.csv
+Universal/Unknown_RC/0,-1.csv
+Universal/Unknown_RM-V211T/2,-1.csv
+Universal/Unknown_RZ-55/1,-1.csv
+Universal/Unknown_testrecord.config/0,-1.csv
+Universal/Unknown_tv/1,-1.csv
+Universal/Unknown_URC-6012w/2,-1.csv
+universum/SAT/97,135.csv
+universum/SAT_SR420/15,-1.csv
+universum/Unknown_universum/0,-1.csv
+universum/Unknown_universum/16,16.csv
+universum/VCR/128,123.csv
+universum/VCR_VR743A/5,-1.csv
+UPC/Unknown_SAT/39,-1.csv
+US Electronics/Cable Box/0,-1.csv
+Velodyne/Subwoofer/0,69.csv
+Venturer/Unknown_boombox/129,129.csv
+Venturer/Unknown_STB7766G1/66,187.csv
+Vestel/Unknown_TV/0,-1.csv
+Video7/Unknown_Video7-RC750/32,-1.csv
+videologic/Unknown_rm201/134,107.csv
+Vidikron/Video Projector/0,-1.csv
+Viewmaster/Unknown_RC-03/73,-1.csv
+viewmaxpro/Unknown_viewmaxpro/32,64.csv
+Viewsat/Unknown_SAT/32,255.csv
+Viewsat/Unknown_VS2000/32,255.csv
+ViewSonic/Unknown_98TR7BD-ONT-VSF/131,241.csv
+ViewSonic/Unknown_RC00070P/131,241.csv
+ViewSonic/Unknown_vsnv6/0,-1.csv
+Virgin-media/Unknown_VIRGINTIVO/10,-1.csv
+Visionetics/Unknown_Cable/134,107.csv
+Vistron/Unknown_DVD-5211/0,-1.csv
+Vistron/Unknown_LTM-3271E/8,-1.csv
+Vivanco/Unknown_DVD/26,73.csv
+Vivanco/Unknown_UR2/10,-1.csv
+Vivanco/Unknown_ur89/0,-1.csv
+Vizio/Unknown_Vizio/4,-1.csv
+Vizio/Unknown_VX37L/4,-1.csv
+VocoPro/Karaoke/32,1.csv
+Voxson/Unknown_PT2222-1/0,-1.csv
+WD/Unknown_HDTVMediaPlayerV1/132,121.csv
+WD/Unknown_TV/132,121.csv
+Westinghouse/Unknown_LVM-47W1/1,-1.csv
+Westinghouse/Unknown_RMT/1,-1.csv
+Wilfa/Unknown_RVC-17/64,175.csv
+X10/Unknown_MD1/None,None.csv
+Xantech/Programmer/6,-1.csv
+Xantech/Relay Module/6,-1.csv
+Xlogic/Unknown_XLOGIC-KF8000D/64,63.csv
+XMS/Unknown_XMS503/32,-1.csv
+XORO/Sat/0,191.csv
+XORO/Unknown_DVB/1,-1.csv
+xsat/Unknown_xsat/34,-1.csv
+Xtreamer/Unknown_Xtreamer/0,-1.csv
+Yakumo/Unknown_DVD/4,-1.csv
+Yamada/Unknown_DVX-6xxx/4,-1.csv
+Yamada/Unknown_PVD-500/0,-1.csv
+Yamaha/Amplifier/120,-1.csv
+Yamaha/Amplifier/122,-1.csv
+Yamaha/Amplifier/125,-1.csv
+Yamaha/AV Receiver/122,-1.csv
+Yamaha/AV Receiver/126,-1.csv
+Yamaha/AV Receiver/127,-1.csv
+Yamaha/AV Receiver/127,1.csv
+Yamaha/Blu-Ray/124,-1.csv
+Yamaha/Cassette Tape/122,-1.csv
+Yamaha/Cassette Tape/127,-1.csv
+Yamaha/CD Changer/121,-1.csv
+Yamaha/CD Changer/122,-1.csv
+Yamaha/CD Jukebox/121,-1.csv
+Yamaha/CD Jukebox/122,-1.csv
+Yamaha/CD Player/121,-1.csv
+Yamaha/CD Player/122,-1.csv
+Yamaha/CD-R/127,-1.csv
+Yamaha/DAT/128,55.csv
+Yamaha/DSP/120,-1.csv
+Yamaha/DSP/122,-1.csv
+Yamaha/DSP/4,-1.csv
+Yamaha/DSP/6,-1.csv
+Yamaha/DSP/80,-1.csv
+Yamaha/DSP/87,-1.csv
+Yamaha/DVD/124,-1.csv
+Yamaha/DVD/176,0.csv
+Yamaha/DVD/4,-1.csv
+Yamaha/DVD Changer/4,-1.csv
+Yamaha/DVD Player/124,-1.csv
+Yamaha/DVD Player/176,0.csv
+Yamaha/DVD Player/4,-1.csv
+Yamaha/DVD Pre-amp/120,-1.csv
+Yamaha/DVD Pre-amp/124,-1.csv
+Yamaha/DVD Receiver/120,-1.csv
+Yamaha/DVD Receiver/124,-1.csv
+Yamaha/DVR/120,-1.csv
+Yamaha/DVR/124,-1.csv
+Yamaha/DVR/71,-1.csv
+Yamaha/iPod Dock/127,1.csv
+Yamaha/Laser Disc/124,-1.csv
+Yamaha/Mini System/120,-1.csv
+Yamaha/Music Server/128,55.csv
+Yamaha/Plasma/80,-1.csv
+Yamaha/Projector/209,-1.csv
+Yamaha/Projector/240,-1.csv
+Yamaha/Receiver/0,0.csv
+Yamaha/Receiver/0,-1.csv
+Yamaha/Receiver/120,-1.csv
+Yamaha/Receiver/121,-1.csv
+Yamaha/Receiver/122,-1.csv
+Yamaha/Receiver/124,-1.csv
+Yamaha/Receiver/125,-1.csv
+Yamaha/Receiver/126,-1.csv
+Yamaha/Receiver/127,1.csv
+Yamaha/Receiver/15,-1.csv
+Yamaha/Receiver/209,-1.csv
+Yamaha/Receiver/4,-1.csv
+Yamaha/Receiver/6,-1.csv
+Yamaha/Receiver/8,-1.csv
+Yamaha/Sound Projector/120,-1.csv
+Yamaha/Sound Projector/126,-1.csv
+Yamaha/Stereo Receiver/125,-1.csv
+Yamaha/Stereo Receiver/126,-1.csv
+Yamaha/Tuner/122,-1.csv
+Yamaha/Tuner/209,-1.csv
+Yamaha/Unknown_av/122,-1.csv
+Yamaha/Unknown_cdx-493/121,-1.csv
+Yamaha/Unknown_DVD/69,-1.csv
+Yamaha/Unknown_DVD-RC/32,-1.csv
+Yamaha/Unknown_JVCDVD/239,-1.csv
+Yamaha/Unknown_RAV-12/122,-1.csv
+Yamaha/Unknown_RAV14/122,-1.csv
+Yamaha/Unknown_RAV16/122,-1.csv
+Yamaha/Unknown_RAV207/122,-1.csv
+Yamaha/Unknown_rax9/122,-1.csv
+Yamaha/Unknown_RCX/122,-1.csv
+Yamaha/Unknown_RCX2/122,-1.csv
+Yamaha/Unknown_RCX660/122,-1.csv
+Yamaha/Unknown_RCX-750/122,-1.csv
+Yamaha/Unknown_receiver/122,-1.csv
+Yamaha/Unknown_RS-CD5/121,-1.csv
+Yamaha/Unknown_RS-CX600/122,-1.csv
+Yamaha/Unknown_RS-K3/127,-1.csv
+Yamaha/Unknown_RX-450/122,-1.csv
+Yamaha/Unknown_RX-CX800/122,-1.csv
+Yamaha/Unknown_RX-V850/122,-1.csv
+Yamaha/Unknown_TX-1000/209,-1.csv
+Yamaha/Unknown_V499920/122,-1.csv
+Yamaha/Unknown_VI47320/209,-1.csv
+Yamaha/Unknown_VI77760/127,-1.csv
+Yamaha/Unknown_VJ59810/121,-1.csv
+Yamaha/Unknown_VJI5420/121,-1.csv
+Yamaha/Unknown_VK34080/121,-1.csv
+Yamaha/Unknown_VK38010/122,-1.csv
+Yamaha/Unknown_VM70300/122,-1.csv
+Yamaha/Unknown_VP59040/122,-1.csv
+Yamaha/Unknown_VQ95010/121,-1.csv
+Yamaha/Unknown_VR81350/123,-1.csv
+Yamaha/Unknown_vu50620/120,-1.csv
+Yamaha/Unknown_VU71330/121,-1.csv
+Yamaha/Unknown_YAMAHA/122,-1.csv
+Yamaha/Unknown_yamaha-amp/122,-1.csv
+Yamaha/Unknown_yamaha-rax7/122,-1.csv
+Yamaha/Unknown_Y-TV-1004/4,-1.csv
+Yamaha/Video Projector/209,-1.csv
+Yamakawa/DVD Player/32,-1.csv
+Yamakawa/Unknown_dvd285vga/32,-1.csv
+YES/Unknown_YES/132,60.csv
+Yuan/Unknown_SmartVDO/128,-1.csv
+Zalman/Unknown_HD160XT/115,154.csv
+Zehnder/Unknown_VCR/3,-1.csv
+Zenith/TV/5,1.csv
+Zenith/TV/7,0.csv
+Zenith/TV/7,1.csv
+Zenith/Unknown_AKB36157102/247,-1.csv
+Zenith/Unknown_C32V37/4,-1.csv
+Zenith/Unknown_TV/4,-1.csv
+Zenith/Unknown_VCR/2,-1.csv
+Zenith/Unknown_ZN5015/26,154.csv
+Zenith/VCR/7,0.csv
+Zenith/Video Projector/5,1.csv
+Zenith/Video Projector/6,0.csv
+Zinwell/Satellite Receiver/64,223.csv
+Zolid/Unknown_ZOL100/0,239.csv
+Zoltrix/Unknown_Zoltrix/0,252.csv
+Zyxel/Unknown_DMA-1000/8,230.csv

--- a/codes/index.sh
+++ b/codes/index.sh
@@ -1,1 +1,2 @@
-find . -name *.csv | sed -e 's|^\./||g' > index
+#!/bin/sh
+find . -name *.csv | sed -e 's|^\./||g' | sort > index

--- a/index
+++ b/index
@@ -1,10 +1,10 @@
 codes/2wire/Unknown_2wire/32,159.csv
 codes/3M/Projector/134,-1.csv
 codes/3M/Video Projector/134,-1.csv
-codes/ABIT/Unknown_WINDVD/1,-1.csv
-codes/ABS/Unknown_8776/8,0.csv
-codes/AccessHD/Unknown_DTA1080U/0,191.csv
-codes/AccessMedia/Unknown_ThinBox/31,-1.csv
+codes/ABIT/DVD_WINDVD/1,-1.csv
+codes/ABS/SAT_8776/8,0.csv
+codes/AccessHD/CONVERTER_DTA1080U/0,191.csv
+codes/AccessMedia/ThinBox/31,-1.csv
 codes/Accupel/Signal Generator/0,-1.csv
 codes/Acer/Projector/8,19.csv
 codes/Acer/Unknown_Aspire/4,15.csv
@@ -15,8 +15,8 @@ codes/Acesonic/Karaoke/77,-1.csv
 codes/Aconatic/Unknown_AN-2121/2,-1.csv
 codes/Acorp/Unknown_Acorp-878/134,107.csv
 codes/ADA/Millenium/27,-1.csv
+codes/ADB/SAT_ICAN3000/8,0.csv
 codes/ADB/Set Top Box/42,17.csv
-codes/ADB/Unknown_ICAN3000/8,0.csv
 codes/Adcom/AV Preamplifier/26,-1.csv
 codes/Adcom/CD Player/26,-1.csv
 codes/Adcom/Pre-Amplifier/232,26.csv
@@ -34,12 +34,12 @@ codes/Adcom/Unknown/81,0.csv
 codes/Adelphia/Cable Box/0,-1.csv
 codes/Adelphia/Cable Box/1,-1.csv
 codes/Adelphia/Cable Box/27,-1.csv
-codes/ADS/Unknown_Instant/2,-1.csv
-codes/ADS/Unknown_Tech/0,-1.csv
-codes/Advanced_acoustic/Unknown_Acoustic/36,75.csv
+codes/ADS/AUDIO_Tech/0,-1.csv
+codes/ADS/TV_Instant/2,-1.csv
+codes/Advanced Acoustics/Unknown_Acoustic/36,75.csv
 codes/Aesthetix/Pre-Amplifier/16,-1.csv
-codes/AIM/Unknown_AIM-RC126/4,15.csv
-codes/AIM/Unknown_Radio/129,129.csv
+codes/AIM/MCE_AIM-RC126/4,15.csv
+codes/AIM/RADIO/129,129.csv
 codes/Aiwa/Cassette Tape/115,0.csv
 codes/Aiwa/CD Player/118,0.csv
 codes/Aiwa/Mini System/110,0.csv
@@ -57,6 +57,7 @@ codes/Aiwa/Unknown_AWIA-RC-ZVR04/128,123.csv
 codes/Aiwa/Unknown_HIFI/112,0.csv
 codes/Aiwa/Unknown_hu/112,0.csv
 codes/Aiwa/Unknown_RC-6AS07/112,0.csv
+codes/Aiwa/Unknown_rc6as14/110,0.csv
 codes/Aiwa/Unknown_RC-7AS06/110,0.csv
 codes/Aiwa/Unknown_RC-8AS04/110,0.csv
 codes/Aiwa/Unknown_RC-8AT02/110,0.csv
@@ -83,7 +84,6 @@ codes/Aiwa/Unknown_RC-ZAS02/110,0.csv
 codes/Aiwa/Unknown_RC-ZAS10/110,0.csv
 codes/Aiwa/Unknown_RC-ZAT04/112,0.csv
 codes/Aiwa/Unknown_RC-ZVR02/127,0.csv
-codes/Aiwa/Unknown_rc6as14/110,0.csv
 codes/Aiwa/Unknown_S79/72,0.csv
 codes/Aiwa/VCR/127,0.csv
 codes/Aiwa/VCR/130,111.csv
@@ -93,6 +93,7 @@ codes/Akai/Unknown_akai/139,-1.csv
 codes/Akai/Unknown_Akai-RC-61A/11,11.csv
 codes/Akai/Unknown_AKAI-RC-AAV2100/160,160.csv
 codes/Akai/Unknown_Akai-RC-V23E/137,119.csv
+codes/Akai/Unknown_RC891/137,-1.csv
 codes/Akai/Unknown_rc-c37/141,-1.csv
 codes/Akai/Unknown_RC-C79/141,-1.csv
 codes/Akai/Unknown_RC-W152E/137,119.csv
@@ -100,7 +101,6 @@ codes/Akai/Unknown_RC-W201G/137,119.csv
 codes/Akai/Unknown_RC-W212F/137,119.csv
 codes/Akai/Unknown_RC-X121E/137,119.csv
 codes/Akai/Unknown_RC-Y121G/137,119.csv
-codes/Akai/Unknown_RC891/137,-1.csv
 codes/Akai/Unknown_TV/0,-1.csv
 codes/Akai/Unknown_V425A/137,-1.csv
 codes/Aki/Unknown_DVD-838W/0,-1.csv
@@ -123,11 +123,11 @@ codes/Amstrad/Unknown_SRX340/128,105.csv
 codes/AMX/PLR-IR1/4,-1.csv
 codes/AMX/PLR-IR1/85,-1.csv
 codes/Amytel/Unknown_ACI-200/0,-1.csv
-codes/ANIMAX/Unknown_MOUSE/0,-1.csv
-codes/ANITECH/Unknown_TV/0,-1.csv
+codes/ANIMAX/MOUSE/0,-1.csv
+codes/ANITECH/TV/0,-1.csv
 codes/Antex Electronics/Satellite Radio/26,-1.csv
 codes/anysee/Unknown_anysee/8,-1.csv
-codes/AOC/Unknown_M19W531/0,189.csv
+codes/AOC/TV/0,189.csv
 codes/Aopen/Media PC/4,-1.csv
 codes/Aopen/Unknown_RC-R470/4,-1.csv
 codes/Apex/DVD Player/4,-1.csv
@@ -181,16 +181,16 @@ codes/Arrakis Systems/CD Jukebox/103,-1.csv
 codes/Arrakis Systems/CD Jukebox/39,-1.csv
 codes/Arrakis Systems/CD Jukebox/71,-1.csv
 codes/Askey/Unknown_AS-218/134,107.csv
-codes/Aspire_digital/Unknown_Digital/8,-1.csv
+codes/Aspire Digital/Unknown_Digital/8,-1.csv
 codes/Astro/Satellite/8,-1.csv
 codes/Astro/Unknown_ASR340/0,253.csv
 codes/Asus/Unknown_Digital/0,239.csv
 codes/Asus/Unknown_RC1974502/4,15.csv
-codes/Asus/Unknown_TV-Box/None,None.csv
 codes/Asus/Unknown_TVBox/134,107.csv
+codes/Asus/Unknown_TV-Box/None,None.csv
 codes/Aten/Unknown_VS-431/0,-1.csv
 codes/Atiusb/Unknown_Ch16/None,None.csv
-codes/Atlanta_dth/Unknown_DTH/5,-1.csv
+codes/Atlanta DTH/Unknown_DTH/5,-1.csv
 codes/Atlantic Technology/Surround Processor/131,95.csv
 codes/Atlantic Technology/Surround Processor/64,64.csv
 codes/Atlantic Technology/Surround Processor/7,-1.csv
@@ -212,15 +212,16 @@ codes/Audio Control/Processor/16,-1.csv
 codes/Audio Control/Receiver/16,-1.csv
 codes/Audio Control/Receiver/17,-1.csv
 codes/Audio Control/Receiver/23,-1.csv
+codes/Audiola/DEC654_DVB-T/8,247.csv
 codes/Audio Refinement/Amplifier/20,-1.csv
 codes/Audio Refinement/CD Player/20,-1.csv
 codes/Audio Refinement/Tuner/20,-1.csv
 codes/Audio Research/Pre-Amplifier/7,-1.csv
 codes/audiosonic/Unknown_TXCD-1240/129,129.csv
 codes/AudioSource/Unknown_SS-Three/6,1.csv
+codes/Audiovox/Monitor/128,126.csv
 codes/Audiovox/Unknown_SIR/16,-1.csv
 codes/Audiovox/Unknown_Sirius/16,-1.csv
-codes/AudiovoxMonitor/128,126.csv
 codes/Austar/Cable Box/32,224.csv
 codes/AutumnWave/Unknown_Onair/8,-1.csv
 codes/Avermedia/Unknown_Avermedia/64,-1.csv
@@ -232,137 +233,23 @@ codes/Avex/Unknown_AVEX-RC501/5,-1.csv
 codes/Avtoolbox/Unknown_hdswitch/32,-1.csv
 codes/Axion/Unknown_AXN-6075/2,255.csv
 codes/Axonix/DVD Player/17,-1.csv
-codes/Axonix/Media Server/17,-1.csv
 codes/Axonix/MediaMax/17,20.csv
+codes/Axonix/Media Server/17,-1.csv
 codes/Ayre/Amplifier/16,-1.csv
 codes/AzBox/Unknown_S700/1,4.csv
-codes/B&K Components/2-Channel Preamp/11,-1.csv
-codes/B&K Components/2-Channel Preamp/11,79.csv
-codes/B&K Components/6 Zone Receiver/11,79.csv
-codes/B&K Components/6 Zone Receiver/123,72.csv
-codes/B&K Components/6 Zone Receiver/139,71.csv
-codes/B&K Components/6 Zone Receiver/187,-1.csv
-codes/B&K Components/6 Zone Receiver/203,67.csv
-codes/B&K Components/6 Zone Receiver/219,66.csv
-codes/B&K Components/6 Zone Receiver/242,208.csv
-codes/B&K Components/6 Zone Receiver/243,192.csv
-codes/B&K Components/6 Zone Receiver/251,64.csv
-codes/B&K Components/6 Zone Receiver/27,78.csv
-codes/B&K Components/6 Zone Receiver/43,77.csv
-codes/B&K Components/6 Zone Receiver/59,76.csv
-codes/B&K Components/6 Zone Receiver/75,75.csv
-codes/B&K Components/6 Zone Receiver/91,74.csv
-codes/B&K Components/Matrix Switcher/0,-1.csv
-codes/B&K Components/Matrix Switcher/103,137.csv
-codes/B&K Components/Matrix Switcher/108,57.csv
-codes/B&K Components/Matrix Switcher/111,9.csv
-codes/B&K Components/Matrix Switcher/119,-1.csv
-codes/B&K Components/Matrix Switcher/123,72.csv
-codes/B&K Components/Matrix Switcher/127,8.csv
-codes/B&K Components/Matrix Switcher/128,247.csv
-codes/B&K Components/Matrix Switcher/135,135.csv
-codes/B&K Components/Matrix Switcher/143,7.csv
-codes/B&K Components/Matrix Switcher/15,15.csv
-codes/B&K Components/Matrix Switcher/159,6.csv
-codes/B&K Components/Matrix Switcher/167,133.csv
-codes/B&K Components/Matrix Switcher/172,53.csv
-codes/B&K Components/Matrix Switcher/183,132.csv
-codes/B&K Components/Matrix Switcher/187,-1.csv
-codes/B&K Components/Matrix Switcher/192,243.csv
-codes/B&K Components/Matrix Switcher/199,131.csv
-codes/B&K Components/Matrix Switcher/204,-1.csv
-codes/B&K Components/Matrix Switcher/219,66.csv
-codes/B&K Components/Matrix Switcher/223,2.csv
-codes/B&K Components/Matrix Switcher/23,142.csv
-codes/B&K Components/Matrix Switcher/239,1.csv
-codes/B&K Components/Matrix Switcher/242,208.csv
-codes/B&K Components/Matrix Switcher/243,192.csv
-codes/B&K Components/Matrix Switcher/247,128.csv
-codes/B&K Components/Matrix Switcher/251,64.csv
-codes/B&K Components/Matrix Switcher/255,-1.csv
-codes/B&K Components/Matrix Switcher/31,14.csv
-codes/B&K Components/Matrix Switcher/39,141.csv
-codes/B&K Components/Matrix Switcher/44,61.csv
-codes/B&K Components/Matrix Switcher/55,140.csv
-codes/B&K Components/Matrix Switcher/59,76.csv
-codes/B&K Components/Matrix Switcher/63,12.csv
-codes/B&K Components/Matrix Switcher/64,251.csv
-codes/B&K Components/Matrix Switcher/7,143.csv
-codes/B&K Components/Matrix Switcher/71,139.csv
-codes/B&K Components/Matrix Switcher/76,59.csv
-codes/B&K Components/Matrix Switcher/79,11.csv
-codes/B&K Components/Matrix Switcher/91,74.csv
-codes/B&K Components/Matrix Switcher/95,10.csv
-codes/B&K Components/Multi-Zone Receiver/103,137.csv
-codes/B&K Components/Multi-Zone Receiver/119,-1.csv
-codes/B&K Components/Multi-Zone Receiver/123,72.csv
-codes/B&K Components/Multi-Zone Receiver/135,135.csv
-codes/B&K Components/Multi-Zone Receiver/143,7.csv
-codes/B&K Components/Multi-Zone Receiver/15,15.csv
-codes/B&K Components/Multi-Zone Receiver/151,134.csv
-codes/B&K Components/Multi-Zone Receiver/167,133.csv
-codes/B&K Components/Multi-Zone Receiver/183,132.csv
-codes/B&K Components/Multi-Zone Receiver/187,-1.csv
-codes/B&K Components/Multi-Zone Receiver/199,131.csv
-codes/B&K Components/Multi-Zone Receiver/215,130.csv
-codes/B&K Components/Multi-Zone Receiver/219,66.csv
-codes/B&K Components/Multi-Zone Receiver/23,142.csv
-codes/B&K Components/Multi-Zone Receiver/231,129.csv
-codes/B&K Components/Multi-Zone Receiver/242,208.csv
-codes/B&K Components/Multi-Zone Receiver/243,192.csv
-codes/B&K Components/Multi-Zone Receiver/247,128.csv
-codes/B&K Components/Multi-Zone Receiver/251,64.csv
-codes/B&K Components/Multi-Zone Receiver/31,14.csv
-codes/B&K Components/Multi-Zone Receiver/39,141.csv
-codes/B&K Components/Multi-Zone Receiver/55,140.csv
-codes/B&K Components/Multi-Zone Receiver/59,76.csv
-codes/B&K Components/Multi-Zone Receiver/7,143.csv
-codes/B&K Components/Multi-Zone Receiver/71,139.csv
-codes/B&K Components/Multi-Zone Receiver/79,11.csv
-codes/B&K Components/Multi-Zone Receiver/87,138.csv
-codes/B&K Components/Multi-Zone Receiver/91,74.csv
-codes/B&K Components/Pre-Amplifier/11,-1.csv
-codes/B&K Components/Pre-Amplifier/11,79.csv
-codes/B&K Components/Pre-Amplifier/139,71.csv
-codes/B&K Components/Pre-Amplifier/203,67.csv
-codes/B&K Components/Pre-Amplifier/27,78.csv
-codes/B&K Components/Pre-Amplifier/5,1.csv
-codes/B&K Components/Pre-Amplifier/6,1.csv
-codes/B&K Components/Receiver/139,71.csv
-codes/B&K Components/Receiver/203,67.csv
-codes/B&K Components/Receiver/27,78.csv
-codes/B&K Components/Surround Processor/11,79.csv
-codes/B&K Components/Surround Processor/27,78.csv
-codes/B&K Components/Theater Preamplifier/139,71.csv
-codes/B&K Components/Theater Preamplifier/203,67.csv
-codes/B&K Components/Theater Preamplifier/27,78.csv
-codes/B&K Components/Theater-Zone 2/11,79.csv
-codes/B&K Components/Theater-Zone 2/43,77.csv
-codes/B&K Components/Theater-Zone 2/75,75.csv
-codes/B&K Components/Tuner_preamp/11,-1.csv
-codes/B&K Components/Tuner_preamp/11,79.csv
-codes/B.A.TPre-Amplifier/16,-1.csv
-codes/Bang & Olufsen/CD Player/26,73.csv
+codes/Bang Olufsen/CD Player/26,73.csv
 codes/Barco/Unknown_barcoRC5/0,-1.csv
 codes/Barco/Video Projector/0,-1.csv
 codes/Barco/Video Projector/18,-1.csv
 codes/Barix/CD Jukebox/0,127.csv
+codes/B.A.T./Pre-Amplifier/16,-1.csv
 codes/BBK/Unknown_Popcorn/4,203.csv
 codes/BBK/Unknown_PV400s/80,-1.csv
 codes/BBK/Unknown_RC022-03R/73,-1.csv
 codes/Beko/Unknown_Beko/7,-1.csv
 codes/Beko/Unknown_TV/0,-1.csv
 codes/Belkin/Unknown_F5X019/27,-1.csv
-codes/Bell/Satellite/0,0.csv
-codes/Bell/Satellite/0,1.csv
-codes/Bell/Satellite/0,2.csv
-codes/Bell/Satellite/1,0.csv
-codes/Bell/Satellite/1,1.csv
-codes/Bell/Satellite/1,2.csv
-codes/Bell/Satellite/128,0.csv
-codes/Bell/Satellite/16,1.csv
-codes/Bell/Satellite/24,0.csv
-codes/Bell/Satellite/7,-1.csv
+codes/Bellagio/Unknown_P807/32,-1.csv
 codes/Bell ExpressVu/HD DVR/0,0.csv
 codes/Bell ExpressVu/HD DVR/1,0.csv
 codes/Bell ExpressVu/HD DVR/12,0.csv
@@ -370,7 +257,16 @@ codes/Bell ExpressVu/HD DVR/7,-1.csv
 codes/Bell ExpressVu/Satellite/0,0.csv
 codes/Bell ExpressVu/Satellite/1,0.csv
 codes/Bell ExpressVu/Satellite/16,0.csv
-codes/Bellagio/Unknown_P807/32,-1.csv
+codes/Bell/Satellite/0,0.csv
+codes/Bell/Satellite/0,1.csv
+codes/Bell/Satellite/0,2.csv
+codes/Bell/Satellite/1,0.csv
+codes/Bell/Satellite/1,1.csv
+codes/Bell/Satellite/128,0.csv
+codes/Bell/Satellite/1,2.csv
+codes/Bell/Satellite/16,1.csv
+codes/Bell/Satellite/24,0.csv
+codes/Bell/Satellite/7,-1.csv
 codes/Bench/Unknown_kh2800/48,-1.csv
 codes/BenQ/DLP Projector/48,-1.csv
 codes/BenQ/Projector/48,-1.csv
@@ -378,9 +274,113 @@ codes/BenQ/Projector/72,80.csv
 codes/BenQ/Unknown_DV3080/96,-1.csv
 codes/BenQ/Unknown_MP620/0,48.csv
 codes/BenQ/Unknown_W1070/0,48.csv
-codes/BESTBUY/Unknown_BESTBUY/None,None.csv
 codes/Big Ben/Game Console/67,164.csv
 codes/Bluesky/Unknown_DV900/5,-1.csv
+codes/BnK Components/2-Channel Preamp/11,-1.csv
+codes/BnK Components/2-Channel Preamp/11,79.csv
+codes/BnK Components/6 Zone Receiver/11,79.csv
+codes/BnK Components/6 Zone Receiver/123,72.csv
+codes/BnK Components/6 Zone Receiver/139,71.csv
+codes/BnK Components/6 Zone Receiver/187,-1.csv
+codes/BnK Components/6 Zone Receiver/203,67.csv
+codes/BnK Components/6 Zone Receiver/219,66.csv
+codes/BnK Components/6 Zone Receiver/242,208.csv
+codes/BnK Components/6 Zone Receiver/243,192.csv
+codes/BnK Components/6 Zone Receiver/251,64.csv
+codes/BnK Components/6 Zone Receiver/27,78.csv
+codes/BnK Components/6 Zone Receiver/43,77.csv
+codes/BnK Components/6 Zone Receiver/59,76.csv
+codes/BnK Components/6 Zone Receiver/75,75.csv
+codes/BnK Components/6 Zone Receiver/91,74.csv
+codes/BnK Components/Matrix Switcher/0,-1.csv
+codes/BnK Components/Matrix Switcher/103,137.csv
+codes/BnK Components/Matrix Switcher/108,57.csv
+codes/BnK Components/Matrix Switcher/111,9.csv
+codes/BnK Components/Matrix Switcher/119,-1.csv
+codes/BnK Components/Matrix Switcher/123,72.csv
+codes/BnK Components/Matrix Switcher/127,8.csv
+codes/BnK Components/Matrix Switcher/128,247.csv
+codes/BnK Components/Matrix Switcher/135,135.csv
+codes/BnK Components/Matrix Switcher/143,7.csv
+codes/BnK Components/Matrix Switcher/15,15.csv
+codes/BnK Components/Matrix Switcher/159,6.csv
+codes/BnK Components/Matrix Switcher/167,133.csv
+codes/BnK Components/Matrix Switcher/172,53.csv
+codes/BnK Components/Matrix Switcher/183,132.csv
+codes/BnK Components/Matrix Switcher/187,-1.csv
+codes/BnK Components/Matrix Switcher/192,243.csv
+codes/BnK Components/Matrix Switcher/199,131.csv
+codes/BnK Components/Matrix Switcher/204,-1.csv
+codes/BnK Components/Matrix Switcher/219,66.csv
+codes/BnK Components/Matrix Switcher/223,2.csv
+codes/BnK Components/Matrix Switcher/23,142.csv
+codes/BnK Components/Matrix Switcher/239,1.csv
+codes/BnK Components/Matrix Switcher/242,208.csv
+codes/BnK Components/Matrix Switcher/243,192.csv
+codes/BnK Components/Matrix Switcher/247,128.csv
+codes/BnK Components/Matrix Switcher/251,64.csv
+codes/BnK Components/Matrix Switcher/255,-1.csv
+codes/BnK Components/Matrix Switcher/31,14.csv
+codes/BnK Components/Matrix Switcher/39,141.csv
+codes/BnK Components/Matrix Switcher/44,61.csv
+codes/BnK Components/Matrix Switcher/55,140.csv
+codes/BnK Components/Matrix Switcher/59,76.csv
+codes/BnK Components/Matrix Switcher/63,12.csv
+codes/BnK Components/Matrix Switcher/64,251.csv
+codes/BnK Components/Matrix Switcher/71,139.csv
+codes/BnK Components/Matrix Switcher/7,143.csv
+codes/BnK Components/Matrix Switcher/76,59.csv
+codes/BnK Components/Matrix Switcher/79,11.csv
+codes/BnK Components/Matrix Switcher/91,74.csv
+codes/BnK Components/Matrix Switcher/95,10.csv
+codes/BnK Components/Multi-Zone Receiver/103,137.csv
+codes/BnK Components/Multi-Zone Receiver/119,-1.csv
+codes/BnK Components/Multi-Zone Receiver/123,72.csv
+codes/BnK Components/Multi-Zone Receiver/135,135.csv
+codes/BnK Components/Multi-Zone Receiver/143,7.csv
+codes/BnK Components/Multi-Zone Receiver/151,134.csv
+codes/BnK Components/Multi-Zone Receiver/15,15.csv
+codes/BnK Components/Multi-Zone Receiver/167,133.csv
+codes/BnK Components/Multi-Zone Receiver/183,132.csv
+codes/BnK Components/Multi-Zone Receiver/187,-1.csv
+codes/BnK Components/Multi-Zone Receiver/199,131.csv
+codes/BnK Components/Multi-Zone Receiver/215,130.csv
+codes/BnK Components/Multi-Zone Receiver/219,66.csv
+codes/BnK Components/Multi-Zone Receiver/231,129.csv
+codes/BnK Components/Multi-Zone Receiver/23,142.csv
+codes/BnK Components/Multi-Zone Receiver/242,208.csv
+codes/BnK Components/Multi-Zone Receiver/243,192.csv
+codes/BnK Components/Multi-Zone Receiver/247,128.csv
+codes/BnK Components/Multi-Zone Receiver/251,64.csv
+codes/BnK Components/Multi-Zone Receiver/31,14.csv
+codes/BnK Components/Multi-Zone Receiver/39,141.csv
+codes/BnK Components/Multi-Zone Receiver/55,140.csv
+codes/BnK Components/Multi-Zone Receiver/59,76.csv
+codes/BnK Components/Multi-Zone Receiver/71,139.csv
+codes/BnK Components/Multi-Zone Receiver/7,143.csv
+codes/BnK Components/Multi-Zone Receiver/79,11.csv
+codes/BnK Components/Multi-Zone Receiver/87,138.csv
+codes/BnK Components/Multi-Zone Receiver/91,74.csv
+codes/BnK Components/Pre-Amplifier/11,-1.csv
+codes/BnK Components/Pre-Amplifier/11,79.csv
+codes/BnK Components/Pre-Amplifier/139,71.csv
+codes/BnK Components/Pre-Amplifier/203,67.csv
+codes/BnK Components/Pre-Amplifier/27,78.csv
+codes/BnK Components/Pre-Amplifier/5,1.csv
+codes/BnK Components/Pre-Amplifier/6,1.csv
+codes/BnK Components/Receiver/139,71.csv
+codes/BnK Components/Receiver/203,67.csv
+codes/BnK Components/Receiver/27,78.csv
+codes/BnK Components/Surround Processor/11,79.csv
+codes/BnK Components/Surround Processor/27,78.csv
+codes/BnK Components/Theater Preamplifier/139,71.csv
+codes/BnK Components/Theater Preamplifier/203,67.csv
+codes/BnK Components/Theater Preamplifier/27,78.csv
+codes/BnK Components/Theater-Zone 2/11,79.csv
+codes/BnK Components/Theater-Zone 2/43,77.csv
+codes/BnK Components/Theater-Zone 2/75,75.csv
+codes/BnK Components/Tuner_preamp/11,-1.csv
+codes/BnK Components/Tuner_preamp/11,79.csv
 codes/Bogen/Amplifier/1,-1.csv
 codes/BORK/Unknown_DV/8,-1.csv
 codes/Bose/3-2-1/186,75.csv
@@ -389,7 +389,6 @@ codes/Bose/CCF Conversion/186,133.csv
 codes/Bose/CCF Conversion/186,213.csv
 codes/Bose/CCF Conversion/186,229.csv
 codes/Bose/CCF Conversion/186,85.csv
-codes/Bose/Lifestyle/186,1.csv
 codes/Bose/Lifestyle/186,136.csv
 codes/Bose/Lifestyle/186,160.csv
 codes/Bose/Lifestyle/186,161.csv
@@ -422,6 +421,7 @@ codes/Bose/Lifestyle/186,188.csv
 codes/Bose/Lifestyle/186,189.csv
 codes/Bose/Lifestyle/186,190.csv
 codes/Bose/Lifestyle/186,191.csv
+codes/Bose/Lifestyle/186,1.csv
 codes/Bose/Lifestyle/186,85.csv
 codes/Bose/Media Center/1,-1.csv
 codes/Bose/Media Center/186,136.csv
@@ -465,15 +465,15 @@ codes/Calypso/Amplifier/17,-1.csv
 codes/Calypso/Control System/1,-1.csv
 codes/Calypso/Control System/17,-1.csv
 codes/Calypso/Control System/7,-1.csv
-codes/Cambridge Audio/Amp_CD/16,-1.csv
 codes/Cambridge Audio/Amp_CD/160,160.csv
+codes/Cambridge Audio/Amp_CD/16,-1.csv
 codes/Cambridge Audio/DVD Player/12,-1.csv
 codes/Cambridge Audio/DVD Player/7,-1.csv
 codes/Cambridge Audio/Receiver/16,-1.csv
 codes/Cambridge Audio/Receiver/19,-1.csv
 codes/Cambridge Audio/Receiver/192,192.csv
-codes/Cambridge_audio/Unknown_Audio/192,192.csv
-codes/Cambridge_audio/Unknown_X40A/16,-1.csv
+codes/Cambridge Audio/Unknown_Audio/192,192.csv
+codes/Cambridge Audio/Unknown_X40A/16,-1.csv
 codes/Camera/Camera Multi Plex/133,115.csv
 codes/Canalsat/Satellite/10,-1.csv
 codes/Canalsat/Unknown_CanalSat/10,-1.csv
@@ -532,7 +532,7 @@ codes/Celadon/IR to RS232/123,2.csv
 codes/cenOmax/Unknown_F702/2,255.csv
 codes/Centrum/Unknown_Gemini/29,-1.csv
 codes/Centrum/Unknown_rc5/29,-1.csv
-codes/Century_concept/Unknown_dvd/0,246.csv
+codes/Century Concept/Unknown_dvd/0,246.csv
 codes/Channel Master/Satellite/132,99.csv
 codes/Channel Plus/Video Switcher/49,235.csv
 codes/Chaparral/Unknown_11-5315-1/128,103.csv
@@ -553,8 +553,8 @@ codes/CIS BOX/HDTV ALL/151,-1.csv
 codes/CIS BOX/HDTV ALL/164,-1.csv
 codes/CIS BOX/HDTV ALL/26,26.csv
 codes/CIS BOX/LCD Projector/84,-1.csv
-codes/CIS BOX/Plasma/1,-1.csv
 codes/CIS BOX/Plasma/119,-1.csv
+codes/CIS BOX/Plasma/1,-1.csv
 codes/CIS BOX/Plasma/164,-1.csv
 codes/CIS BOX/Receiver/121,-1.csv
 codes/CIS BOX/Receiver/144,-1.csv
@@ -574,17 +574,17 @@ codes/Citizen/Unknown_JX-2022C/0,-1.csv
 codes/Classe Audio/Amplifier/201,-1.csv
 codes/Classe Audio/Amplifier/3,-1.csv
 codes/Classe Audio/Amplifier/7,-1.csv
+codes/Classe Audio/CD_DVD/200,-1.csv
+codes/Classe Audio/CD_DVD/20,-1.csv
+codes/Classe Audio/CD_DVD/4,-1.csv
 codes/Classe Audio/CD Player/134,97.csv
 codes/Classe Audio/CD Player/20,-1.csv
-codes/Classe Audio/CD_DVD/20,-1.csv
-codes/Classe Audio/CD_DVD/200,-1.csv
-codes/Classe Audio/CD_DVD/4,-1.csv
 codes/Classe Audio/CRCD/16,-1.csv
 codes/Classe Audio/CRCD/17,-1.csv
 codes/Classe Audio/CRCD/20,-1.csv
 codes/Classe Audio/DVD Player/12,-1.csv
-codes/Classe Audio/DVD Player/20,-1.csv
 codes/Classe Audio/DVD Player/200,-1.csv
+codes/Classe Audio/DVD Player/20,-1.csv
 codes/Classe Audio/DVD Player/25,-1.csv
 codes/Classe Audio/DVD Player/4,-1.csv
 codes/Classe Audio/DVD Player/7,-1.csv
@@ -636,10 +636,10 @@ codes/Creative/Unknown_BreakOut-Box/None,None.csv
 codes/Creative/Unknown_DDTS-100/193,68.csv
 codes/Creative/Unknown_INFRA/33,172.csv
 codes/Creative/Unknown_JUKEBOX3/33,172.csv
+codes/Creative/Unknown_rm1000w/193,68.csv
 codes/Creative/Unknown_RM-1500/193,68.csv
 codes/Creative/Unknown_RM-1800/193,68.csv
 codes/Creative/Unknown_RM-850/193,68.csv
-codes/Creative/Unknown_rm1000w/193,68.csv
 codes/Creative/Unknown_RM900/193,68.csv
 codes/Creek/Line_Volume Control/16,-1.csv
 codes/Crestron/IR Receiver/0,-1.csv
@@ -651,9 +651,9 @@ codes/Crestron/Lighting Controller/30,-1.csv
 codes/Crestron/Music Server/14,-1.csv
 codes/Crown/Unknown_cd-80/202,20.csv
 codes/Crown/Unknown_testinglirc.config/0,-1.csv
+codes/Curtis Electronics/Unknown_TV/0,-1.csv
 codes/Curtis Mathes/VCR/144,0.csv
 codes/Curtis Mathes/VCR/144,1.csv
-codes/Curtis_electronics/Unknown_TV/0,-1.csv
 codes/Cyberhome/DVD Player/114,205.csv
 codes/Cyberhome/Unknown_300-RMC-300Z/114,205.csv
 codes/Cyberhome/Unknown_504/114,205.csv
@@ -663,14 +663,6 @@ codes/Cyberhome/Unknown_CH-DVD-302/114,205.csv
 codes/Cyberhome/Unknown_cyberhome/114,205.csv
 codes/Cypress/Unknown_CR-72/64,175.csv
 codes/Cyron/Lighting Controller/2,189.csv
-codes/D-LINK/Media Center/8,230.csv
-codes/D-LINK/Media Center/8,231.csv
-codes/D-LINK/MP3 Player/18,37.csv
-codes/D-LINK/MP3 Player/8,230.csv
-codes/D-LINK/Unknown_DSM-10/8,230.csv
-codes/D-LINK/Unknown_DSM320/8,230.csv
-codes/D-LINK/Unknown_i2eye/130,19.csv
-codes/Da Lite/Screen/0,-1.csv
 codes/Daeumling/Unknown_SR200/128,38.csv
 codes/Daewoo/DVD Player/21,-1.csv
 codes/Daewoo/TV/20,-1.csv
@@ -684,8 +676,8 @@ codes/Daewoo/Unknown_DAEWOO/0,-1.csv
 codes/Daewoo/Unknown_DAEWOO/21,-1.csv
 codes/Daewoo/Unknown_DS608P/17,-1.csv
 codes/Daewoo/Unknown_DV-800/21,-1.csv
-codes/Daewoo/Unknown_DV-F24D/21,-1.csv
 codes/Daewoo/Unknown_DVDS150/32,-1.csv
+codes/Daewoo/Unknown_DV-F24D/21,-1.csv
 codes/Daewoo/Unknown_r-22/0,-1.csv
 codes/Daewoo/Unknown_R-40A06/20,-1.csv
 codes/Daewoo/Unknown_R-40A10/20,-1.csv
@@ -695,9 +687,11 @@ codes/Daewoo/Unknown_VCR/21,-1.csv
 codes/Daewoo/Unknown_VCR/49,-1.csv
 codes/Daewoo/Unknown_Visa/20,-1.csv
 codes/Daewoo/VCR/21,-1.csv
+codes/Da Lite/Screen/0,-1.csv
 codes/Dantax/DVD Player/0,-1.csv
 codes/Dantax/Unknown_RC/0,-1.csv
 codes/daytron/Unknown_daytron/4,-1.csv
+codes/DBPower/Projector_T20/2,-1.csv
 codes/Dedicated Micros/Camera Switcher/4,-1.csv
 codes/Dell/TV/0,28.csv
 codes/Dell/Unknown_XPS/43,28.csv
@@ -711,16 +705,6 @@ codes/Denon/Amplifier/8,-1.csv
 codes/Denon/AV Processor/12,-1.csv
 codes/Denon/AV Processor/2,-1.csv
 codes/Denon/AV Processor/4,-1.csv
-codes/Denon/AV Receiver/12,-1.csv
-codes/Denon/AV Receiver/2,-1.csv
-codes/Denon/AV Receiver/2,3.csv
-codes/Denon/AV Receiver/4,-1.csv
-codes/Denon/AV Receiver/4,1.csv
-codes/Denon/AV Receiver/4,2.csv
-codes/Denon/AV Receiver/4,3.csv
-codes/Denon/AV Receiver/4,5.csv
-codes/Denon/AV Receiver/4,7.csv
-codes/Denon/AV Receiver/7,5.csv
 codes/Denon/Blu-Ray/2,1.csv
 codes/Denon/Cassette Tape/12,-1.csv
 codes/Denon/Cassette Tape/2,-1.csv
@@ -769,20 +753,12 @@ codes/Denon/Receiver/7,5.csv
 codes/Denon/Receiver/7,6.csv
 codes/Denon/Receiver/7,7.csv
 codes/Denon/Receiver/7,8.csv
-codes/Denon/Receiver/8,-1.csv
 codes/Denon/Receiver/80,-1.csv
+codes/Denon/Receiver/8,-1.csv
 codes/Denon/Receiver/96,-1.csv
 codes/Denon/Receiver/97,-1.csv
-codes/Denon/Receiver_CD/12,-1.csv
-codes/Denon/Receiver_CD/4,-1.csv
-codes/Denon/Receiver_CD/6,-1.csv
-codes/Denon/Receiver_CD/8,-1.csv
-codes/Denon/Surround Receiver/12,-1.csv
-codes/Denon/Surround Receiver/2,-1.csv
-codes/Denon/Surround Receiver/4,-1.csv
 codes/Denon/Tuner/12,-1.csv
 codes/Denon/Tuner/2,-1.csv
-codes/Denon/Tuner/6,1.csv
 codes/Denon/Tuner/6,100.csv
 codes/Denon/Tuner/6,101.csv
 codes/Denon/Tuner/6,102.csv
@@ -810,36 +786,36 @@ codes/Denon/Tuner/6,163.csv
 codes/Denon/Tuner/6,164.csv
 codes/Denon/Tuner/6,165.csv
 codes/Denon/Tuner/6,166.csv
-codes/Denon/Tuner/6,17.csv
 codes/Denon/Tuner/6,177.csv
 codes/Denon/Tuner/6,178.csv
 codes/Denon/Tuner/6,179.csv
-codes/Denon/Tuner/6,18.csv
+codes/Denon/Tuner/6,17.csv
 codes/Denon/Tuner/6,180.csv
 codes/Denon/Tuner/6,181.csv
 codes/Denon/Tuner/6,182.csv
-codes/Denon/Tuner/6,19.csv
+codes/Denon/Tuner/6,18.csv
 codes/Denon/Tuner/6,193.csv
 codes/Denon/Tuner/6,194.csv
 codes/Denon/Tuner/6,195.csv
 codes/Denon/Tuner/6,196.csv
 codes/Denon/Tuner/6,197.csv
 codes/Denon/Tuner/6,198.csv
-codes/Denon/Tuner/6,2.csv
-codes/Denon/Tuner/6,20.csv
+codes/Denon/Tuner/6,19.csv
+codes/Denon/Tuner/6,1.csv
 codes/Denon/Tuner/6,209.csv
-codes/Denon/Tuner/6,21.csv
+codes/Denon/Tuner/6,20.csv
 codes/Denon/Tuner/6,210.csv
 codes/Denon/Tuner/6,211.csv
 codes/Denon/Tuner/6,212.csv
 codes/Denon/Tuner/6,213.csv
 codes/Denon/Tuner/6,214.csv
-codes/Denon/Tuner/6,22.csv
+codes/Denon/Tuner/6,21.csv
 codes/Denon/Tuner/6,225.csv
 codes/Denon/Tuner/6,226.csv
 codes/Denon/Tuner/6,227.csv
 codes/Denon/Tuner/6,228.csv
 codes/Denon/Tuner/6,229.csv
+codes/Denon/Tuner/6,22.csv
 codes/Denon/Tuner/6,230.csv
 codes/Denon/Tuner/6,241.csv
 codes/Denon/Tuner/6,242.csv
@@ -847,27 +823,28 @@ codes/Denon/Tuner/6,243.csv
 codes/Denon/Tuner/6,244.csv
 codes/Denon/Tuner/6,245.csv
 codes/Denon/Tuner/6,246.csv
-codes/Denon/Tuner/6,3.csv
+codes/Denon/Tuner/6,2.csv
 codes/Denon/Tuner/6,33.csv
 codes/Denon/Tuner/6,34.csv
 codes/Denon/Tuner/6,35.csv
 codes/Denon/Tuner/6,36.csv
 codes/Denon/Tuner/6,37.csv
 codes/Denon/Tuner/6,38.csv
-codes/Denon/Tuner/6,4.csv
+codes/Denon/Tuner/6,3.csv
 codes/Denon/Tuner/6,49.csv
-codes/Denon/Tuner/6,5.csv
+codes/Denon/Tuner/6,4.csv
 codes/Denon/Tuner/6,50.csv
 codes/Denon/Tuner/6,51.csv
 codes/Denon/Tuner/6,52.csv
 codes/Denon/Tuner/6,53.csv
 codes/Denon/Tuner/6,54.csv
-codes/Denon/Tuner/6,6.csv
+codes/Denon/Tuner/6,5.csv
 codes/Denon/Tuner/6,65.csv
 codes/Denon/Tuner/6,66.csv
 codes/Denon/Tuner/6,67.csv
 codes/Denon/Tuner/6,68.csv
 codes/Denon/Tuner/6,69.csv
+codes/Denon/Tuner/6,6.csv
 codes/Denon/Tuner/6,70.csv
 codes/Denon/Tuner/6,81.csv
 codes/Denon/Tuner/6,82.csv
@@ -885,18 +862,21 @@ codes/Denon/Unknown_denon-rc-266/8,-1.csv
 codes/Denon/Unknown_RC-220/8,-1.csv
 codes/Denon/Unknown_RC-224/8,-1.csv
 codes/Denon/Unknown_RC-241/8,-1.csv
+codes/Denon/Unknown_RC267/6,-1.csv
 codes/Denon/Unknown_RC-541/176,0.csv
 codes/Denon/Unknown_RC-861/2,2.csv
-codes/Denon/Unknown_RC267/6,-1.csv
 codes/Denver/Unknown_DVD-228/4,-1.csv
 codes/devinput/Unknown_devinput/None,None.csv
 codes/DIFRNCE/Unknown_DVD5010S/0,-1.csv
+codes/Digiquest/DGQ-3300_DVB-T/0,191.csv
+codes/Digiquest/DGQ-7600HD_DVB-T/0,191.csv
+codes/Digiquest/DVB-T/1,254.csv
 codes/Digital Music Expres/DMX/38,-1.csv
 codes/Digital Projection/Projector/32,-1.csv
 codes/Digital Projection/Video Projector/32,-1.csv
 codes/Digital Projection/Video Scaler/58,-1.csv
 codes/Digital Stream/HDTV Tuner/4,2.csv
-codes/Digital_stream/Unknown_Stream/18,52.csv
+codes/Digital Stream/Unknown_Stream/18,52.csv
 codes/DigitalView/HDTV Tuner/128,-1.csv
 codes/DirecTV/Basic Satellite/12,-1.csv
 codes/DirecTV/Basic Satellite/7,-1.csv
@@ -913,12 +893,12 @@ codes/DirecTV/Receiver HDDVR/2,-1.csv
 codes/DirecTV/Receiver HDDVR/3,-1.csv
 codes/DirecTV/Receiver HDDVR/64,-1.csv
 codes/DirecTV/Receiver HDDVR/71,-1.csv
+codes/DirecTV/Receiver_HDR/133,48.csv
 codes/DirecTV/Receiver SD/12,-1.csv
 codes/DirecTV/Receiver SD/13,-1.csv
 codes/DirecTV/Receiver SDDVR/12,-1.csv
 codes/DirecTV/Receiver SDDVR/133,48.csv
 codes/DirecTV/Receiver SDDVR/15,-1.csv
-codes/DirecTV/Receiver_HDR/133,48.csv
 codes/DirecTV/Satellite/12,-1.csv
 codes/DirecTV/Satellite/133,48.csv
 codes/DirecTV/Satellite/4,-1.csv
@@ -936,26 +916,26 @@ codes/Dish Network/Satelite DVR/0,0.csv
 codes/Dish Network/Satelite DVR/1,0.csv
 codes/Dish Network/Satelite DVR/15,-1.csv
 codes/Dish Network/Satellite/0,0.csv
-codes/Dish Network/Satellite/0,1.csv
 codes/Dish Network/Satellite/0,12.csv
+codes/Dish Network/Satellite/0,1.csv
 codes/Dish Network/Satellite/0,2.csv
-codes/Dish Network/Satellite/0,3.csv
 codes/Dish Network/Satellite/0,31.csv
+codes/Dish Network/Satellite/0,3.csv
 codes/Dish Network/Satellite/0,4.csv
 codes/Dish Network/Satellite/0,5.csv
 codes/Dish Network/Satellite/0,6.csv
 codes/Dish Network/Satellite/0,7.csv
 codes/Dish Network/Satellite/1,0.csv
-codes/Dish Network/Satellite/1,1.csv
 codes/Dish Network/Satellite/1,12.csv
+codes/Dish Network/Satellite/1,1.csv
 codes/Dish Network/Satellite/1,2.csv
 codes/Dish Network/Satellite/1,3.csv
 codes/Dish Network/Satellite/1,4.csv
+codes/Dish Network/Satellite/15,-1.csv
 codes/Dish Network/Satellite/1,5.csv
+codes/Dish Network/Satellite/16,0.csv
 codes/Dish Network/Satellite/1,6.csv
 codes/Dish Network/Satellite/1,7.csv
-codes/Dish Network/Satellite/15,-1.csv
-codes/Dish Network/Satellite/16,0.csv
 codes/Dish Network/Satellite/24,0.csv
 codes/Dish Network/Satellite/28,-1.csv
 codes/Dish Network/Satellite/4,0.csv
@@ -963,13 +943,21 @@ codes/Dish Network/Satellite/4,5.csv
 codes/Dish Network/Satellite/48,-1.csv
 codes/Dish Network/Satellite/8,0.csv
 codes/DK digital/DVD Player/0,-1.csv
-codes/Dk_digital/Unknown_Digital/0,-1.csv
+codes/DK Digital/Unknown_Digital/0,-1.csv
+codes/D-LINK/Media Center/8,230.csv
+codes/D-LINK/Media Center/8,231.csv
+codes/D-LINK/MP3 Player/18,37.csv
+codes/D-LINK/MP3 Player/8,230.csv
+codes/D-LINK/Unknown_DSM-10/8,230.csv
+codes/D-LINK/Unknown_DSM320/8,230.csv
+codes/D-LINK/Unknown_i2eye/130,19.csv
 codes/DLO/HomeDock/238,135.csv
 codes/Domland/Unknown_domland-MH10CA/131,101.csv
 codes/Draper/Dropdown Screen/0,-1.csv
 codes/Draper/Electric Screen/0,-1.csv
 codes/Draper/Screen/0,-1.csv
 codes/Draper/Screen/2,-1.csv
+codes/Dream Multimedia/Unknown_URC7562/0,-1.csv
 codes/Dream/Satellite/0,-1.csv
 codes/Dream/Satellite/10,0.csv
 codes/Dream/Satellite/11,0.csv
@@ -977,7 +965,6 @@ codes/Dream/Satellite/25,0.csv
 codes/Dream/Satellite/26,0.csv
 codes/Dream/Satellite/41,0.csv
 codes/Dream Vision/DLP Projector/135,78.csv
-codes/Dream_multimedia/Unknown_URC7562/0,-1.csv
 codes/DSE/Unknown_G1605/5,-1.csv
 codes/DSE/Unknown_G1928/0,-1.csv
 codes/DSE/Unknown_G7659/0,-1.csv
@@ -998,17 +985,13 @@ codes/Dwin/Video Projector/15,-1.csv
 codes/Dwin/Video Projector/7,0.csv
 codes/Dynaudio/Unknown_Sub/1,-1.csv
 codes/Dynex/Unknown_DX-CVS4/2,-1.csv
-codes/E-tech/Unknown_FLY98/96,1.csv
-codes/e:max/DVD Player/0,223.csv
-codes/Eagle_aspen/Unknown_Aspen/120,-1.csv
+codes/Eagle Aspen/Unknown_Aspen/120,-1.csv
 codes/Echostar/Dish Network/0,0.csv
 codes/Echostar/DSS/0,0.csv
 codes/Echostar/DVR/0,0.csv
 codes/Echostar/DVR/1,0.csv
 codes/Echostar/PVR SAT/0,0.csv
 codes/Echostar/PVR SAT/1,0.csv
-codes/Echostar/Sat_PVR Recorder Box/0,4.csv
-codes/Echostar/Sat_PVR Recorder Box/1,4.csv
 codes/Echostar/Satelite DVR/0,0.csv
 codes/Echostar/Satelite DVR/0,4.csv
 codes/Echostar/Satelite DVR/1,0.csv
@@ -1018,6 +1001,8 @@ codes/Echostar/Satellite/0,0.csv
 codes/Echostar/Satellite/1,0.csv
 codes/Echostar/Satellite/16,0.csv
 codes/Echostar/Satellite/4,-1.csv
+codes/Echostar/Sat_PVR Recorder Box/0,4.csv
+codes/Echostar/Sat_PVR Recorder Box/1,4.csv
 codes/Echostar/Unknown_AD3000IP/4,0.csv
 codes/Echostar/Unknown_DSB-616/5,-1.csv
 codes/Echostar/Unknown_DSB-636/4,0.csv
@@ -1054,11 +1039,12 @@ codes/Electrokinetics/Plasma Lift/0,-1.csv
 codes/Elenberg/Unknown_RC-404E/0,251.csv
 codes/Elitron/Unknown_utk/7,-1.csv
 codes/Elmo/Camera/128,-1.csv
-codes/Elmo/Unknown_PRC-100S/32,-1.csv
+codes/Elmo/CAMERA_PRC-100S/32,-1.csv
 codes/Elmo/Video Projector/132,132.csv
 codes/Elmo/Video Projector/134,134.csv
 codes/ELTASAT/Unknown_SAT170/66,253.csv
 codes/eltax/Unknown_corniche/0,246.csv
+codes/E Max/DVD Player/0,223.csv
 codes/Emerson/TV/0,-1.csv
 codes/Emerson/TV/135,34.csv
 codes/Emerson/Unknown_emerson/134,5.csv
@@ -1066,8 +1052,8 @@ codes/Emerson/Unknown_emerson-cd/3,1.csv
 codes/Emerson/Unknown_Emerson-NB050-DVD/135,34.csv
 codes/Emerson/Unknown_emersontv/22,22.csv
 codes/Emerson/VCR/21,-1.csv
-codes/Emerson/VCR/4,-1.csv
 codes/Emerson/VCR/40,-1.csv
+codes/Emerson/VCR/4,-1.csv
 codes/ENTONE/Unknown_URC-4021ABA1-006-R/230,4.csv
 codes/Epson/Projector/131,85.csv
 codes/Epson/Unknown_12807990/131,85.csv
@@ -1093,8 +1079,8 @@ codes/Escient/DVD Player/4,22.csv
 codes/Escient/DVD Player/8,-1.csv
 codes/Escient/Hard Drive Recorder/15,0.csv
 codes/Escient/Media Manager/1,22.csv
-codes/Escient/Media Manager/15,-1.csv
 codes/Escient/Media Manager/15,0.csv
+codes/Escient/Media Manager/15,-1.csv
 codes/Escient/Media Manager/2,22.csv
 codes/Escient/Media Manager/3,22.csv
 codes/Escient/Media Manager/33,184.csv
@@ -1108,6 +1094,7 @@ codes/Escient/MP3 Player/14,-1.csv
 codes/Escient/MP3 Player/15,-1.csv
 codes/Escient/MP3 Player/4,22.csv
 codes/Esoteric Audio/DVD Player/133,32.csv
+codes/E-tech/Unknown_FLY98/96,1.csv
 codes/Euroconsumers/Unknown_LG-5988/136,-1.csv
 codes/Expressvu/Unknown_3100/0,0.csv
 codes/Extron/Switcher/0,-1.csv
@@ -1149,22 +1136,21 @@ codes/Fosgate/Surround Processor/132,66.csv
 codes/Foxtel/Set Top Box/33,160.csv
 codes/Foxtel/Unknown_Digital/0,0.csv
 codes/Foxtel/Unknown_foxtel/33,160.csv
-codes/Free/Unknown_REMOTE/11,-1.csv
-codes/Free/Unknown_V5/36,12.csv
 codes/Freecom/Unknown_MP35/128,-1.csv
 codes/Freecom/Unknown_usb/128,-1.csv
+codes/Free/Unknown_REMOTE/11,-1.csv
+codes/Free/Unknown_V5/36,12.csv
 codes/Fresat/Unknown_SER-3000PL/8,64.csv
 codes/Friedrich/Air Conditioner/1,-1.csv
 codes/Friedrich/Air Conditioner/16,-1.csv
 codes/FSC/DVD Player/4,15.csv
-codes/Fte_maximal/Unknown_FTE/73,-1.csv
+codes/FTE Maximal/Unknown_FTE/73,-1.csv
 codes/FUBA/Unknown_ALPS/134,75.csv
 codes/FUBA/Unknown_FUBA/134,75.csv
-codes/Fujitsu/Monitor/132,-1.csv
 codes/Fujitsu/Monitor/132,138.csv
 codes/Fujitsu/Monitor/132,139.csv
 codes/Fujitsu/Monitor/132,140.csv
-codes/Fujitsu/Plasma/132,-1.csv
+codes/Fujitsu/Monitor/132,-1.csv
 codes/Fujitsu/Plasma/132,129.csv
 codes/Fujitsu/Plasma/132,130.csv
 codes/Fujitsu/Plasma/132,134.csv
@@ -1173,11 +1159,12 @@ codes/Fujitsu/Plasma/132,138.csv
 codes/Fujitsu/Plasma/132,139.csv
 codes/Fujitsu/Plasma/132,140.csv
 codes/Fujitsu/Plasma/132,141.csv
+codes/Fujitsu/Plasma/132,-1.csv
 codes/Fujitsu/Plasma/140,132.csv
+codes/Fujitsu Siemens/Unknown_RC1-1241-21/32,176.csv
+codes/Fujitsu Siemens/Unknown_RC811/4,15.csv
 codes/Fujitsu/TV/132,-1.csv
 codes/Fujitsu/Unknown_CP300375-01/4,15.csv
-codes/Fujitsu_siemens/Unknown_RC1-1241-21/32,176.csv
-codes/Fujitsu_siemens/Unknown_RC811/4,15.csv
 codes/Fujtech/Unknown_DVB-T/3,-1.csv
 codes/FUNAI/Unknown_NF021RD/132,224.csv
 codes/Fusion Research/DVD Server/17,-1.csv
@@ -1187,19 +1174,10 @@ codes/Galaxis/Unknown_Galaxis-RCMM/13,80.csv
 codes/Galaxis/Unknown_Galaxis.sat/81,175.csv
 codes/Galaxis/Unknown_rc1/7,-1.csv
 codes/GAMEFACTORY/Unknown_PS2DVD/0,246.csv
-codes/GE/TV/15,-1.csv
-codes/GE/Unknown/15,-1.csv
-codes/GE/Unknown_TV-25CT511/15,-1.csv
-codes/GE/Unknown_VCR/14,-1.csv
-codes/GE/Unknown_VKFS0938/14,-1.csv
-codes/GE/VCR/11,-1.csv
-codes/GE/VCR/14,-1.csv
-codes/GE/VCR/26,73.csv
 codes/Gefen Systems/DVI Switcher/11,-1.csv
 codes/Gefen Systems/HDMI Switcher/11,-1.csv
 codes/Gefen Systems/Matrix Switcher/11,-1.csv
 codes/Gefen Systems/Unknown/24,-1.csv
-codes/General/Unknown_VCR/22,-1.csv
 codes/General Electric/TV/15,-1.csv
 codes/General Electric/VCR/11,-1.csv
 codes/General Electric/VCR/14,-1.csv
@@ -1213,8 +1191,9 @@ codes/General Instrument/Cable Box/64,-1.csv
 codes/General Instrument/Cable Box/87,-1.csv
 codes/General Instrument/Satellite/1,-1.csv
 codes/General Instrument/Satellite/130,110.csv
-codes/General_instrument/Unknown_550/-1,-1.csv
-codes/General_instrument/Unknown_XRC-200/0,-1.csv
+codes/General Instruments/Unknown_550/-1,-1.csv
+codes/General Instruments/Unknown_XRC-200/0,-1.csv
+codes/General/Unknown_VCR/22,-1.csv
 codes/Generic/Unknown_DENON/None,None.csv
 codes/Generic/Unknown_MOTOROLA/-1,-1.csv
 codes/Generic/Unknown_NEC/None,None.csv
@@ -1231,8 +1210,27 @@ codes/Genius/Unknown_Genius-DVB-T32/5,-1.csv
 codes/Genus/Unknown_DU1/128,-1.csv
 codes/Gericom/Plasma/3,-1.csv
 codes/Get/Unknown_gethdpvr/72,36.csv
+codes/GE/TV/15,-1.csv
+codes/GE/VCR/11,-1.csv
+codes/GE/VCR/14,-1.csv
+codes/GE/VCR/26,73.csv
+codes/GE/VCR_VKFS0938/14,-1.csv
 codes/Gigabyte/Unknown_TV/134,107.csv
+codes/Golden Interstar/Sat/128,255.csv
+codes/Golden Interstar/Unknown_Interstar/4,16.csv
+codes/Goldmund/CD Player/20,-1.csv
+codes/GoldStar/Unknown_cd/16,16.csv
+codes/GoldStar/Unknown_GOLDSTAR/4,-1.csv
+codes/GoldStar/Unknown_Goldstar-VCR/110,-1.csv
+codes/GoldStar/Unknown_RN800AW/110,-1.csv
+codes/GoldStar/Unknown_VCR/110,-1.csv
+codes/GoldStar/VCR/110,-1.csv
+codes/Goodmans/Unknown_GDB/8,-1.csv
+codes/Goodmans/Unknown_GDVD124/0,-1.csv
+codes/Goodmans/Unknown_md305/135,108.csv
+codes/Goodmans/Unknown_RC-BM/128,123.csv
 codes/Go Video/DVD Recorder/10,247.csv
+codes/Govideo/Unknown_GoVideoD2730/8,230.csv
 codes/Go Video/VCR/132,98.csv
 codes/Go Video/VCR/5,5.csv
 codes/Go Video/VCR/7,7.csv
@@ -1242,25 +1240,10 @@ codes/Go Video/VCR_DVD Combo/33,-1.csv
 codes/Go Video/VCR_DVD Combo/45,45.csv
 codes/Go Video/VCR_DVD Combo/5,-1.csv
 codes/Go Video/VCR_DVD Combo/5,5.csv
-codes/Golden_interstart/Unknown_Interstart/4,16.csv
-codes/Goldmund/CD Player/20,-1.csv
-codes/GoldStar/Unknown_cd/16,16.csv
-codes/GoldStar/Unknown_GOLDSTAR/110,-1.csv
-codes/GoldStar/Unknown_GOLDSTAR/4,-1.csv
-codes/GoldStar/Unknown_Goldstar-VCR/110,-1.csv
-codes/GoldStar/Unknown_RN800AW/110,-1.csv
-codes/GoldStar/Unknown_TV/None,None.csv
-codes/GoldStar/Unknown_VCR/110,-1.csv
-codes/GoldStar/VCR/110,-1.csv
-codes/Goodmans/Unknown_GDB/8,-1.csv
-codes/Goodmans/Unknown_GDVD124/0,-1.csv
-codes/Goodmans/Unknown_md305/135,108.csv
-codes/Goodmans/Unknown_RC-BM/128,123.csv
-codes/Govideo/Unknown_GoVideoD2730/8,230.csv
 codes/Gradiente/Unknown_D-10/5,-1.csv
 codes/Gradiente/Unknown_GSD-100/132,60.csv
-codes/Gran_prix/Unknown_prix/0,-1.csv
 codes/Grand Tech/Cable Box/2,-1.csv
+codes/Gran Prix/Unknown_prix/0,-1.csv
 codes/Griffin/iPod/212,190.csv
 codes/Grundig/Satellite/1,-1.csv
 codes/Grundig/Satellite/2,-1.csv
@@ -1271,14 +1254,14 @@ codes/Grundig/Unknown_84D/128,-1.csv
 codes/Grundig/Unknown_CDM700.cfg/162,162.csv
 codes/Grundig/Unknown_Grundig/None,None.csv
 codes/Grundig/Unknown_Grundig-TP660/0,-1.csv
-codes/Grundig/Unknown_RC-TP3/8,-1.csv
 codes/Grundig/Unknown_RC8400CD/20,-1.csv
-codes/Grundig/Unknown_RP/5,-1.csv
+codes/Grundig/Unknown_RC-TP3/8,-1.csv
 codes/Grundig/Unknown_RP25/None,None.csv
+codes/Grundig/Unknown_RP/5,-1.csv
 codes/Grundig/Unknown_rp700/5,-1.csv
 codes/Grundig/Unknown_TP/0,-1.csv
-codes/Grundig/Unknown_TP-750C/0,-1.csv
 codes/Grundig/Unknown_tp621/1,-1.csv
+codes/Grundig/Unknown_TP-750C/0,-1.csv
 codes/Grundig/Unknown_UMS9V/162,162.csv
 codes/Grundig/Video Recorder/127,-1.csv
 codes/Gryphon/Integrated Amplifier/16,-1.csv
@@ -1286,7 +1269,7 @@ codes/Guillemot/Unknown_RemoteWizard-GN-263/134,107.csv
 codes/GVC/Unknown_RM-RK50/143,-1.csv
 codes/Hama/Unknown_Internet/0,-1.csv
 codes/Hama/Unknown_PhotoPlayer/134,107.csv
-codes/Hampton_bay/Unknown_Bay/129,102.csv
+codes/Hampton Bay/Unknown_Bay/129,102.csv
 codes/Harman Kardon/Amplifier/128,112.csv
 codes/Harman Kardon/Amplifier/130,114.csv
 codes/Harman Kardon/Blu-Ray/132,116.csv
@@ -1307,8 +1290,8 @@ codes/Harman Kardon/Receiver/132,66.csv
 codes/Harman Kardon/Receiver/134,118.csv
 codes/Harman Kardon/Receiver/161,-1.csv
 codes/Harman Kardon/Receiver/164,-1.csv
-codes/Harman Kardon/Receiver/4,-1.csv
 codes/Harman Kardon/Receiver/40,-1.csv
+codes/Harman Kardon/Receiver/4,-1.csv
 codes/Harman Kardon/Receiver/7,-1.csv
 codes/Harman Kardon/Surround Processor/0,-1.csv
 codes/Harman Kardon/Surround Processor/12,-1.csv
@@ -1328,16 +1311,16 @@ codes/Harman Kardon/Tuner/0,-1.csv
 codes/Harman Kardon/Tuner/128,112.csv
 codes/Harman Kardon/Tuner/130,114.csv
 codes/Harman Kardon/Unknown/130,114.csv
+codes/Harman Kardon/Unknown_DVD/130,114.csv
+codes/Harman Kardon/Unknown_harmankardon/128,112.csv
+codes/Harman Kardon/Unknown_HD730/131,74.csv
+codes/Harman Kardon/Unknown_Kardon-DVD/130,114.csv
 codes/Harman Kardon/Video Projector/0,-1.csv
 codes/Harman Kardon/Video Projector/1,-1.csv
 codes/Harman Kardon/Video Projector/30,-1.csv
 codes/Harman Kardon/Video Projector/7,0.csv
 codes/Harman Video/Video Projector/1,-1.csv
 codes/Harman Video/Video Projector/7,0.csv
-codes/Harman_kardon/Unknown_DVD/130,114.csv
-codes/Harman_kardon/Unknown_harmankardon/128,112.csv
-codes/Harman_kardon/Unknown_HD730/131,74.csv
-codes/Harman_kardon/Unknown_Kardon-DVD/130,114.csv
 codes/Harmony/PS3 Adaptor/11,-1.csv
 codes/Hauppauge/Unknown_DSR-0095/29,-1.csv
 codes/Hauppauge/Unknown_hauppauge-stb/5,-1.csv
@@ -1346,7 +1329,7 @@ codes/Hauppauge/Unknown_R808/30,-1.csv
 codes/Hauppauge/Unknown_WinTV-HVR/4,15.csv
 codes/Hauppauge/Unknown_WinTV-HVR-950Q/29,-1.csv
 codes/HB/Unknown_DIGITAL/0,-1.csv
-codes/Hello_kitty/Unknown_Kitty/0,-1.csv
+codes/Hello Kitty/Unknown_Kitty/0,-1.csv
 codes/HERCULES/Unknown_SMARTTV/None,None.csv
 codes/Herma/Dipper/5,-1.csv
 codes/Hermstedt/Unknown_Hifidelio/16,-1.csv
@@ -1354,8 +1337,8 @@ codes/Hewlett Packard/Plasma/18,17.csv
 codes/Hewlett Packard/Plasma/2,17.csv
 codes/Hewlett Packard/TV/18,17.csv
 codes/Hewlett Packard/TV/2,17.csv
-codes/Hinen_electronics/Unknown_Electronics/0,-1.csv
-codes/Hip_interactive/Unknown_GE1002/0,246.csv
+codes/Hinen Electronics/Unknown_Electronics/0,-1.csv
+codes/Hip Interactive/Unknown_GE1002/0,246.csv
 codes/Hirschmann/Satellite/32,255.csv
 codes/Hirschmann/Unknown_RC426/54,-1.csv
 codes/Hitachi/Cable Box/80,-1.csv
@@ -1375,15 +1358,15 @@ codes/Hitachi/DVD_VCR Combo/44,-1.csv
 codes/Hitachi/LCD/86,171.csv
 codes/Hitachi/Monitor/144,0.csv
 codes/Hitachi/Monitor/80,-1.csv
-codes/Hitachi/Monitor/96,-1.csv
 codes/Hitachi/Monitor/96,158.csv
+codes/Hitachi/Monitor/96,-1.csv
 codes/Hitachi/Monitor/97,-1.csv
-codes/Hitachi/Plasma/80,-1.csv
 codes/Hitachi/Plasma/80,173.csv
+codes/Hitachi/Plasma/80,-1.csv
 codes/Hitachi/TV/12,251.csv
-codes/Hitachi/TV/80,-1.csv
 codes/Hitachi/TV/80,143.csv
 codes/Hitachi/TV/80,173.csv
+codes/Hitachi/TV/80,-1.csv
 codes/Hitachi/TV/96,-1.csv
 codes/Hitachi/Unknown_CLE-941/80,-1.csv
 codes/Hitachi/Unknown_CLE-947/80,-1.csv
@@ -1401,10 +1384,10 @@ codes/Hitachi/VCR/44,-1.csv
 codes/Hitachi/VCR/5,1.csv
 codes/Hitachi/VCR/80,-1.csv
 codes/Hitachi/VCR/83,-1.csv
-codes/Hitachi/VCR/96,-1.csv
 codes/Hitachi/VCR/96,158.csv
-codes/Hitachi/VCR/97,-1.csv
+codes/Hitachi/VCR/96,-1.csv
 codes/Hitachi/VCR/97,159.csv
+codes/Hitachi/VCR/97,-1.csv
 codes/Hitachi/Video Projector/135,69.csv
 codes/Hitachi/Video Projector/80,-1.csv
 codes/Hiteker/DVD Player/0,-1.csv
@@ -1420,7 +1403,7 @@ codes/HP/Unknown_Pavilion/4,15.csv
 codes/HP/Unknown_RC172308-01B/4,15.csv
 codes/HP/Unknown_RC1762302-00/4,17.csv
 codes/HP/Unknown_RC1762307-01/4,15.csv
-codes/HP/Unknown_RC2234302/01B/4,15.csv
+codes/HP/Unknown_RC2234302-01B/4,15.csv
 codes/HQ/Unknown_RC/0,-1.csv
 codes/HQV/Video Processor/128,-1.csv
 codes/Hughes/DSS/1,-1.csv
@@ -1435,8 +1418,6 @@ codes/Hughes/DVR/12,-1.csv
 codes/Hughes/DVR/133,48.csv
 codes/Hughes/HD Satellite HD Tivo/133,48.csv
 codes/Hughes/HD with TiVo/133,48.csv
-codes/Hughes/Sat_TiVo/133,48.csv
-codes/Hughes/Sat_TiVo/210,109.csv
 codes/Hughes/Satellite/1,-1.csv
 codes/Hughes/Satellite/12,-1.csv
 codes/Hughes/Satellite/12,251.csv
@@ -1445,6 +1426,8 @@ codes/Hughes/Satellite/136,-1.csv
 codes/Hughes/Satellite/4,-1.csv
 codes/Hughes/Satellite/60,178.csv
 codes/Hughes/Satellite/71,-1.csv
+codes/Hughes/Sat_TiVo/133,48.csv
+codes/Hughes/Sat_TiVo/210,109.csv
 codes/Hughes/TiVo/133,48.csv
 codes/Hughes/Unknown_b2/12,251.csv
 codes/Hughes/Unknown_DSS/12,251.csv
@@ -1471,7 +1454,6 @@ codes/Humax/Unknown_RS-521/0,16.csv
 codes/huth/Unknown_prof/15,1.csv
 codes/Hyundai/Unknown_H-DVD5038N/0,251.csv
 codes/Hyundai/Unknown_l17t/170,3.csv
-codes/I-O Data/DVD Player/8,230.csv
 codes/I24/Unknown_I24/0,-1.csv
 codes/Illusion/Unknown_M3/22,-1.csv
 codes/Imerge/Digital Jukebox/14,-1.csv
@@ -1535,23 +1517,23 @@ codes/Integra/Media PC/4,15.csv
 codes/Integra/Pre-Amplifier/210,108.csv
 codes/Integra/Pre-Amplifier/210,109.csv
 codes/Integra/Pre-Amplifier/210,172.csv
-codes/Integra/Pre-Amplifier/210,2.csv
 codes/Integra/Pre-Amplifier/210,25.csv
+codes/Integra/Pre-Amplifier/210,2.csv
 codes/Integra/Pre-Amplifier/210,30.csv
-codes/Integra/Receiver/210,1.csv
 codes/Integra/Receiver/210,108.csv
 codes/Integra/Receiver/210,109.csv
-codes/Integra/Receiver/210,17.csv
 codes/Integra/Receiver/210,172.csv
+codes/Integra/Receiver/210,17.csv
 codes/Integra/Receiver/210,18.csv
 codes/Integra/Receiver/210,19.csv
-codes/Integra/Receiver/210,2.csv
+codes/Integra/Receiver/210,1.csv
 codes/Integra/Receiver/210,20.csv
 codes/Integra/Receiver/210,21.csv
 codes/Integra/Receiver/210,22.csv
 codes/Integra/Receiver/210,23.csv
 codes/Integra/Receiver/210,24.csv
 codes/Integra/Receiver/210,25.csv
+codes/Integra/Receiver/210,2.csv
 codes/Integra/Receiver/210,30.csv
 codes/Integra/Receiver/210,43.csv
 codes/Integra/Tuner/210,109.csv
@@ -1560,11 +1542,13 @@ codes/IntelliNet Controls/Distributed Audio/0,90.csv
 codes/Interact/Unknown_I-22121/0,-1.csv
 codes/Intervideo/VCR/49,-1.csv
 codes/Intervision/Unknown_Intervision/134,107.csv
+codes/I-O Data/DVD Player/8,230.csv
 codes/ione/Unknown_remote/0,-1.csv
 codes/iPort/iPod/1,222.csv
 codes/iPort/iPort/1,222.csv
 codes/iPort/MP3 Player/1,222.csv
 codes/IR4PS3/Blu-Ray/26,35.csv
+codes/Irradio/3331_DVB-T/1,254.csv
 codes/Irradio/Unknown_IrradioHIFI1300V/162,162.csv
 codes/italtel/Unknown_italtel/1,-1.csv
 codes/ITT/Unknown_ITT/49,-1.csv
@@ -1589,16 +1573,16 @@ codes/JVC/Cassette Tape/131,-1.csv
 codes/JVC/CD Jukebox/179,0.csv
 codes/JVC/CD Jukebox/34,33.csv
 codes/JVC/CD Jukebox/34,48.csv
-codes/JVC/CD Player/179,-1.csv
 codes/JVC/CD Player/179,0.csv
+codes/JVC/CD Player/179,-1.csv
 codes/JVC/CD Player/34,33.csv
 codes/JVC/CD Player/34,48.csv
-codes/JVC/D-VHS/67,-1.csv
 codes/JVC/DVD Player/179,-1.csv
 codes/JVC/DVD Player/239,-1.csv
 codes/JVC/DVD Player/26,-1.csv
 codes/JVC/DVD Recorder/111,-1.csv
 codes/JVC/DVD_VCR Combo/67,-1.csv
+codes/JVC/D-VHS/67,-1.csv
 codes/JVC/HD-ILA Projection/115,-1.csv
 codes/JVC/HD-ILA Projection/15,-1.csv
 codes/JVC/HD-ILA Projection/3,-1.csv
@@ -1635,11 +1619,11 @@ codes/JVC/Receiver/3,-1.csv
 codes/JVC/Receiver/34,84.csv
 codes/JVC/Receiver/67,-1.csv
 codes/JVC/Receiver/83,-1.csv
-codes/JVC/S-VHS/67,-1.csv
 codes/JVC/Satellite/0,0.csv
 codes/JVC/Satellite/16,0.csv
 codes/JVC/Satellite/24,0.csv
 codes/JVC/Satellite/8,0.csv
+codes/JVC/S-VHS/67,-1.csv
 codes/JVC/Switcher/243,-1.csv
 codes/JVC/Tuner/131,-1.csv
 codes/JVC/Tuner/147,-1.csv
@@ -1648,14 +1632,14 @@ codes/JVC/Tuner/179,-1.csv
 codes/JVC/Tuner/3,-1.csv
 codes/JVC/Tuner/67,-1.csv
 codes/JVC/TV/15,-1.csv
-codes/JVC/TV/3,-1.csv
 codes/JVC/TV/31,-1.csv
+codes/JVC/TV/3,-1.csv
 codes/JVC/TV/67,-1.csv
 codes/JVC/Unknown_440/179,-1.csv
 codes/JVC/Unknown_JVC/159,-1.csv
+codes/JVC/Unknown_JvcDishPlayer500/3,0.csv
 codes/JVC/Unknown_jvc-lp20465-005-vcr/67,-1.csv
 codes/JVC/Unknown_JVC-RM-C475W/3,-1.csv
-codes/JVC/Unknown_JvcDishPlayer500/3,0.csv
 codes/JVC/Unknown_LP20106-002/67,-1.csv
 codes/JVC/Unknown_PQ10543/83,-1.csv
 codes/JVC/Unknown_remote/159,-1.csv
@@ -1683,8 +1667,8 @@ codes/JVC/Unknown_RM-V730U/223,-1.csv
 codes/JVC/Unknown_sw/243,-1.csv
 codes/JVC/Unknown_SXV037J/239,-1.csv
 codes/JVC/VCR/0,14.csv
-codes/JVC/VCR/1,-1.csv
 codes/JVC/VCR/1,14.csv
+codes/JVC/VCR/1,-1.csv
 codes/JVC/VCR/131,-1.csv
 codes/JVC/VCR/163,-1.csv
 codes/JVC/VCR/179,-1.csv
@@ -1692,8 +1676,8 @@ codes/JVC/VCR/3,-1.csv
 codes/JVC/VCR/5,1.csv
 codes/JVC/VCR/64,-1.csv
 codes/JVC/VCR/67,-1.csv
-codes/JVC/VCR/8,14.csv
 codes/JVC/VCR/80,-1.csv
+codes/JVC/VCR/8,14.csv
 codes/JVC/VCR/83,-1.csv
 codes/JVC/VCR DVD Combo/111,-1.csv
 codes/JVC/VCR DVD Combo/3,-1.csv
@@ -1704,7 +1688,7 @@ codes/JVC/Video Projector/131,85.csv
 codes/JVC/Video Switcher/243,-1.csv
 codes/Kaleidescape/Distributed/69,-1.csv
 codes/Kaleidescape/DVD Player/69,-1.csv
-codes/Kanam_accent/Unknown_Accent/None,None.csv
+codes/Kanam Accent/Unknown_Accent/None,None.csv
 codes/Kaon/Unknown_KSC-i260MCO/32,8.csv
 codes/Kaon/Unknown_KTF-100CO/32,8.csv
 codes/Kaon/Unknown_KTF-I2001CO/32,8.csv
@@ -1712,8 +1696,8 @@ codes/Kathrein/DVBS-Receiver/34,144.csv
 codes/Kathrein/Satellite/0,-1.csv
 codes/Kathrein/Satellite/34,144.csv
 codes/Kathrein/Unknown_KathreinUFD400/0,-1.csv
-codes/KAWA/Unknown_TV/11,11.csv
 codes/Kawasaki/DVD_Amp/154,-1.csv
+codes/KAWA/Unknown_TV/11,11.csv
 codes/kendo/Unknown_RC-610/134,124.csv
 codes/KENMORE/Unknown_253-79081/8,245.csv
 codes/Kensington/iPod Dock/51,170.csv
@@ -1727,10 +1711,10 @@ codes/Kenwood/Cassette Tape/184,-1.csv
 codes/Kenwood/CD Changer/182,-1.csv
 codes/Kenwood/CD Changer/182,72.csv
 codes/Kenwood/CD Changer/184,-1.csv
-codes/Kenwood/CD Player/182,-1.csv
-codes/Kenwood/CD Player/182,0.csv
-codes/Kenwood/CD Player/184,-1.csv
 codes/Kenwood/CD_DVD_MP-3/182,12.csv
+codes/Kenwood/CD Player/182,0.csv
+codes/Kenwood/CD Player/182,-1.csv
+codes/Kenwood/CD Player/184,-1.csv
 codes/Kenwood/DVD Changer/182,0.csv
 codes/Kenwood/DVD Changer/182,12.csv
 codes/Kenwood/DVD Player/182,0.csv
@@ -1744,8 +1728,8 @@ codes/Kenwood/Pre-Amplifier/184,1.csv
 codes/Kenwood/Receiver/1,-1.csv
 codes/Kenwood/Receiver/12,-1.csv
 codes/Kenwood/Receiver/182,75.csv
-codes/Kenwood/Receiver/184,-1.csv
 codes/Kenwood/Receiver/184,0.csv
+codes/Kenwood/Receiver/184,-1.csv
 codes/Kenwood/Receiver/184,1.csv
 codes/Kenwood/Receiver/184,2.csv
 codes/Kenwood/Receiver/184,3.csv
@@ -1754,8 +1738,8 @@ codes/Kenwood/Receiver/184,5.csv
 codes/Kenwood/Receiver/184,6.csv
 codes/Kenwood/Receiver/184,7.csv
 codes/Kenwood/Receiver/25,-1.csv
-codes/Kenwood/Receiver/4,-1.csv
 codes/Kenwood/Receiver/40,-1.csv
+codes/Kenwood/Receiver/4,-1.csv
 codes/Kenwood/Satellite Radio/2,255.csv
 codes/Kenwood/Sirius/2,255.csv
 codes/Kenwood/Tuner/182,75.csv
@@ -1793,7 +1777,6 @@ codes/Kinergetics Research/Receiver/0,-1.csv
 codes/Kinergetics Research/Surround Processor/7,-1.csv
 codes/Kiss/Unknown_DP-1500s/25,-1.csv
 codes/Klipsch/Subwoofer/17,81.csv
-codes/Knc_one/Unknown_lircd.conf/None,None.csv
 codes/Knoll/Video Projector/24,233.csv
 codes/konig/Unknown_konig/128,99.csv
 codes/Konka/Unknown_KK-Y199/25,1.csv
@@ -1817,8 +1800,6 @@ codes/Kworld/Unknown_KWorld-DVBT-220/0,251.csv
 codes/Kworld/Unknown_KWorld-DVBT-PE310/0,251.csv
 codes/Kworld/Unknown_VS-PRV-TV/134,107.csv
 codes/Kyocera/CD Player/119,-1.csv
-codes/L+s/Unknown_30755/5,-1.csv
-codes/L+s/Unknown_LS/164,164.csv
 codes/Lacie/Unknown_Lacie/64,64.csv
 codes/Lacie/Unknown_PNE-N1SS/0,127.csv
 codes/Lasonic/Unknown_LasonicR2000/16,-1.csv
@@ -1866,19 +1847,19 @@ codes/LG/Unknown_BC205P/110,-1.csv
 codes/LG/Unknown_BD300/45,45.csv
 codes/LG/Unknown_CC470TW/110,-1.csv
 codes/LG/Unknown_LG/110,-1.csv
-codes/LG/Unknown_LG-AKB69680403/4,-1.csv
-codes/LG/Unknown_LG-EV230/110,-1.csv
 codes/LG/Unknown_LG.6710V00005G/110,-1.csv
 codes/LG/Unknown_LG.6710V00008K/4,-1.csv
+codes/LG/Unknown_LG-AKB69680403/4,-1.csv
+codes/LG/Unknown_LG-EV230/110,-1.csv
 codes/LG/Unknown_MKJ40653807/4,-1.csv
 codes/LG/Unknown_MKJ61842704/4,-1.csv
 codes/LG/Unknown_PBAFA0189A/110,-1.csv
-codes/Life-view/Unknown_3000/96,1.csv
-codes/Life-view/Unknown_flyvideo/96,1.csv
 codes/Lifesat/Unknown_28/128,38.csv
 codes/Lifetec/Unknown_LT9096/128,123.csv
 codes/Lifetec/Unknown_RC2000/5,-1.csv
 codes/Lifetec/Unknown_remote/164,164.csv
+codes/Life-view/Unknown_3000/96,1.csv
+codes/Life-view/Unknown_flyvideo/96,1.csv
 codes/Lightolier/Lighting Controller/0,-1.csv
 codes/Linksys/Media Adapter/134,107.csv
 codes/Linksys/Unknown_WMA11B-R/134,107.csv
@@ -1929,15 +1910,17 @@ codes/Loewe/VCR/144,1.csv
 codes/Loewe/VCR/5,-1.csv
 codes/Logitech/Unknown_HarmonyOne/30,-1.csv
 codes/Logitech/Unknown_z5500/8,-1.csv
-codes/LP Morgan/Screen/0,-1.csv
 codes/Lpi/Unknown_PCremote/71,-1.csv
+codes/LP Morgan/Screen/0,-1.csv
+codes/L+S/Unknown_30755/5,-1.csv
+codes/L+S/Unknown_LS/164,164.csv
 codes/Lumagen/Scaler/2,-1.csv
 codes/Luxman/CD Player/204,-1.csv
 codes/Luxman/Receiver/204,-1.csv
 codes/Luxor/Unknown_DV405/67,71.csv
 codes/LXI/TV/4,-1.csv
-codes/M3_electronic/Unknown_DVD-209/0,-1.csv
-codes/Macro_image_technology/Unknown_MyHD/48,-1.csv
+codes/M3 Electronic/Unknown_DVD-209/0,-1.csv
+codes/Macro Image Technology/Unknown_MyHD/48,-1.csv
 codes/Madrigal/CD Player/0,-1.csv
 codes/Madrigal/CD Player/2,-1.csv
 codes/Madrigal/CD Player/7,-1.csv
@@ -1952,8 +1935,8 @@ codes/Magnavox/DVD Recorder/135,34.csv
 codes/Magnavox/TV/0,-1.csv
 codes/Magnavox/Unknown_UNIFIED6TRANS/0,-1.csv
 codes/Magnavox/VCR/5,-1.csv
-codes/Magnum/Unknown_5520VT/1,-1.csv
 codes/Magnum Dynalab/Tuner/7,-1.csv
+codes/Magnum/Unknown_5520VT/1,-1.csv
 codes/Majestic/Unknown_DVX377USB/0,-1.csv
 codes/Makita/Drapery Controller/2,-1.csv
 codes/Malata/DVD Player/1,-1.csv
@@ -1974,22 +1957,22 @@ codes/Marantz/Cassette Tape/23,-1.csv
 codes/Marantz/CD Changer/20,-1.csv
 codes/Marantz/CD Jukebox/20,-1.csv
 codes/Marantz/CD Player/20,-1.csv
-codes/Marantz/D-VHS/3,-1.csv
-codes/Marantz/D-VHS/67,-1.csv
 codes/Marantz/DVD/4,-1.csv
 codes/Marantz/DVD/69,-1.csv
 codes/Marantz/DVD Player/20,-1.csv
-codes/Marantz/DVD Player/4,-1.csv
 codes/Marantz/DVD Player/41,-1.csv
+codes/Marantz/DVD Player/4,-1.csv
 codes/Marantz/DVD Player/69,-1.csv
+codes/Marantz/D-VHS/3,-1.csv
+codes/Marantz/D-VHS/67,-1.csv
 codes/Marantz/iPod Dock/14,-1.csv
 codes/Marantz/iPod Dock/16,-1.csv
 codes/Marantz/MP3 Player/14,-1.csv
 codes/Marantz/MP3 Player/16,-1.csv
 codes/Marantz/Plasma/0,-1.csv
 codes/Marantz/Plasma/24,-1.csv
-codes/Marantz/Plasma/24,24.csv
 codes/Marantz/Plasma/24,247.csv
+codes/Marantz/Plasma/24,24.csv
 codes/Marantz/Plasma/80,-1.csv
 codes/Marantz/Plasma Displays/24,-1.csv
 codes/Marantz/Plasma Displays/24,24.csv
@@ -2021,29 +2004,29 @@ codes/Marantz/Tuner Section/17,-1.csv
 codes/Marantz/TV/0,-1.csv
 codes/Marantz/TV/144,0.csv
 codes/Marantz/TV/24,-1.csv
-codes/Marantz/TV/24,24.csv
 codes/Marantz/TV/24,247.csv
+codes/Marantz/TV/24,24.csv
 codes/Marantz/TV/80,-1.csv
 codes/Marantz/Unknown_Marantz-RC-63CD/20,-1.csv
-codes/Marantz/Unknown_rc/4,-1.csv
 codes/Marantz/Unknown_RC-1400/4,-1.csv
-codes/Marantz/Unknown_RC-65CD/20,-1.csv
-codes/Marantz/Unknown_RC-72CD/20,-1.csv
 codes/Marantz/Unknown_RC1400-MD/255,255.csv
 codes/Marantz/Unknown_RC4000CD/20,-1.csv
+codes/Marantz/Unknown_rc/4,-1.csv
 codes/Marantz/Unknown_RC4300CC/20,-1.csv
+codes/Marantz/Unknown_RC-65CD/20,-1.csv
+codes/Marantz/Unknown_RC-72CD/20,-1.csv
 codes/Marantz/VCR/134,97.csv
 codes/Marantz/VCR/23,-1.csv
 codes/Marantz/VCR/5,-1.csv
 codes/Marantz/Video Projector/0,-1.csv
 codes/Marantz/Video Projector/13,-1.csv
-codes/Mark/Unknown_rc5/0,-1.csv
 codes/Mark Levinson/CD Player/1,-1.csv
 codes/Mark Levinson/CD Player/16,-1.csv
 codes/Mark Levinson/CD Player/2,-1.csv
 codes/Mark Levinson/CD Player/3,-1.csv
 codes/Mark Levinson/Pre-Amplifier/4,-1.csv
 codes/Mark Levinson/Pre-Amplifier/7,-1.csv
+codes/Mark/Unknown_rc5/0,-1.csv
 codes/Mas/Unknown_HSD-303/0,-1.csv
 codes/Mas/Unknown_HSD-400/0,-1.csv
 codes/Mas/Unknown_RC-0135/6,-1.csv
@@ -2066,8 +2049,8 @@ codes/Medion/Unknown_rc2000/5,-1.csv
 codes/MEGATRON/Unknown_MEGATRON/255,255.csv
 codes/Melectronic/Unknown_PP3600/2,-1.csv
 codes/Meliconi/Unknown_Facile/0,-1.csv
-codes/Meliconi/Unknown_MELICONI-U3/10,-1.csv
 codes/Meliconi/Unknown_MeliconiSpeedy2/5,-1.csv
+codes/Meliconi/Unknown_MELICONI-U3/10,-1.csv
 codes/Meliconi/Unknown_Speedy/7,7.csv
 codes/Memorex/DVD Player/0,-1.csv
 codes/Memorex/TV/4,-1.csv
@@ -2122,8 +2105,8 @@ codes/Mitsubishi/HDTV Receiver/12,251.csv
 codes/Mitsubishi/HDTV Receiver/71,-1.csv
 codes/Mitsubishi/Laser Disc/168,-1.csv
 codes/Mitsubishi/Laser Disc/175,-1.csv
-codes/Mitsubishi/Monitor/1,-1.csv
 codes/Mitsubishi/Monitor/119,-1.csv
+codes/Mitsubishi/Monitor/1,-1.csv
 codes/Mitsubishi/Monitor/130,100.csv
 codes/Mitsubishi/Monitor/2,-1.csv
 codes/Mitsubishi/Monitor/4,-1.csv
@@ -2134,14 +2117,14 @@ codes/Mitsubishi/Receiver/168,-1.csv
 codes/Mitsubishi/Receiver/71,-1.csv
 codes/Mitsubishi/Receiver/87,-1.csv
 codes/Mitsubishi/Satellite/12,251.csv
-codes/Mitsubishi/TV/1,-1.csv
 codes/Mitsubishi/TV/119,-1.csv
+codes/Mitsubishi/TV/1,-1.csv
 codes/Mitsubishi/TV/71,-1.csv
 codes/Mitsubishi/TV/87,-1.csv
 codes/Mitsubishi/Unknown/119,-1.csv
 codes/Mitsubishi/Unknown/71,-1.csv
-codes/Mitsubishi/Unknown/87,-1.csv
 codes/Mitsubishi/Unknown_75501/87,-1.csv
+codes/Mitsubishi/Unknown/87,-1.csv
 codes/Mitsubishi/Unknown_HD1000/240,-1.csv
 codes/Mitsubishi/Unknown_HS-349/87,-1.csv
 codes/Mitsubishi/Unknown_mitsubishi/71,-1.csv
@@ -2149,14 +2132,14 @@ codes/Mitsubishi/Unknown_tv/71,-1.csv
 codes/Mitsubishi/VCR/119,-1.csv
 codes/Mitsubishi/VCR/23,-1.csv
 codes/Mitsubishi/VCR/3,-1.csv
-codes/Mitsubishi/VCR/7,-1.csv
 codes/Mitsubishi/VCR/71,-1.csv
+codes/Mitsubishi/VCR/7,-1.csv
 codes/Mitsubishi/VCR/87,-1.csv
 codes/Mitsubishi/Video Projector/71,-1.csv
 codes/mivar/Unknown_mivar/7,-1.csv
 codes/Monoprice/Unknown_HDX(C)-501E/0,-1.csv
-codes/Morgan's_daytona/Unknown_T15/128,38.csv
-codes/Morgan's_daytona/Unknown_Tornado/202,165.csv
+codes/Morgans Daytona/Unknown_T15/128,38.csv
+codes/Morgans Daytona/Unknown_Tornado/202,165.csv
 codes/Motorola/Cable Box/0,-1.csv
 codes/Motorola/Cable Box/1,-1.csv
 codes/Motorola/Cable Box/15,-1.csv
@@ -2190,14 +2173,14 @@ codes/Motorola/Unknown_MOTOROLA/0,-1.csv
 codes/Motorola/Unknown_QIP2500/0,-1.csv
 codes/Motorola/Unknown_RC1445302-00B-REV2/0,-1.csv
 codes/Motorola/Unknown_VIP/35,64.csv
-codes/MS-Tech/Unknown_HTPC/0,95.csv
-codes/MS-Tech/Unknown_MS-Tech/0,95.csv
 codes/MSI/Unknown_lircd.conf/134,107.csv
 codes/MSI/Unknown_MegaPC/134,107.csv
 codes/MSI/Unknown_PC/134,107.csv
 codes/MSI/Unknown_test/134,107.csv
 codes/mStation/Unknown_mStation/64,175.csv
-codes/Multi_canal/Unknown_Canal/133,123.csv
+codes/MS-Tech/Unknown_HTPC/0,95.csv
+codes/MS-Tech/Unknown_MS-Tech/0,95.csv
+codes/Multi Canal/Unknown_Canal/133,123.csv
 codes/Multichoice/Unknown_DSD910/24,-1.csv
 codes/multiTEC/Unknown_multiTEC/7,-1.csv
 codes/Mustek/Unknown_DVD/16,237.csv
@@ -2243,18 +2226,18 @@ codes/Nakamichi/DVD Player/92,162.csv
 codes/Nakamichi/Receiver/103,-1.csv
 codes/Nakamichi/Receiver/130,93.csv
 codes/Nakamichi/Receiver/186,-1.csv
-codes/Nakamichi/Receiver/92,-1.csv
 codes/Nakamichi/Receiver/92,161.csv
+codes/Nakamichi/Receiver/92,-1.csv
 codes/Nakamichi/Tuner/103,-1.csv
 codes/Nakamichi/Tuner/92,-1.csv
 codes/Nakamichi/Unknown_lirc.config/103,-1.csv
 codes/Napa/Unknown_DAV-309/0,-1.csv
-codes/Nebula_electronics/Unknown_DVB/0,-1.csv
+codes/Nebula Electronics/Unknown_DVB/0,-1.csv
 codes/NEC/Monitor/25,-1.csv
 codes/NEC/Monitor/4,-1.csv
 codes/NEC/Receiver/25,-1.csv
-codes/NEC/Receiver/26,-1.csv
 codes/NEC/Receiver/26,197.csv
+codes/NEC/Receiver/26,-1.csv
 codes/NEC/Receiver/26,225.csv
 codes/NEC/Receiver/26,228.csv
 codes/NEC/Receiver/26,231.csv
@@ -2291,13 +2274,13 @@ codes/NEC/VCR/25,-1.csv
 codes/NEC/VCR/4,-1.csv
 codes/NEC/Video Projector/24,233.csv
 codes/NEC/Video Projector/24,247.csv
-codes/NET TV/TV/2,-1.csv
 codes/Netgem/Unknown_iPlayer/131,51.csv
+codes/NET TV/TV/2,-1.csv
 codes/Nextwave/Unknown_EX300/4,16.csv
 codes/Nikko/Unknown_Nikko/5,-1.csv
 codes/Niles Audio/Unknown/128,93.csv
 codes/Niles Audio/Unknown/132,18.csv
-codes/No_brand/Unknown_YK-001/0,-1.csv
+codes/No Brand/Unknown_YK-001/0,-1.csv
 codes/Nokia/Satellite/24,-1.csv
 codes/Nokia/Satellite/6,-1.csv
 codes/Nokia/Unknown_624/74,-1.csv
@@ -2310,8 +2293,8 @@ codes/Nokia/Unknown_VCR/137,119.csv
 codes/Norcent/Unknown_DP/0,-1.csv
 codes/NorthQ/Unknown_6400/8,-1.csv
 codes/Novaplex/Cable Box/27,-1.csv
-codes/Now_broadband_tv/Unknown_Broadband/128,110.csv
-codes/Now_broadband_tv/Unknown_Broadband/64,64.csv
+codes/Now Broadband TV/Unknown_Broadband/128,110.csv
+codes/Now Broadband TV/Unknown_Broadband/64,64.csv
 codes/NTL/Unknown_DI4001N/10,-1.csv
 codes/NVIDIA/Unknown_Personal/128,126.csv
 codes/oceanic/Unknown_oceanic/1,-1.csv
@@ -2319,30 +2302,30 @@ codes/Olevia/Unknown_RC-LTFN/4,-1.csv
 codes/Olevia/Unknown_RC-LTL/4,185.csv
 codes/Olympus/Unknown_RM-1/134,59.csv
 codes/Olympus/Unknown_RM-2/134,59.csv
-codes/One_for_all/Unknown_7720/0,-1.csv
-codes/One_for_all/Unknown_control-Philips-0081d/0,-1.csv
-codes/One_for_all/Unknown_For/0,-1.csv
-codes/One_for_all/Unknown_For/8,-1.csv
-codes/One_for_all/Unknown_ofa-urc-7550-vcr0150/5,-1.csv
-codes/One_for_all/Unknown_One-For-All/0,-1.csv
-codes/One_for_all/Unknown_Phillips/5,-1.csv
-codes/One_for_all/Unknown_SAT/32,8.csv
-codes/One_for_all/Unknown_URC-2510(12341)/71,-1.csv
-codes/One_for_all/Unknown_URC-3021B00-VCR-0081/5,-1.csv
-codes/One_for_all/Unknown_URC-3440/5,-1.csv
-codes/One_for_all/Unknown_URC-5550/11,-1.csv
-codes/One_for_all/Unknown_URC-6012w/2,-1.csv
-codes/One_for_all/Unknown_URC-7020/5,-1.csv
-codes/One_for_all/Unknown_URC-7240/5,-1.csv
-codes/One_for_all/Unknown_URC-7530/7,-1.csv
-codes/One_for_all/Unknown_URC-7555/0,-1.csv
-codes/One_for_all/Unknown_URC-7562/68,-1.csv
-codes/One_for_all/Unknown_URC-7710/0,-1.csv
-codes/One_for_all/Unknown_URC-8204.1300/32,8.csv
-codes/One_for_all/Unknown_URC-8910/7,-1.csv
-codes/One_for_all/Unknown_urc7562/0,-1.csv
-codes/One_for_all/Unknown_urc7730/0,-1.csv
-codes/One_for_all/Unknown_VCR/113,-1.csv
+codes/One For All/Unknown_7720/0,-1.csv
+codes/One For All/Unknown_control-Philips-0081d/0,-1.csv
+codes/One For All/Unknown_For/0,-1.csv
+codes/One For All/Unknown_For/8,-1.csv
+codes/One For All/Unknown_ofa-urc-7550-vcr0150/5,-1.csv
+codes/One For All/Unknown_One-For-All/0,-1.csv
+codes/One For All/Unknown_Phillips/5,-1.csv
+codes/One For All/Unknown_SAT/32,8.csv
+codes/One For All/Unknown_URC-2510(12341)/71,-1.csv
+codes/One For All/Unknown_URC-3021B00-VCR-0081/5,-1.csv
+codes/One For All/Unknown_URC-3440/5,-1.csv
+codes/One For All/Unknown_URC-5550/11,-1.csv
+codes/One For All/Unknown_URC-6012w/2,-1.csv
+codes/One For All/Unknown_URC-7020/5,-1.csv
+codes/One For All/Unknown_URC-7240/5,-1.csv
+codes/One For All/Unknown_URC-7530/7,-1.csv
+codes/One For All/Unknown_URC-7555/0,-1.csv
+codes/One For All/Unknown_urc7562/0,-1.csv
+codes/One For All/Unknown_URC-7562/68,-1.csv
+codes/One For All/Unknown_URC-7710/0,-1.csv
+codes/One For All/Unknown_urc7730/0,-1.csv
+codes/One For All/Unknown_URC-8204.1300/32,8.csv
+codes/One For All/Unknown_URC-8910/7,-1.csv
+codes/One For All/Unknown_VCR/113,-1.csv
 codes/Onida/Unknown_DFX/0,-1.csv
 codes/Onida/Unknown_TVE/3,-1.csv
 codes/Onkyo/Amplifier/210,108.csv
@@ -2355,6 +2338,9 @@ codes/Onkyo/CD Player/210,13.csv
 codes/Onkyo/CD Player/210,44.csv
 codes/Onkyo/DVD Player/210,43.csv
 codes/Onkyo/DVD Player/69,-1.csv
+codes/Onkyo Integra/DVD Changer/210,43.csv
+codes/Onkyo Integra/Receiver/210,108.csv
+codes/Onkyo Integra/Receiver/210,109.csv
 codes/Onkyo/Laser Disc/168,-1.csv
 codes/Onkyo/Receiver/210,108.csv
 codes/Onkyo/Receiver/210,109.csv
@@ -2375,9 +2361,6 @@ codes/Onkyo/Unknown_rc-252s/210,109.csv
 codes/Onkyo/Unknown_RC-425DV/210,43.csv
 codes/Onkyo/Unknown_RC-50/210,-1.csv
 codes/Onkyo/Unknown_RC-682M/210,43.csv
-codes/Onkyo Integra/DVD Changer/210,43.csv
-codes/Onkyo Integra/Receiver/210,108.csv
-codes/Onkyo Integra/Receiver/210,109.csv
 codes/Optex/Unknown_ORT/0,-1.csv
 codes/orion/Unknown_orion/128,123.csv
 codes/orion/Unknown_orion-RC57/128,126.csv
@@ -2390,15 +2373,15 @@ codes/Pace/Unknown_DI4010I/10,-1.csv
 codes/Pace/Unknown_Digital/0,0.csv
 codes/Pace/Unknown_DS420/16,80.csv
 codes/Pace/Unknown_DS620/132,60.csv
-codes/Pace/Unknown_PACE-RC-10/132,60.csv
 codes/Pace/Unknown_pace900/8,-1.csv
 codes/Pace/Unknown_PaceMSS/1,-1.csv
+codes/Pace/Unknown_PACE-RC-10/132,60.csv
 codes/Pace/Unknown_pacetwin/34,-1.csv
 codes/Pace/Unknown_RC-17/132,60.csv
 codes/Pace/Unknown_RC-30/132,60.csv
 codes/Pace/Unknown_TDS460NNZ/35,128.csv
 codes/Pace/Unknown_xsat/34,-1.csv
-codes/Packard_bell/Unknown_PackBell/16,-1.csv
+codes/Packard Bell/Unknown_PackBell/16,-1.csv
 codes/Palcom/Unknown_DSL-6/192,-1.csv
 codes/palmbutler/Unknown_palmbutler/7,-1.csv
 codes/Panasonic/DVD Player/128,0.csv
@@ -2411,13 +2394,13 @@ codes/Panasonic/DVD Player/160,4.csv
 codes/Panasonic/DVD Player/176,0.csv
 codes/Panasonic/HDTV Tuner/128,2.csv
 codes/Panasonic/Laser Disc/144,64.csv
-codes/Panasonic/Plasma/128,0.csv
-codes/Panasonic/Plasma/128,4.csv
 codes/Panasonic/Receiver/160,0.csv
 codes/Panasonic/Receiver/160,28.csv
 codes/Panasonic/Receiver/160,4.csv
 codes/Panasonic/TV/128,0.csv
+codes/Panasonic/TV/128,1.csv
 codes/Panasonic/TV/128,4.csv
+codes/Panasonic/TV/128,9.csv
 codes/Panasonic/Unknown_AMP/2,32.csv
 codes/Panasonic/Unknown_CARC60EX/129,106.csv
 codes/Panasonic/Unknown_cd/160,194.csv
@@ -2439,12 +2422,12 @@ codes/Panasonic/Unknown_NV-F65/144,0.csv
 codes/Panasonic/Unknown_panas928/160,194.csv
 codes/Panasonic/Unknown_PANASONIC/0,-1.csv
 codes/Panasonic/Unknown_PANASONIC/176,0.csv
+codes/Panasonic/Unknown_panasonic.conf/144,0.csv
 codes/Panasonic/Unknown_Panasonic-EUR571100/144,0.csv
 codes/Panasonic/Unknown_Panasonic-RAK-RX314W/160,194.csv
 codes/Panasonic/Unknown_panasonic-RAX-RX318W/160,194.csv
-codes/Panasonic/Unknown_panasonic.conf/144,0.csv
 codes/Panasonic/Unknown_RAK-RX309W/160,194.csv
-codes/Panasonic/Unknown_RC4346/01B/0,-1.csv
+codes/Panasonic/Unknown_RC4346-01B/0,-1.csv
 codes/Panasonic/Unknown_RX-ED70/160,194.csv
 codes/Panasonic/Unknown_TV/0,-1.csv
 codes/Panasonic/Unknown_VCR/144,1.csv
@@ -2502,9 +2485,9 @@ codes/Philips/Unknown_CD720/20,-1.csv
 codes/Philips/Unknown_CD723/20,-1.csv
 codes/Philips/Unknown_digital/0,-1.csv
 codes/Philips/Unknown_DSX-5500/39,-1.csv
-codes/Philips/Unknown_DVD-724/4,-1.csv
 codes/Philips/Unknown_DVD711/4,-1.csv
 codes/Philips/Unknown_dvd712/4,-1.csv
+codes/Philips/Unknown_DVD-724/4,-1.csv
 codes/Philips/Unknown_DVP-5982/4,-1.csv
 codes/Philips/Unknown_DVP-642/4,-1.csv
 codes/Philips/Unknown_FW2104/134,83.csv
@@ -2515,25 +2498,24 @@ codes/Philips/Unknown_MULTI/6,-1.csv
 codes/Philips/Unknown_PHDVD5/26,154.csv
 codes/Philips/Unknown_PHILIPS/0,-1.csv
 codes/Philips/Unknown_PHILIPS/34,-1.csv
-codes/Philips/Unknown_PHILIPS/SBC-RU-520/5,-1.csv
 codes/Philips/Unknown_Philips-PMDVD6T-Universal-AUX/64,47.csv
 codes/Philips/Unknown_philips-rc2592-MODE-v1/8,-1.csv
 codes/Philips/Unknown_PM725S/27,-1.csv
 codes/Philips/Unknown_R-48F01/20,-1.csv
 codes/Philips/Unknown_RC/0,-1.csv
-codes/Philips/Unknown_RC/20,-1.csv
-codes/Philips/Unknown_RC-2012/4,-1.csv
-codes/Philips/Unknown_RC-5/0,-1.csv
-codes/Philips/Unknown_RC-5/5,-1.csv
-codes/Philips/Unknown_RC-7843/0,-1.csv
 codes/Philips/Unknown_RC19042002/0,-1.csv
 codes/Philips/Unknown_RC19237006/4,-1.csv
-codes/Philips/Unknown_RC19335003/01P/0,-1.csv
+codes/Philips/Unknown_RC19335003-01P/0,-1.csv
+codes/Philips/Unknown_RC-2012/4,-1.csv
+codes/Philips/Unknown_RC/20,-1.csv
 codes/Philips/Unknown_RC2034302/0,-1.csv
 codes/Philips/Unknown_RC2070/0,-1.csv
 codes/Philips/Unknown_RC2582/39,-1.csv
+codes/Philips/Unknown_RC-5/0,-1.csv
+codes/Philips/Unknown_RC-5/5,-1.csv
 codes/Philips/Unknown_RC5-BP6/0,-1.csv
 codes/Philips/Unknown_RC7507/5,-1.csv
+codes/Philips/Unknown_RC-7843/0,-1.csv
 codes/Philips/Unknown_RC7843/0,-1.csv
 codes/Philips/Unknown_RC7925/26,-1.csv
 codes/Philips/Unknown_RC8244/10,-1.csv
@@ -2545,6 +2527,7 @@ codes/Philips/Unknown_RT150/5,-1.csv
 codes/Philips/Unknown_RU120/0,-1.csv
 codes/Philips/Unknown_SBC/0,-1.csv
 codes/Philips/Unknown_SBC/6,-1.csv
+codes/Philips/Unknown_SBC-RU-520/5,-1.csv
 codes/Philips/Unknown_SF172/39,-1.csv
 codes/Philips/Unknown_SRM5100/4,15.csv
 codes/Philips/Unknown_SRU/0,-1.csv
@@ -2557,10 +2540,10 @@ codes/Philips/Unknown_VCR/5,-1.csv
 codes/Philips/Unknown_VR175/5,-1.csv
 codes/Philips/VCR/5,-1.csv
 codes/Phonotrend/Unknown_Prestige/4,-1.csv
-codes/Pinnacle_systems/Unknown_300i/17,20.csv
-codes/Pinnacle_systems/Unknown_800i/7,-1.csv
-codes/Pinnacle_systems/Unknown_PCTV/7,-1.csv
-codes/Pinnacle_systems/Unknown_RC-42D/7,-1.csv
+codes/Pinnacle Systems/Unknown_300i/17,20.csv
+codes/Pinnacle Systems/Unknown_800i/7,-1.csv
+codes/Pinnacle Systems/Unknown_PCTV/7,-1.csv
+codes/Pinnacle Systems/Unknown_RC-42D/7,-1.csv
 codes/Pioneer/Amplifier/162,-1.csv
 codes/Pioneer/Amplifier/164,-1.csv
 codes/Pioneer/Amplifier/165,-1.csv
@@ -2624,12 +2607,12 @@ codes/Provision/Unknown_PRDVD2166/0,153.csv
 codes/PS Audio/CD Player/20,-1.csv
 codes/QUADRAL/Unknown_RC-804/19,1.csv
 codes/Quasar/TV/128,0.csv
-codes/Radio_shack/Unknown_RadioShack/3,1.csv
-codes/Radio_shack/Unknown_Radioshack2115/5,-1.csv
-codes/Radio_shack/Unknown_RS2142/5,-1.csv
+codes/Radio Shack/Unknown_Radioshack2115/5,-1.csv
+codes/Radio Shack/Unknown_RadioShack/3,1.csv
+codes/Radio Shack/Unknown_RS2142/5,-1.csv
 codes/Radix/Unknown_Alpha/138,245.csv
-codes/Radix/Unknown_DT-X1/0,127.csv
 codes/Radix/Unknown_DTR-9000-Twin/0,127.csv
+codes/Radix/Unknown_DT-X1/0,127.csv
 codes/Radix/Unknown_lircd.conf/0,127.csv
 codes/Radix/Unknown_radix/138,245.csv
 codes/Radix/Unknown_SAT/138,245.csv
@@ -2650,7 +2633,6 @@ codes/RCA/Unknown_RCZ/135,94.csv
 codes/RCA/Unknown_TV/15,-1.csv
 codes/RCA/VCR/14,-1.csv
 codes/RCA/VCR/15,-1.csv
-codes/Re.x/Unknown_SDVD/0,-1.csv
 codes/Recor/Unknown_IRC-1304/7,-1.csv
 codes/Rega/Receiver/110,-1.csv
 codes/Rega/Receiver/135,124.csv
@@ -2664,6 +2646,7 @@ codes/Replay Networks/Digital Recorder/1,0.csv
 codes/ReplayTV/Unknown_5000/1,0.csv
 codes/Revo/Unknown_Blik/0,-1.csv
 codes/Revoy/Unknown_Revoy2200/0,153.csv
+codes/Re.x/Unknown_SDVD/0,-1.csv
 codes/Rio/Unknown_Audio/130,19.csv
 codes/roadstar/Unknown_dvd/136,-1.csv
 codes/Roku/Unknown_N1000-04/190,239.csv
@@ -2686,10 +2669,9 @@ codes/Runco/Video Projector/1,-1.csv
 codes/Runco/Video Projector/24,247.csv
 codes/Runco/Video Projector/5,1.csv
 codes/Russound/Music Server/10,-1.csv
-codes/RX-CX1000.a/Unknown_RX-CX1000.a/122,-1.csv
-codes/SAB/Unknown_Explorer/1,-1.csv
 codes/SABA/Unknown_SabaTC460/7,-1.csv
 codes/SABA/Unknown_TC3003/7,-1.csv
+codes/SAB/Unknown_Explorer/1,-1.csv
 codes/Sagem/Unknown_DVB-T-Receiver/135,94.csv
 codes/Sagem/Unknown_HD103-C/135,94.csv
 codes/Sagem/Unknown_Sagem/135,94.csv
@@ -2740,15 +2722,15 @@ codes/Samsung/Unknown_BN59-00940A/7,7.csv
 codes/Samsung/Unknown_BRM-E1E/33,33.csv
 codes/Samsung/Unknown_hifi/0,1.csv
 codes/Samsung/Unknown_HLN507W/7,7.csv
-codes/Samsung/Unknown_MF59/0,-1.csv
 codes/Samsung/Unknown_MF59-00242B/9,9.csv
 codes/Samsung/Unknown_MF59-00291a/32,0.csv
+codes/Samsung/Unknown_MF59/0,-1.csv
 codes/Samsung/Unknown_PR3914/5,5.csv
 codes/Samsung/Unknown_RCD-M70/0,4.csv
+codes/Samsung/Unknown_samsung-10095T/7,7.csv
 codes/Samsung/Unknown_SAMSUNG/102,0.csv
 codes/Samsung/Unknown_SAMSUNG/5,5.csv
 codes/Samsung/Unknown_SAMSUNG/7,7.csv
-codes/Samsung/Unknown_samsung-10095T/7,7.csv
 codes/Samsung/Unknown_SAT/21,-1.csv
 codes/Samsung/Unknown_SFT-702E/64,-1.csv
 codes/Samsung/Unknown_SMT-1000T/64,64.csv
@@ -2779,13 +2761,13 @@ codes/Sanyo/Unknown_RC700/56,-1.csv
 codes/Sanyo/Unknown_Sanyo/49,-1.csv
 codes/Sanyo/Unknown_Sanyo/56,-1.csv
 codes/Sanyo/Unknown_Sanyo-B13509/49,-1.csv
+codes/Sanyo/Unknown_sanyoB13537/49,-1.csv
 codes/Sanyo/Unknown_Sanyo-JXZB/56,-1.csv
 codes/Sanyo/Unknown_sanyo-tv01/56,-1.csv
-codes/Sanyo/Unknown_sanyoB13537/49,-1.csv
 codes/Sanyo/Unknown_TV/56,-1.csv
 codes/Sanyo/Unknown_VCR/49,-1.csv
 codes/Sanyo/Video Projector/48,-1.csv
-codes/Satelco/Unknown_lircd.conf/24,-1.csv
+codes/Satelco/Sat/24,-1.csv
 codes/Schneider/Unknown_FB2000/5,-1.csv
 codes/Schneider/Unknown_RC-193/154,-1.csv
 codes/Schneider/Unknown_RC202/11,11.csv
@@ -2794,10 +2776,10 @@ codes/Schneider/Unknown_RC902/0,-1.csv
 codes/Schwaiger/Unknown_DSR/0,-1.csv
 codes/Scientific Atlanta/Cable Box/27,-1.csv
 codes/Scientific Atlanta/Cable Box/71,-1.csv
-codes/Scientific_atlanta/Unknown_Atlanta-1840/27,-1.csv
-codes/Scientific_atlanta/Unknown_IV/27,-1.csv
-codes/Scientific_atlanta/Unknown_RM9834/27,-1.csv
-codes/Scientific_atlanta/Unknown_SAE8000/27,-1.csv
+codes/Scientific Atlanta/Unknown_Atlanta-1840/27,-1.csv
+codes/Scientific Atlanta/Unknown_IV/27,-1.csv
+codes/Scientific Atlanta/Unknown_RM9834/27,-1.csv
+codes/Scientific Atlanta/Unknown_SAE8000/27,-1.csv
 codes/Scott/Unknown_DVD-838/8,-1.csv
 codes/Scott/Unknown_scott-dvd/4,-1.csv
 codes/SEG/Unknown_E6900-X020A/2,-1.csv
@@ -2806,8 +2788,8 @@ codes/SEG/Unknown_SEG-VCR4300/21,-1.csv
 codes/SEG/Unknown_SR-040/133,115.csv
 codes/SEG/Unknown_SR-201/66,253.csv
 codes/SEG/Unknown_SR800/4,-1.csv
-codes/SEG/Unknown_VCR/21,-1.csv
 codes/SEG/Unknown_VCR2000/134,124.csv
+codes/SEG/Unknown_VCR/21,-1.csv
 codes/Seleco/TV/0,-1.csv
 codes/Seleco/TV/30,-1.csv
 codes/Sencor/Unknown_SFN9011SL/0,252.csv
@@ -2815,6 +2797,7 @@ codes/Sgi/Unknown_SGIMON/26,9.csv
 codes/SHANNON/Unknown_SHANNON/None,None.csv
 codes/Sharp/DTV Decoder/1,-1.csv
 codes/Sharp/Monitor/1,-1.csv
+codes/Sharpsat/Unknown_T28/128,38.csv
 codes/Sharp/TV/1,-1.csv
 codes/Sharp/Unknown_CV-2131CK1/1,-1.csv
 codes/Sharp/Unknown_G0048TA/19,-1.csv
@@ -2828,7 +2811,6 @@ codes/Sharp/Unknown_SHARP/1,-1.csv
 codes/Sharp/Unknown_sharp1781/1,-1.csv
 codes/Sharp/VCR/3,-1.csv
 codes/Sharp/Video Projector/13,-1.csv
-codes/Sharpsat/Unknown_T28/128,38.csv
 codes/Sherwood/Receiver/131,69.csv
 codes/Sherwood/Unknown_CD/255,255.csv
 codes/Sherwood/Unknown_GC-1285/129,114.csv
@@ -2842,10 +2824,10 @@ codes/Sherwood/Unknown_Sherwood-S2770R-CP-II/129,123.csv
 codes/Shinco/Unknown_RC-1730/0,153.csv
 codes/Shuttle/Unknown_mceusb/4,15.csv
 codes/Siemens/Unknown_fb405/134,84.csv
-codes/Siemens/Unknown_siemens-fb400/131,89.csv
 codes/Siemens/Unknown_siemens1/49,-1.csv
+codes/Siemens/Unknown_siemens-fb400/131,89.csv
 codes/Sigma Designs/DVD Player/128,-1.csv
-codes/Sigma_designs/Unknown_SIR/128,-1.csv
+codes/Sigma Designs/Unknown_SIR/128,-1.csv
 codes/Sigmatek/Unknown_X100/8,-1.csv
 codes/Sigmatek/Unknown_XMB-510-PRO/8,-1.csv
 codes/Silvercrest/Unknown_RCH7S52/32,-1.csv
@@ -2854,16 +2836,16 @@ codes/Sirius/Unknown_SBKB-3201KR/128,-1.csv
 codes/Sirius/Unknown_Sportster/1,-1.csv
 codes/Sirius/Unknown_ST2/0,-1.csv
 codes/Sitronics/Unknown_RC-D010E/0,251.csv
-codes/Sky/Unknown_DVB-S/0,12.csv
-codes/Sky/Unknown_rev.4/0,0.csv
 codes/Skymaster/Unknown_2421/2,-1.csv
 codes/Skymaster/Unknown_2424/37,250.csv
 codes/Skymaster/Unknown_DCI/5,-1.csv
 codes/Skymaster/Unknown_skymaster/19,1.csv
 codes/Skymaster/Unknown_SkymasterXLS99/19,1.csv
 codes/Skymaster/Unknown_XL10/6,-1.csv
-codes/Slim_art/Unknown_SA-100/0,-1.csv
-codes/Slim_devices/Unknown_Devices/110,-1.csv
+codes/Sky/Unknown_DVB-S/0,12.csv
+codes/Sky/Unknown_rev.4/0,0.csv
+codes/Slim Art/Unknown_SA-100/0,-1.csv
+codes/Slim Devices/Unknown_Devices/110,-1.csv
 codes/SnapStream/Unknown_Firefly-Mini/0,-1.csv
 codes/Snazio/Unknown_Net/8,230.csv
 codes/Snell/Speaker/80,0.csv
@@ -2892,8 +2874,8 @@ codes/Sony/Digital Recorder/26,154.csv
 codes/Sony/Digital Recorder/26,73.csv
 codes/Sony/Digital Recorder/26,98.csv
 codes/Sony/DSP/26,233.csv
-codes/Sony/DSS/1,-1.csv
 codes/Sony/DSS/11,-1.csv
+codes/Sony/DSS/1,-1.csv
 codes/Sony/DSS/183,-1.csv
 codes/Sony/DSS/23,133.csv
 codes/Sony/DSS/3,-1.csv
@@ -2920,18 +2902,18 @@ codes/Sony/Pre-Amplifier/16,-1.csv
 codes/Sony/Pre-Amplifier/17,-1.csv
 codes/Sony/Pre-Amplifier/18,-1.csv
 codes/Sony/Pre-Amplifier/183,-1.csv
-codes/Sony/Pre-Amplifier/2,-1.csv
 codes/Sony/Pre-Amplifier/20,-1.csv
+codes/Sony/Pre-Amplifier/2,-1.csv
 codes/Sony/Pre-Amplifier/23,-1.csv
 codes/Sony/Pre-Amplifier/26,66.csv
 codes/Sony/Pre-Amplifier/26,73.csv
 codes/Sony/Pre-Amplifier/36,-1.csv
 codes/Sony/Pre-Amplifier/6,-1.csv
 codes/Sony/Pre-Amplifier/7,-1.csv
-codes/Sony/Receiver/1,-1.csv
 codes/Sony/Receiver/11,-1.csv
-codes/Sony/Receiver/12,-1.csv
+codes/Sony/Receiver/1,-1.csv
 codes/Sony/Receiver/121,-1.csv
+codes/Sony/Receiver/12,-1.csv
 codes/Sony/Receiver/13,-1.csv
 codes/Sony/Receiver/144,-1.csv
 codes/Sony/Receiver/15,-1.csv
@@ -2939,8 +2921,8 @@ codes/Sony/Receiver/16,-1.csv
 codes/Sony/Receiver/17,-1.csv
 codes/Sony/Receiver/176,-1.csv
 codes/Sony/Receiver/18,-1.csv
-codes/Sony/Receiver/2,-1.csv
 codes/Sony/Receiver/20,-1.csv
+codes/Sony/Receiver/2,-1.csv
 codes/Sony/Receiver/23,-1.csv
 codes/Sony/Receiver/26,66.csv
 codes/Sony/Receiver/26,73.csv
@@ -2954,8 +2936,8 @@ codes/Sony/Surround Processor/26,233.csv
 codes/Sony/TiVo/183,-1.csv
 codes/Sony/TiVo/23,133.csv
 codes/Sony/TiVo/26,154.csv
-codes/Sony/TV/1,-1.csv
 codes/Sony/TV/119,-1.csv
+codes/Sony/TV/1,-1.csv
 codes/Sony/TV/151,-1.csv
 codes/Sony/TV/164,-1.csv
 codes/Sony/TV/183,-1.csv
@@ -3003,20 +2985,6 @@ codes/Sony/Unknown_RM-PJP1/26,42.csv
 codes/Sony/Unknown_RM-SG20/131,0.csv
 codes/Sony/Unknown_RM-SG5/131,0.csv
 codes/Sony/Unknown_RM-SG7/131,0.csv
-codes/Sony/Unknown_RM-U302/255,255.csv
-codes/Sony/Unknown_rm-v10t/1,-1.csv
-codes/Sony/Unknown_RM-V211T/2,-1.csv
-codes/Sony/Unknown_RM-W101/1,-1.csv
-codes/Sony/Unknown_RM-X30/132,-1.csv
-codes/Sony/Unknown_RM-X40/132,-1.csv
-codes/Sony/Unknown_RM-X42/132,-1.csv
-codes/Sony/Unknown_RM-X47/132,-1.csv
-codes/Sony/Unknown_rm-x95/132,-1.csv
-codes/Sony/Unknown_RM-Y155B/1,-1.csv
-codes/Sony/Unknown_RM-Y173/1,-1.csv
-codes/Sony/Unknown_RM-Y180/1,-1.csv
-codes/Sony/Unknown_RM-Y800/183,-1.csv
-codes/Sony/Unknown_RM-Y812/183,-1.csv
 codes/Sony/Unknown_RMT-136/2,-1.csv
 codes/Sony/Unknown_RMT-506/7,-1.csv
 codes/Sony/Unknown_RMT-B101A/26,226.csv
@@ -3031,6 +2999,20 @@ codes/Sony/Unknown_RMT-V107/11,-1.csv
 codes/Sony/Unknown_RMT-V108-VTR/255,255.csv
 codes/Sony/Unknown_RMT-V270/11,-1.csv
 codes/Sony/Unknown_RMT-V501A/26,83.csv
+codes/Sony/Unknown_RM-U302/255,255.csv
+codes/Sony/Unknown_rm-v10t/1,-1.csv
+codes/Sony/Unknown_RM-V211T/2,-1.csv
+codes/Sony/Unknown_RM-W101/1,-1.csv
+codes/Sony/Unknown_RM-X30/132,-1.csv
+codes/Sony/Unknown_RM-X40/132,-1.csv
+codes/Sony/Unknown_RM-X42/132,-1.csv
+codes/Sony/Unknown_RM-X47/132,-1.csv
+codes/Sony/Unknown_rm-x95/132,-1.csv
+codes/Sony/Unknown_RM-Y155B/1,-1.csv
+codes/Sony/Unknown_RM-Y173/1,-1.csv
+codes/Sony/Unknown_RM-Y180/1,-1.csv
+codes/Sony/Unknown_RM-Y800/183,-1.csv
+codes/Sony/Unknown_RM-Y812/183,-1.csv
 codes/Sony/Unknown_SCPH-10150.irman/255,255.csv
 codes/Sony/Unknown_SONY/1,-1.csv
 codes/Sony/Unknown_SONY/17,-1.csv
@@ -3043,8 +3025,8 @@ codes/Sony/Unknown_tv/2,-1.csv
 codes/Sony/Unknown_VaioRemote/4,15.csv
 codes/Sony/Unknown_VPL-W400/84,-1.csv
 codes/Sony/VCR/0,-1.csv
-codes/Sony/VCR/1,-1.csv
 codes/Sony/VCR/11,-1.csv
+codes/Sony/VCR/1,-1.csv
 codes/Sony/VCR/180,-1.csv
 codes/Sony/VCR/185,-1.csv
 codes/Sony/VCR/186,-1.csv
@@ -3057,19 +3039,20 @@ codes/Sony/VCR/9,-1.csv
 codes/Sony/Video Projector/26,42.csv
 codes/Sony/Video Projector/84,-1.csv
 codes/Speed-link/Unknown_SL-6399/0,-1.csv
-codes/ST/Unknown_DTTRC-4/1,-1.csv
-codes/ST/Unknown_HMP/8,-1.csv
 codes/starhub/Unknown_starhub/33,144.csv
 codes/Starsat/Unknown_120/64,64.csv
 codes/Starview/Unknown_Starview/0,249.csv
 codes/Streamzap/Unknown_PC/35,-1.csv
+codes/Strong/8821_DVB-T/2,2.csv
 codes/STRONG/Unknown_STRONG/128,119.csv
+codes/ST/Unknown_DTTRC-4/1,-1.csv
+codes/ST/Unknown_HMP/8,-1.csv
 codes/Sumvision/Unknown_Sumvision/0,-1.csv
-codes/sun/Unknown_sun/26,9.csv
 codes/Sunfire/Surround Processor/184,0.csv
 codes/Sunfire/Surround Processor/184,1.csv
 codes/Sunfire/Surround Processor/184,3.csv
 codes/Sungale/Unknown_JX-2002/0,-1.csv
+codes/sun/Unknown_sun/26,9.csv
 codes/Supermax/Unknown_Supermax/128,38.csv
 codes/SUPERSQNY/Unknown_KM-168/0,-1.csv
 codes/Supportplus/Unknown_SP-URC-LCD-F15/10,-1.csv
@@ -3079,7 +3062,7 @@ codes/Syabas/Unknown_A-100/4,203.csv
 codes/Symphonic/TV/41,-1.csv
 codes/Symphonic/VCR/40,-1.csv
 codes/Symphonic/VCR/44,-1.csv
-codes/Tab_electronics/Unknown_Kit/0,-1.csv
+codes/Tab Electronics/Unknown_Kit/0,-1.csv
 codes/TCM/Unknown_212845-CD/5,-1.csv
 codes/TCM/Unknown_218681/5,5.csv
 codes/TCM/Unknown_225925/24,233.csv
@@ -3105,9 +3088,9 @@ codes/TECHNICS/Unknown_sl-ps670a/160,10.csv
 codes/TECHNISAT/Unknown_100TS035/10,-1.csv
 codes/TECHNISAT/Unknown_FBPNA35/10,-1.csv
 codes/TECHNISAT/Unknown_FBPVR335A/10,-1.csv
-codes/TECHNISAT/Unknown_st-6000e/131,121.csv
 codes/TECHNISAT/Unknown_ST3002S/1,-1.csv
 codes/TECHNISAT/Unknown_ST3004S/1,-1.csv
+codes/TECHNISAT/Unknown_st-6000e/131,121.csv
 codes/TECHNISAT/Unknown_TECHNISAT/1,-1.csv
 codes/TECHNISAT/Unknown_TTS35AI/10,-1.csv
 codes/TECHNISAT/Unknown_TTS35AI.conf/10,-1.csv
@@ -3118,11 +3101,11 @@ codes/Technotrend/Unknown_remote/21,-1.csv
 codes/Technotrend/Unknown_S2400/21,-1.csv
 codes/Technotrend/Unknown_Technotrend/21,-1.csv
 codes/Tekram/Unknown_M230/None,None.csv
-codes/TELEFUNKEN/Unknown_1127/7,-1.csv
-codes/TELEFUNKEN/Unknown_FB1550/67,-1.csv
-codes/TELEFUNKEN/Unknown_IR3000/0,1.csv
-codes/TELEFUNKEN/Unknown_RC1323-Video-B/8,-1.csv
-codes/TELEFUNKEN/Unknown_TVRC-1345/5,-1.csv
+codes/TELEFUNKEN/AUDIO_IR3000/0,1.csv
+codes/TELEFUNKEN/TV_1127/7,-1.csv
+codes/TELEFUNKEN/TV_RC-1345/5,-1.csv
+codes/TELEFUNKEN/VCR_FB1550/67,-1.csv
+codes/TELEFUNKEN/VCR_RC1323-Video-B/8,-1.csv
 codes/Teleka/Unknown_STR2060/1,-1.csv
 codes/Telemann/PC HDTV Tuner Card/8,-1.csv
 codes/Televes/Unknown_145075/8,-1.csv
@@ -3153,9 +3136,9 @@ codes/Tevion/Unknown_TDR-250HD/0,159.csv
 codes/Tevion/Unknown_TDR51DV/0,159.csv
 codes/Tevion/Unknown_TE-0603/64,63.csv
 codes/Tevion/Unknown_TEV1020/0,-1.csv
+codes/Tevion/Unknown_TevionMd3607/7,-1.csv
 codes/Tevion/Unknown_Tevion-MD80383/5,5.csv
 codes/Tevion/Unknown_Tevion-MD81035-ASAT-Code-0905/23,105.csv
-codes/Tevion/Unknown_TevionMd3607/7,-1.csv
 codes/Theta Digital/DVD Player/163,-1.csv
 codes/Theta Digital/DVD Player/175,-1.csv
 codes/Theta Digital/Surround Processor/16,-1.csv
@@ -3165,10 +3148,10 @@ codes/Thomson/Unknown_230/0,-1.csv
 codes/Thomson/Unknown_RCS615TCLM1/5,-1.csv
 codes/Thomson/Unknown_TM9258/128,255.csv
 codes/Thomson/Unknown_TV/7,-1.csv
+codes/Tivoli/Unknown_Sirius/0,-1.csv
 codes/TiVo/PVR/26,154.csv
 codes/TiVo/TiVo/133,48.csv
 codes/TiVo/Unknown_Series1/133,48.csv
-codes/Tivoli/Unknown_Sirius/0,-1.csv
 codes/Tokai/Unknown_DVD-715/32,-1.csv
 codes/Topfield/Unknown_PVR/32,-1.csv
 codes/Topfield/Unknown_TF4000Fi/4,255.csv
@@ -3210,8 +3193,8 @@ codes/Toshiba/Unknown_VT-204G/68,-1.csv
 codes/Toshiba/Unknown_VT-209W/68,-1.csv
 codes/Toshiba/Unknown_VT-75F/68,-1.csv
 codes/Toshiba/VCR/68,-1.csv
-codes/Total_control/Unknown_Control/7,-1.csv
-codes/Total_media_in_hand/Unknown_Media/2,189.csv
+codes/Total Control/Unknown_Control/7,-1.csv
+codes/Total Media In Hand/Unknown_Media/2,189.csv
 codes/Traxis/Unknown_3500/4,-1.csv
 codes/TRIAX/Unknown_DVB/10,-1.csv
 codes/Trice/Unknown_TR-302/1,254.csv
@@ -3249,16 +3232,14 @@ codes/Universal/Unknown_RZ-55/1,-1.csv
 codes/Universal/Unknown_testrecord.config/0,-1.csv
 codes/Universal/Unknown_tv/1,-1.csv
 codes/Universal/Unknown_URC-6012w/2,-1.csv
-codes/universum/Unknown_SAT/97,135.csv
-codes/universum/Unknown_SR420/15,-1.csv
+codes/universum/SAT/97,135.csv
+codes/universum/SAT_SR420/15,-1.csv
 codes/universum/Unknown_universum/0,-1.csv
 codes/universum/Unknown_universum/16,16.csv
-codes/universum/Unknown_vcr/128,123.csv
-codes/universum/Unknown_video/128,123.csv
-codes/universum/Unknown_VR743A/5,-1.csv
+codes/universum/VCR/128,123.csv
+codes/universum/VCR_VR743A/5,-1.csv
 codes/UPC/Unknown_SAT/39,-1.csv
 codes/US Electronics/Cable Box/0,-1.csv
-codes/Users/user/lirc-remotes/yamaha/Unknown_RX-CX1000.a/122,-1.csv
 codes/Velodyne/Subwoofer/0,69.csv
 codes/Venturer/Unknown_boombox/129,129.csv
 codes/Venturer/Unknown_STB7766G1/66,187.csv
@@ -3346,8 +3327,8 @@ codes/Yamaha/Music Server/128,55.csv
 codes/Yamaha/Plasma/80,-1.csv
 codes/Yamaha/Projector/209,-1.csv
 codes/Yamaha/Projector/240,-1.csv
-codes/Yamaha/Receiver/0,-1.csv
 codes/Yamaha/Receiver/0,0.csv
+codes/Yamaha/Receiver/0,-1.csv
 codes/Yamaha/Receiver/120,-1.csv
 codes/Yamaha/Receiver/121,-1.csv
 codes/Yamaha/Receiver/122,-1.csv
@@ -3377,15 +3358,14 @@ codes/Yamaha/Unknown_RAV16/122,-1.csv
 codes/Yamaha/Unknown_RAV207/122,-1.csv
 codes/Yamaha/Unknown_rax9/122,-1.csv
 codes/Yamaha/Unknown_RCX/122,-1.csv
-codes/Yamaha/Unknown_RCX-750/122,-1.csv
 codes/Yamaha/Unknown_RCX2/122,-1.csv
 codes/Yamaha/Unknown_RCX660/122,-1.csv
+codes/Yamaha/Unknown_RCX-750/122,-1.csv
 codes/Yamaha/Unknown_receiver/122,-1.csv
 codes/Yamaha/Unknown_RS-CD5/121,-1.csv
 codes/Yamaha/Unknown_RS-CX600/122,-1.csv
 codes/Yamaha/Unknown_RS-K3/127,-1.csv
 codes/Yamaha/Unknown_RX-450/122,-1.csv
-codes/Yamaha/Unknown_RX-CX1000.a/122,-1.csv
 codes/Yamaha/Unknown_RX-CX800/122,-1.csv
 codes/Yamaha/Unknown_RX-V850/122,-1.csv
 codes/Yamaha/Unknown_TX-1000/209,-1.csv
@@ -3402,10 +3382,10 @@ codes/Yamaha/Unknown_VQ95010/121,-1.csv
 codes/Yamaha/Unknown_VR81350/123,-1.csv
 codes/Yamaha/Unknown_vu50620/120,-1.csv
 codes/Yamaha/Unknown_VU71330/121,-1.csv
-codes/Yamaha/Unknown_Y-TV-1004/4,-1.csv
 codes/Yamaha/Unknown_YAMAHA/122,-1.csv
 codes/Yamaha/Unknown_yamaha-amp/122,-1.csv
 codes/Yamaha/Unknown_yamaha-rax7/122,-1.csv
+codes/Yamaha/Unknown_Y-TV-1004/4,-1.csv
 codes/Yamaha/Video Projector/209,-1.csv
 codes/Yamakawa/DVD Player/32,-1.csv
 codes/Yamakawa/Unknown_dvd285vga/32,-1.csv


### PR DESCRIPTION
The indexes are currently years out of date, yet the README advertises using it.
I have recompiled the indexes and updated the shellscript to output in an alphabetically sorted format.

A future improvement would be unifying the two indexes into one, but I don't want to risk breaking usage of this repo in production.