### PR TITLE
Replace meaningless protocol XMP-1/2 by either XMP-1 or XMP-2.

### DIFF
--- a/codes/ADB/Set Top Box/42,17.csv
+++ b/codes/ADB/Set Top Box/42,17.csv
@@ -1,5 +1,5 @@
 functionname,protocol,device,subdevice,function
-TV/RADIO,XMP-1/2,42,17,0
+TV/RADIO,XMP-1,42,17,0
 2,XMP-1,42,17,1
 3,XMP-1,42,17,2
 4,XMP-1,42,17,3

--- a/codes/Comcast/Cable Box/62,16.csv
+++ b/codes/Comcast/Cable Box/62,16.csv
@@ -1,6 +1,6 @@
 functionname,protocol,device,subdevice,function
-0,XMP-1/2,62,16,0
-4 - TEST 3 - ADJ 1ST,XMP-1/2,62,16,0
+0,XMP-1,62,16,0
+4 - TEST 3 - ADJ 1ST,XMP-1,62,16,0
 1,XMP-1,62,16,1
 2,XMP-1,62,16,2
 3,XMP-1,62,16,3

--- a/codes/Dream/Satellite/10,0.csv
+++ b/codes/Dream/Satellite/10,0.csv
@@ -1,5 +1,5 @@
 functionname,protocol,device,subdevice,function
-0,XMP-1/2,10,0,0
+0,XMP-1,10,0,0
 5,XMP-1,10,0,4
 VIDEO,XMP-1,10,0,39
 ,XMP-1,10,0,68

--- a/codes/Dream/Satellite/26,0.csv
+++ b/codes/Dream/Satellite/26,0.csv
@@ -1,6 +1,6 @@
 functionname,protocol,device,subdevice,function
-0,XMP-1/2,26,0,0
-DIGIT 0,XMP-1/2,26,0,0
+0,XMP-1,26,0,0
+DIGIT 0,XMP-1,26,0,0
 1,XMP-1,26,0,1
 DIGIT 1,XMP-1,26,0,1
 ,XMP-1,26,0,2

--- a/codes/Escient/CD Jukebox/15,0.csv
+++ b/codes/Escient/CD Jukebox/15,0.csv
@@ -1,5 +1,5 @@
 functionname,protocol,device,subdevice,function
-0,XMP-1/2,15,0,0
+0,XMP-2,15,0,0
 1,XMP-2,15,0,1
 2,XMP-2,15,0,2
 6,XMP-2,15,0,6

--- a/codes/Escient/CD Management/14,0.csv
+++ b/codes/Escient/CD Management/14,0.csv
@@ -1,5 +1,5 @@
 functionname,protocol,device,subdevice,function
-0,XMP-1/2,14,0,0
+0,XMP-2,14,0,0
 1,XMP-2,14,0,1
 2,XMP-2,14,0,2
 3,XMP-2,14,0,3

--- a/codes/Escient/Digital Jukebox/15,0.csv
+++ b/codes/Escient/Digital Jukebox/15,0.csv
@@ -1,5 +1,5 @@
 functionname,protocol,device,subdevice,function
-0,XMP-1/2,15,0,0
+0,XMP-2,15,0,0
 1,XMP-2,15,0,1
 2,XMP-2,15,0,2
 3,XMP-2,15,0,3

--- a/codes/Escient/Hard Drive Recorder/15,0.csv
+++ b/codes/Escient/Hard Drive Recorder/15,0.csv
@@ -1,5 +1,5 @@
 functionname,protocol,device,subdevice,function
-0,XMP-1/2,15,0,0
+0,XMP-2,15,0,0
 1,XMP-2,15,0,1
 2,XMP-2,15,0,2
 3,XMP-2,15,0,3

--- a/codes/Escient/Media Manager/15,0.csv
+++ b/codes/Escient/Media Manager/15,0.csv
@@ -1,5 +1,5 @@
 functionname,protocol,device,subdevice,function
-0,XMP-1/2,15,0,0
+0,XMP-2,15,0,0
 1,XMP-2,15,0,1
 2,XMP-2,15,0,2
 3,XMP-2,15,0,3

--- a/codes/Motorola/Cable Box/18,0.csv
+++ b/codes/Motorola/Cable Box/18,0.csv
@@ -1,5 +1,5 @@
 functionname,protocol,device,subdevice,function
-0,XMP-1/2,18,0,0
+0,XMP-1,18,0,0
 1,XMP-1,18,0,1
 2,XMP-1,18,0,2
 3,XMP-1,18,0,3


### PR DESCRIPTION
DecodeIR generates "XMP-1/2" for incomplete signals. It is not renderable. From the context, it is clear that it should be either XMP-1 or XMP-2.