### PR TITLE
Added link to DIYRemote Android app in the Examples section

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ https://cdn.jsdelivr.net/gh/probonopd/irdb@master/codes/Samsung/TV/7,7.csv
 In this section, projects and products will be listed which include or access irdb.
 * [irdb.tk](http://irdb.tk) website that allows you to search the database and render codes in various formats
 * [IrScrutinizer](https://github.com/bengtmartensson/harctoolboxbundle) software that can import infrared remote signals from irdb, scrutinize them, and send them using various sending devices
+* [DIYRemote](https://github.com/shannah/DIYRemote) Android app that allows you to browse the [irdb.tk](http://irdb.tk) website and test the IR codes live on Android devices that have an IR emitter.  Also allows you to create your own custom universal remote controls using HTML.
 
 ## License
 


### PR DESCRIPTION
I created an Android app that allows you to browse the irdb website and test the codes live inside the app on Android devices that have an IR emitter.   I think this would be useful to the community so I have added a link to the Github repository for the app in the Examples section of the README.