### PR TITLE
Change non-renderable protocols G.I. Cable & G.I. Cable[1} to G.I.Cable.

### DIFF
--- a/codes/Adelphia/Cable Box/0,-1.csv
+++ b/codes/Adelphia/Cable Box/0,-1.csv
@@ -1,30 +1,30 @@
 functionname,protocol,device,subdevice,function
-0,G.I. Cable,0,-1,0
-1,G.I. Cable,0,-1,1
-2,G.I. Cable,0,-1,2
-3,G.I. Cable,0,-1,3
-4,G.I. Cable,0,-1,4
-5,G.I. Cable,0,-1,5
-6,G.I. Cable,0,-1,6
-7,G.I. Cable,0,-1,7
-8,G.I. Cable,0,-1,8
-9,G.I. Cable,0,-1,9
-POWER,G.I. Cable,0,-1,10
-CH+,G.I. Cable,0,-1,11
-CH-,G.I. Cable,0,-1,12
-MUSIC/ENTER,G.I. Cable,0,-1,16
-OK,G.I. Cable,0,-1,17
-EXIT,G.I. Cable,0,-1,18
-LAST,G.I. Cable,0,-1,19
-FAVORITE,G.I. Cable,0,-1,21
-MENU,G.I. Cable,0,-1,25
-GUIDE,G.I. Cable,0,-1,48
-INFO,G.I. Cable,0,-1,51
-UP,G.I. Cable,0,-1,52
-DOWN,G.I. Cable,0,-1,53
-LEFT,G.I. Cable,0,-1,54
-RIGHT,G.I. Cable,0,-1,55
-DAY+,G.I. Cable,0,-1,56
-DAY-,G.I. Cable,0,-1,57
-PAGE-,G.I. Cable,0,-1,58
-PAGE+,G.I. Cable,0,-1,59
+0,G.I.Cable,0,-1,0
+1,G.I.Cable,0,-1,1
+2,G.I.Cable,0,-1,2
+3,G.I.Cable,0,-1,3
+4,G.I.Cable,0,-1,4
+5,G.I.Cable,0,-1,5
+6,G.I.Cable,0,-1,6
+7,G.I.Cable,0,-1,7
+8,G.I.Cable,0,-1,8
+9,G.I.Cable,0,-1,9
+POWER,G.I.Cable,0,-1,10
+CH+,G.I.Cable,0,-1,11
+CH-,G.I.Cable,0,-1,12
+MUSIC/ENTER,G.I.Cable,0,-1,16
+OK,G.I.Cable,0,-1,17
+EXIT,G.I.Cable,0,-1,18
+LAST,G.I.Cable,0,-1,19
+FAVORITE,G.I.Cable,0,-1,21
+MENU,G.I.Cable,0,-1,25
+GUIDE,G.I.Cable,0,-1,48
+INFO,G.I.Cable,0,-1,51
+UP,G.I.Cable,0,-1,52
+DOWN,G.I.Cable,0,-1,53
+LEFT,G.I.Cable,0,-1,54
+RIGHT,G.I.Cable,0,-1,55
+DAY+,G.I.Cable,0,-1,56
+DAY-,G.I.Cable,0,-1,57
+PAGE-,G.I.Cable,0,-1,58
+PAGE+,G.I.Cable,0,-1,59

--- a/codes/Comcast/Cable Box/0,-1.csv
+++ b/codes/Comcast/Cable Box/0,-1.csv
@@ -1,90 +1,90 @@
 functionname,protocol,device,subdevice,function
-0,G.I. Cable,0,-1,0
-,G.I. Cable,0,-1,0
-ON DEMAND,G.I. Cable,0,-1,0
-1,G.I. Cable,0,-1,1
-ON DEMAND,G.I. Cable,0,-1,1
-PPV,G.I. Cable,0,-1,1
-2,G.I. Cable,0,-1,2
-PPV,G.I. Cable,0,-1,2
-PPV INFO,G.I. Cable,0,-1,2
-C,G.I. Cable,0,-1,2
-3,G.I. Cable,0,-1,3
-4,G.I. Cable,0,-1,4
-5,G.I. Cable,0,-1,5
-6,G.I. Cable,0,-1,6
-7,G.I. Cable,0,-1,7
-8,G.I. Cable,0,-1,8
-9,G.I. Cable,0,-1,9
-,G.I. Cable,0,-1,9
-POWER,G.I. Cable,0,-1,10
-CH UP,G.I. Cable,0,-1,11
-CHANNEL +,G.I. Cable,0,-1,11
-CH DN,G.I. Cable,0,-1,12
-CHANNEL -,G.I. Cable,0,-1,12
-ENTER,G.I. Cable,0,-1,16
-ENTER / MUSIC,G.I. Cable,0,-1,16
-ENTER #PAD,G.I. Cable,0,-1,16
-OK/SELECT,G.I. Cable,0,-1,17
-,G.I. Cable,0,-1,17
-SELECT,G.I. Cable,0,-1,17
-OK / SELECT,G.I. Cable,0,-1,17
-ENTER,G.I. Cable,0,-1,17
-EXIT,G.I. Cable,0,-1,18
-LAST,G.I. Cable,0,-1,19
-INPUT TV/VCR,G.I. Cable,0,-1,20
-TV/VCR,G.I. Cable,0,-1,20
-FAV,G.I. Cable,0,-1,21
-A,G.I. Cable,0,-1,22
-MENU,G.I. Cable,0,-1,25
-PLAY,G.I. Cable,0,-1,27
-PLAY,G.I. Cable{1},0,-1,27
-STOP,G.I. Cable,0,-1,28
-STOP,G.I. Cable{1},0,-1,28
-FF,G.I. Cable,0,-1,29
-FFWD,G.I. Cable,0,-1,29
-FF,G.I. Cable{1},0,-1,29
-FAST FOWARD,G.I. Cable,0,-1,29
-RW,G.I. Cable,0,-1,30
-REWIND,G.I. Cable,0,-1,30
-REW,G.I. Cable{1},0,-1,30
-REW,G.I. Cable,0,-1,30
-PAUSE,G.I. Cable,0,-1,31
-PAUSE,G.I. Cable{1},0,-1,31
-TUNER JUMP,G.I. Cable,0,-1,35
-SWAP,G.I. Cable,0,-1,35
-GUIDE,G.I. Cable,0,-1,48
-RECORD,G.I. Cable,0,-1,49
-HELP[,G.I. Cable,0,-1,50
-HELP,G.I. Cable,0,-1,50
-INFO,G.I. Cable,0,-1,51
-UP,G.I. Cable,0,-1,52
-ARROW UP,G.I. Cable,0,-1,52
-CURSOR UP,G.I. Cable,0,-1,52
-DN,G.I. Cable,0,-1,53
-ARROW DOWN,G.I. Cable,0,-1,53
-CURSOR DOWN,G.I. Cable,0,-1,53
-DOWN,G.I. Cable,0,-1,53
-LEFT,G.I. Cable,0,-1,54
-ARROW LEFT,G.I. Cable,0,-1,54
-CURSOR LEFT,G.I. Cable,0,-1,54
-RIGHT,G.I. Cable,0,-1,55
-ARROW RIGHT,G.I. Cable,0,-1,55
-CURSOR RIGHT,G.I. Cable,0,-1,55
-PLAY,G.I. Cable,0,-1,56
-STOP,G.I. Cable,0,-1,57
-PAGE UP,G.I. Cable,0,-1,58
-PAGE DOWN,G.I. Cable,0,-1,58
-PAGE +,G.I. Cable,0,-1,58
-PAGE DN,G.I. Cable,0,-1,59
-PAGE UP,G.I. Cable,0,-1,59
-PAGE -,G.I. Cable,0,-1,59
-PAGE DOWN,G.I. Cable,0,-1,59
-REPLAY,G.I. Cable,0,-1,60
-REPLAY,G.I. Cable{1},0,-1,60
-MY DVR,G.I. Cable,0,-1,61
-LIVE TV,G.I. Cable,0,-1,62
-LIVE,G.I. Cable,0,-1,62
-30 SECOND SKIP,G.I. Cable,0,-1,63
-SKIP 30 SECONDS,G.I. Cable,0,-1,63
-ENTER,G.I. Cable,0,-1,64
+0,G.I.Cable,0,-1,0
+,G.I.Cable,0,-1,0
+ON DEMAND,G.I.Cable,0,-1,0
+1,G.I.Cable,0,-1,1
+ON DEMAND,G.I.Cable,0,-1,1
+PPV,G.I.Cable,0,-1,1
+2,G.I.Cable,0,-1,2
+PPV,G.I.Cable,0,-1,2
+PPV INFO,G.I.Cable,0,-1,2
+C,G.I.Cable,0,-1,2
+3,G.I.Cable,0,-1,3
+4,G.I.Cable,0,-1,4
+5,G.I.Cable,0,-1,5
+6,G.I.Cable,0,-1,6
+7,G.I.Cable,0,-1,7
+8,G.I.Cable,0,-1,8
+9,G.I.Cable,0,-1,9
+,G.I.Cable,0,-1,9
+POWER,G.I.Cable,0,-1,10
+CH UP,G.I.Cable,0,-1,11
+CHANNEL +,G.I.Cable,0,-1,11
+CH DN,G.I.Cable,0,-1,12
+CHANNEL -,G.I.Cable,0,-1,12
+ENTER,G.I.Cable,0,-1,16
+ENTER / MUSIC,G.I.Cable,0,-1,16
+ENTER #PAD,G.I.Cable,0,-1,16
+OK/SELECT,G.I.Cable,0,-1,17
+,G.I.Cable,0,-1,17
+SELECT,G.I.Cable,0,-1,17
+OK / SELECT,G.I.Cable,0,-1,17
+ENTER,G.I.Cable,0,-1,17
+EXIT,G.I.Cable,0,-1,18
+LAST,G.I.Cable,0,-1,19
+INPUT TV/VCR,G.I.Cable,0,-1,20
+TV/VCR,G.I.Cable,0,-1,20
+FAV,G.I.Cable,0,-1,21
+A,G.I.Cable,0,-1,22
+MENU,G.I.Cable,0,-1,25
+PLAY,G.I.Cable,0,-1,27
+PLAY,G.I.Cable,0,-1,27
+STOP,G.I.Cable,0,-1,28
+STOP,G.I.Cable,0,-1,28
+FF,G.I.Cable,0,-1,29
+FFWD,G.I.Cable,0,-1,29
+FF,G.I.Cable,0,-1,29
+FAST FOWARD,G.I.Cable,0,-1,29
+RW,G.I.Cable,0,-1,30
+REWIND,G.I.Cable,0,-1,30
+REW,G.I.Cable,0,-1,30
+REW,G.I.Cable,0,-1,30
+PAUSE,G.I.Cable,0,-1,31
+PAUSE,G.I.Cable,0,-1,31
+TUNER JUMP,G.I.Cable,0,-1,35
+SWAP,G.I.Cable,0,-1,35
+GUIDE,G.I.Cable,0,-1,48
+RECORD,G.I.Cable,0,-1,49
+HELP[,G.I.Cable,0,-1,50
+HELP,G.I.Cable,0,-1,50
+INFO,G.I.Cable,0,-1,51
+UP,G.I.Cable,0,-1,52
+ARROW UP,G.I.Cable,0,-1,52
+CURSOR UP,G.I.Cable,0,-1,52
+DN,G.I.Cable,0,-1,53
+ARROW DOWN,G.I.Cable,0,-1,53
+CURSOR DOWN,G.I.Cable,0,-1,53
+DOWN,G.I.Cable,0,-1,53
+LEFT,G.I.Cable,0,-1,54
+ARROW LEFT,G.I.Cable,0,-1,54
+CURSOR LEFT,G.I.Cable,0,-1,54
+RIGHT,G.I.Cable,0,-1,55
+ARROW RIGHT,G.I.Cable,0,-1,55
+CURSOR RIGHT,G.I.Cable,0,-1,55
+PLAY,G.I.Cable,0,-1,56
+STOP,G.I.Cable,0,-1,57
+PAGE UP,G.I.Cable,0,-1,58
+PAGE DOWN,G.I.Cable,0,-1,58
+PAGE +,G.I.Cable,0,-1,58
+PAGE DN,G.I.Cable,0,-1,59
+PAGE UP,G.I.Cable,0,-1,59
+PAGE -,G.I.Cable,0,-1,59
+PAGE DOWN,G.I.Cable,0,-1,59
+REPLAY,G.I.Cable,0,-1,60
+REPLAY,G.I.Cable,0,-1,60
+MY DVR,G.I.Cable,0,-1,61
+LIVE TV,G.I.Cable,0,-1,62
+LIVE,G.I.Cable,0,-1,62
+30 SECOND SKIP,G.I.Cable,0,-1,63
+SKIP 30 SECONDS,G.I.Cable,0,-1,63
+ENTER,G.I.Cable,0,-1,64

--- a/codes/Comcast/HD Cable with DVR/0,-1.csv
+++ b/codes/Comcast/HD Cable with DVR/0,-1.csv
@@ -1,44 +1,44 @@
 functionname,protocol,device,subdevice,function
-0,G.I. Cable,0,-1,0
-,G.I. Cable,0,-1,0
-1,G.I. Cable,0,-1,1
-ON DEMAND,G.I. Cable,0,-1,1
-PPV,G.I. Cable,0,-1,1
-2,G.I. Cable,0,-1,2
-PPV,G.I. Cable,0,-1,2
-3,G.I. Cable,0,-1,3
-4,G.I. Cable,0,-1,4
-5,G.I. Cable,0,-1,5
-6,G.I. Cable,0,-1,6
-7,G.I. Cable,0,-1,7
-8,G.I. Cable,0,-1,8
-9,G.I. Cable,0,-1,9
-,G.I. Cable,0,-1,9
-CH UP,G.I. Cable,0,-1,11
-CH DN,G.I. Cable,0,-1,12
-ENTER,G.I. Cable,0,-1,16
-OK/SELECT,G.I. Cable,0,-1,17
-,G.I. Cable,0,-1,17
-ENTER,G.I. Cable,0,-1,17
-EXIT,G.I. Cable,0,-1,18
-LAST,G.I. Cable,0,-1,19
-FAV,G.I. Cable,0,-1,21
-MENU,G.I. Cable,0,-1,25
-PLAY,G.I. Cable,0,-1,27
-STOP,G.I. Cable,0,-1,28
-FF,G.I. Cable,0,-1,29
-RW,G.I. Cable,0,-1,30
-PAUSE,G.I. Cable,0,-1,31
-GUIDE,G.I. Cable,0,-1,48
-RECORD,G.I. Cable,0,-1,49
-HELP[,G.I. Cable,0,-1,50
-UP,G.I. Cable,0,-1,52
-DN,G.I. Cable,0,-1,53
-DOWN,G.I. Cable,0,-1,53
-LEFT,G.I. Cable,0,-1,54
-RIGHT,G.I. Cable,0,-1,55
-PLAY,G.I. Cable,0,-1,56
-STOP,G.I. Cable,0,-1,57
-PAGE UP,G.I. Cable,0,-1,58
-PAGE DN,G.I. Cable,0,-1,59
-SKIP 30 SECONDS,G.I. Cable,0,-1,63
+0,G.I.Cable,0,-1,0
+,G.I.Cable,0,-1,0
+1,G.I.Cable,0,-1,1
+ON DEMAND,G.I.Cable,0,-1,1
+PPV,G.I.Cable,0,-1,1
+2,G.I.Cable,0,-1,2
+PPV,G.I.Cable,0,-1,2
+3,G.I.Cable,0,-1,3
+4,G.I.Cable,0,-1,4
+5,G.I.Cable,0,-1,5
+6,G.I.Cable,0,-1,6
+7,G.I.Cable,0,-1,7
+8,G.I.Cable,0,-1,8
+9,G.I.Cable,0,-1,9
+,G.I.Cable,0,-1,9
+CH UP,G.I.Cable,0,-1,11
+CH DN,G.I.Cable,0,-1,12
+ENTER,G.I.Cable,0,-1,16
+OK/SELECT,G.I.Cable,0,-1,17
+,G.I.Cable,0,-1,17
+ENTER,G.I.Cable,0,-1,17
+EXIT,G.I.Cable,0,-1,18
+LAST,G.I.Cable,0,-1,19
+FAV,G.I.Cable,0,-1,21
+MENU,G.I.Cable,0,-1,25
+PLAY,G.I.Cable,0,-1,27
+STOP,G.I.Cable,0,-1,28
+FF,G.I.Cable,0,-1,29
+RW,G.I.Cable,0,-1,30
+PAUSE,G.I.Cable,0,-1,31
+GUIDE,G.I.Cable,0,-1,48
+RECORD,G.I.Cable,0,-1,49
+HELP[,G.I.Cable,0,-1,50
+UP,G.I.Cable,0,-1,52
+DN,G.I.Cable,0,-1,53
+DOWN,G.I.Cable,0,-1,53
+LEFT,G.I.Cable,0,-1,54
+RIGHT,G.I.Cable,0,-1,55
+PLAY,G.I.Cable,0,-1,56
+STOP,G.I.Cable,0,-1,57
+PAGE UP,G.I.Cable,0,-1,58
+PAGE DN,G.I.Cable,0,-1,59
+SKIP 30 SECONDS,G.I.Cable,0,-1,63

--- a/codes/Cox/Digital Cable/0,-1.csv
+++ b/codes/Cox/Digital Cable/0,-1.csv
@@ -1,31 +1,31 @@
 functionname,protocol,device,subdevice,function
-,G.I. Cable,0,-1,0
-0,G.I. Cable{1},0,-1,0
-1,G.I. Cable,0,-1,1
-2,G.I. Cable,0,-1,2
-3,G.I. Cable,0,-1,3
-4,G.I. Cable,0,-1,4
-5,G.I. Cable,0,-1,5
-PPV INFO,G.I. Cable,0,-1,5
-6,G.I. Cable,0,-1,6
-7,G.I. Cable,0,-1,7
-8,G.I. Cable,0,-1,8
-9,G.I. Cable,0,-1,9
-POWER,G.I. Cable,0,-1,10
-CHANNEL +,G.I. Cable,0,-1,11
-CHANNEL -,G.I. Cable,0,-1,12
-MUSIC,G.I. Cable,0,-1,16
-SELECT,G.I. Cable,0,-1,17
-EXIT,G.I. Cable,0,-1,18
-LAST,G.I. Cable,0,-1,19
-FAV,G.I. Cable,0,-1,21
-MENU,G.I. Cable,0,-1,25
-GUIDE,G.I. Cable,0,-1,48
-1 TOUCH REC,G.I. Cable,0,-1,49
-INFO,G.I. Cable,0,-1,51
-UP,G.I. Cable,0,-1,52
-DOWN,G.I. Cable,0,-1,53
-LEFT,G.I. Cable,0,-1,54
-RIGHT,G.I. Cable,0,-1,55
-PAGE UP,G.I. Cable,0,-1,58
-PAGE DOWN,G.I. Cable,0,-1,59
+,G.I.Cable,0,-1,0
+0,G.I.Cable,0,-1,0
+1,G.I.Cable,0,-1,1
+2,G.I.Cable,0,-1,2
+3,G.I.Cable,0,-1,3
+4,G.I.Cable,0,-1,4
+5,G.I.Cable,0,-1,5
+PPV INFO,G.I.Cable,0,-1,5
+6,G.I.Cable,0,-1,6
+7,G.I.Cable,0,-1,7
+8,G.I.Cable,0,-1,8
+9,G.I.Cable,0,-1,9
+POWER,G.I.Cable,0,-1,10
+CHANNEL +,G.I.Cable,0,-1,11
+CHANNEL -,G.I.Cable,0,-1,12
+MUSIC,G.I.Cable,0,-1,16
+SELECT,G.I.Cable,0,-1,17
+EXIT,G.I.Cable,0,-1,18
+LAST,G.I.Cable,0,-1,19
+FAV,G.I.Cable,0,-1,21
+MENU,G.I.Cable,0,-1,25
+GUIDE,G.I.Cable,0,-1,48
+1 TOUCH REC,G.I.Cable,0,-1,49
+INFO,G.I.Cable,0,-1,51
+UP,G.I.Cable,0,-1,52
+DOWN,G.I.Cable,0,-1,53
+LEFT,G.I.Cable,0,-1,54
+RIGHT,G.I.Cable,0,-1,55
+PAGE UP,G.I.Cable,0,-1,58
+PAGE DOWN,G.I.Cable,0,-1,59

--- a/codes/Escient/MP3 Player/0,-1.csv
+++ b/codes/Escient/MP3 Player/0,-1.csv
@@ -1,7 +1,7 @@
 functionname,protocol,device,subdevice,function
-CHANNEL +,G.I. Cable,0,-1,11
-CHANNEL -,G.I. Cable,0,-1,12
-CURSER UP,G.I. Cable,0,-1,52
-CURSER DOWN,G.I. Cable,0,-1,53
-CURSER LEFT,G.I. Cable,0,-1,54
-CURSER RIGHT,G.I. Cable,0,-1,55
+CHANNEL +,G.I.Cable,0,-1,11
+CHANNEL -,G.I.Cable,0,-1,12
+CURSER UP,G.I.Cable,0,-1,52
+CURSER DOWN,G.I.Cable,0,-1,53
+CURSER LEFT,G.I.Cable,0,-1,54
+CURSER RIGHT,G.I.Cable,0,-1,55

--- a/codes/General Instrument/Cable Box/0,-1.csv
+++ b/codes/General Instrument/Cable Box/0,-1.csv
@@ -1,66 +1,66 @@
 functionname,protocol,device,subdevice,function
-0,G.I. Cable,0,-1,0
-1,G.I. Cable,0,-1,1
-1,G.I. Cable{1},0,-1,1
-2,G.I. Cable,0,-1,2
-3,G.I. Cable,0,-1,3
-3,G.I. Cable{1},0,-1,3
-4,G.I. Cable,0,-1,4
-5,G.I. Cable,0,-1,5
-5,G.I. Cable{1},0,-1,5
-6,G.I. Cable,0,-1,6
-7,G.I. Cable,0,-1,7
-7,G.I. Cable{1},0,-1,7
-8,G.I. Cable,0,-1,8
-9,G.I. Cable,0,-1,9
-9,G.I. Cable{1},0,-1,9
-POWER,G.I. Cable,0,-1,10
-POWER ON/OFF,G.I. Cable,0,-1,10
-CHANNEL+,G.I. Cable,0,-1,11
-CHANNEL UP,G.I. Cable{1},0,-1,11
-CHANNEL +,G.I. Cable,0,-1,11
-CHANNEL-,G.I. Cable,0,-1,12
-CHANNEL -,G.I. Cable,0,-1,12
+0,G.I.Cable,0,-1,0
+1,G.I.Cable,0,-1,1
+1,G.I.Cable,0,-1,1
+2,G.I.Cable,0,-1,2
+3,G.I.Cable,0,-1,3
+3,G.I.Cable,0,-1,3
+4,G.I.Cable,0,-1,4
+5,G.I.Cable,0,-1,5
+5,G.I.Cable,0,-1,5
+6,G.I.Cable,0,-1,6
+7,G.I.Cable,0,-1,7
+7,G.I.Cable,0,-1,7
+8,G.I.Cable,0,-1,8
+9,G.I.Cable,0,-1,9
+9,G.I.Cable,0,-1,9
+POWER,G.I.Cable,0,-1,10
+POWER ON/OFF,G.I.Cable,0,-1,10
+CHANNEL+,G.I.Cable,0,-1,11
+CHANNEL UP,G.I.Cable,0,-1,11
+CHANNEL +,G.I.Cable,0,-1,11
+CHANNEL-,G.I.Cable,0,-1,12
+CHANNEL -,G.I.Cable,0,-1,12
 ,RC5,0,-1,12
-VOLUME +,G.I. Cable,0,-1,13
+VOLUME +,G.I.Cable,0,-1,13
 MUTE,RC5,0,-1,13
-VOLUME -,G.I. Cable,0,-1,14
-MUSIC,G.I. Cable,0,-1,16
-MUSIC,G.I. Cable{1},0,-1,16
-ENTER,G.I. Cable,0,-1,16
-OK,G.I. Cable,0,-1,17
-SELECT,G.I. Cable{1},0,-1,17
-SELECT,G.I. Cable,0,-1,17
-EXIT,G.I. Cable,0,-1,18
-EXIT,G.I. Cable{1},0,-1,18
-LAST,G.I. Cable,0,-1,19
-LAST CHANNEL,G.I. Cable{1},0,-1,19
-FAV,G.I. Cable,0,-1,21
-LOCKOUT,G.I. Cable,0,-1,22
-MENU,G.I. Cable,0,-1,25
-MENU,G.I. Cable{1},0,-1,25
-GUIDE,G.I. Cable,0,-1,48
-GUIDE,G.I. Cable{1},0,-1,48
-HELP,G.I. Cable{1},0,-1,50
-HELP,G.I. Cable,0,-1,50
-INFO,G.I. Cable,0,-1,51
-INFO,G.I. Cable{1},0,-1,51
-UP,G.I. Cable,0,-1,52
-UP,G.I. Cable{1},0,-1,52
-CURSOR UP,G.I. Cable,0,-1,52
-DOWN,G.I. Cable,0,-1,53
-DOWN,G.I. Cable{1},0,-1,53
-CURSOR DOWN,G.I. Cable,0,-1,53
-LEFT,G.I. Cable,0,-1,54
-LEFT,G.I. Cable{1},0,-1,54
-CURSOR LEFT,G.I. Cable,0,-1,54
-RIGHT,G.I. Cable,0,-1,55
-RIGHT,G.I. Cable{1},0,-1,55
-CURSOR RIGHT,G.I. Cable,0,-1,55
-DAY >,G.I. Cable,0,-1,56
-DAY<,G.I. Cable,0,-1,57
-PAGE UP,G.I. Cable,0,-1,58
-PAGE UP,G.I. Cable{1},0,-1,58
-PAGE DOWN,G.I. Cable,0,-1,59
-PAGE DOWN,G.I. Cable{1},0,-1,59
-PAGE DN,G.I. Cable,0,-1,59
+VOLUME -,G.I.Cable,0,-1,14
+MUSIC,G.I.Cable,0,-1,16
+MUSIC,G.I.Cable,0,-1,16
+ENTER,G.I.Cable,0,-1,16
+OK,G.I.Cable,0,-1,17
+SELECT,G.I.Cable,0,-1,17
+SELECT,G.I.Cable,0,-1,17
+EXIT,G.I.Cable,0,-1,18
+EXIT,G.I.Cable,0,-1,18
+LAST,G.I.Cable,0,-1,19
+LAST CHANNEL,G.I.Cable,0,-1,19
+FAV,G.I.Cable,0,-1,21
+LOCKOUT,G.I.Cable,0,-1,22
+MENU,G.I.Cable,0,-1,25
+MENU,G.I.Cable,0,-1,25
+GUIDE,G.I.Cable,0,-1,48
+GUIDE,G.I.Cable,0,-1,48
+HELP,G.I.Cable,0,-1,50
+HELP,G.I.Cable,0,-1,50
+INFO,G.I.Cable,0,-1,51
+INFO,G.I.Cable,0,-1,51
+UP,G.I.Cable,0,-1,52
+UP,G.I.Cable,0,-1,52
+CURSOR UP,G.I.Cable,0,-1,52
+DOWN,G.I.Cable,0,-1,53
+DOWN,G.I.Cable,0,-1,53
+CURSOR DOWN,G.I.Cable,0,-1,53
+LEFT,G.I.Cable,0,-1,54
+LEFT,G.I.Cable,0,-1,54
+CURSOR LEFT,G.I.Cable,0,-1,54
+RIGHT,G.I.Cable,0,-1,55
+RIGHT,G.I.Cable,0,-1,55
+CURSOR RIGHT,G.I.Cable,0,-1,55
+DAY >,G.I.Cable,0,-1,56
+DAY<,G.I.Cable,0,-1,57
+PAGE UP,G.I.Cable,0,-1,58
+PAGE UP,G.I.Cable,0,-1,58
+PAGE DOWN,G.I.Cable,0,-1,59
+PAGE DOWN,G.I.Cable,0,-1,59
+PAGE DN,G.I.Cable,0,-1,59

--- a/codes/General Instruments/Unknown_XRC-200/0,-1.csv
+++ b/codes/General Instruments/Unknown_XRC-200/0,-1.csv
@@ -1,85 +1,85 @@
 functionname,protocol,device,subdevice,function
-CBL_0,G.I. Cable{1},0,-1,0
-CBL_0,G.I. Cable{1},0,-1,0
-CBL_1,G.I. Cable{1},0,-1,1
-CBL_1,G.I. Cable{1},0,-1,1
-CBL_2,G.I. Cable{1},0,-1,2
-CBL_2,G.I. Cable{1},0,-1,2
-CBL_3,G.I. Cable{1},0,-1,3
-CBL_3,G.I. Cable{1},0,-1,3
-CBL_4,G.I. Cable{1},0,-1,4
-CBL_4,G.I. Cable{1},0,-1,4
-CBL_5,G.I. Cable{1},0,-1,5
-CBL_5,G.I. Cable{1},0,-1,5
-CBL_6,G.I. Cable{1},0,-1,6
-CBL_6,G.I. Cable{1},0,-1,6
-CBL_7,G.I. Cable{1},0,-1,7
-CBL_7,G.I. Cable{1},0,-1,7
-CBL_8,G.I. Cable{1},0,-1,8
-CBL_8,G.I. Cable{1},0,-1,8
-CBL_9,G.I. Cable{1},0,-1,9
-CBL_9,G.I. Cable{1},0,-1,9
-CBL_POWER,G.I. Cable{1},0,-1,10
-CBL_POWER,G.I. Cable{1},0,-1,10
-CBL_CHAN+,G.I. Cable{1},0,-1,11
-CBL_CHAN+,G.I. Cable{1},0,-1,11
-CBL_CHAN-,G.I. Cable{1},0,-1,12
-CBL_CHAN-,G.I. Cable{1},0,-1,12
-CBL_VOL+,G.I. Cable{1},0,-1,13
-CBL_VOL+,G.I. Cable{1},0,-1,13
-CBL_VOL-,G.I. Cable{1},0,-1,14
-CBL_VOL-,G.I. Cable{1},0,-1,14
-CBL_MUTE,G.I. Cable{1},0,-1,15
-CBL_MUTE,G.I. Cable{1},0,-1,15
-CBL_MUSIC,G.I. Cable{1},0,-1,16
-CBL_MUSIC,G.I. Cable{1},0,-1,16
-CBL_OK,G.I. Cable{1},0,-1,17
-CBL_OK,G.I. Cable{1},0,-1,17
-KEY_EXIT,G.I. Cable{1},0,-1,18
-KEY_EXIT,G.I. Cable{1},0,-1,18
-CBL_LAST,G.I. Cable{1},0,-1,19
-CBL_LAST,G.I. Cable{1},0,-1,19
-CBL_BYPASS,G.I. Cable{1},0,-1,20
-CBL_BYPASS,G.I. Cable{1},0,-1,20
-CBL_FAV,G.I. Cable{1},0,-1,21
-CBL_FAV,G.I. Cable{1},0,-1,21
-CBL_LOCK,G.I. Cable{1},0,-1,22
-CBL_LOCK,G.I. Cable{1},0,-1,22
-CBL_A,G.I. Cable{1},0,-1,23
-CBL_A,G.I. Cable{1},0,-1,23
-CBL_MENU,G.I. Cable{1},0,-1,25
-CBL_MENU,G.I. Cable{1},0,-1,25
-CBL_FF,G.I. Cable{1},0,-1,29
-CBL_FF,G.I. Cable{1},0,-1,29
-CBL_REW,G.I. Cable{1},0,-1,30
-CBL_REW,G.I. Cable{1},0,-1,30
-CBL_PAUSE,G.I. Cable{1},0,-1,31
-CBL_PAUSE,G.I. Cable{1},0,-1,31
-CBL_B,G.I. Cable{1},0,-1,39
-CBL_B,G.I. Cable{1},0,-1,39
-CBL_C,G.I. Cable{1},0,-1,40
-CBL_C,G.I. Cable{1},0,-1,40
-CBL_GUIDE,G.I. Cable{1},0,-1,48
-CBL_GUIDE,G.I. Cable{1},0,-1,48
-CBL_REC,G.I. Cable{1},0,-1,49
-CBL_REC,G.I. Cable{1},0,-1,49
-CBL_HELP,G.I. Cable{1},0,-1,50
-CBL_HELP,G.I. Cable{1},0,-1,50
-CBL_INFO,G.I. Cable{1},0,-1,51
-CBL_INFO,G.I. Cable{1},0,-1,51
-CBL_UP,G.I. Cable{1},0,-1,52
-CBL_UP,G.I. Cable{1},0,-1,52
-CBL_DOWN,G.I. Cable{1},0,-1,53
-CBL_DOWN,G.I. Cable{1},0,-1,53
-CBL_LEFT,G.I. Cable{1},0,-1,54
-CBL_LEFT,G.I. Cable{1},0,-1,54
-CBL_RIGHT,G.I. Cable{1},0,-1,55
-CBL_RIGHT,G.I. Cable{1},0,-1,55
-CBL_PLAY,G.I. Cable{1},0,-1,56
-CBL_PLAY,G.I. Cable{1},0,-1,56
-CBL_STOP,G.I. Cable{1},0,-1,57
-CBL_STOP,G.I. Cable{1},0,-1,57
-CBL_PAGE+,G.I. Cable{1},0,-1,58
-CBL_PAGE+,G.I. Cable{1},0,-1,58
-CBL_PAGE-,G.I. Cable{1},0,-1,59
-CBL_PAGE-,G.I. Cable{1},0,-1,59
+CBL_0,G.I.Cable,0,-1,0
+CBL_0,G.I.Cable,0,-1,0
+CBL_1,G.I.Cable,0,-1,1
+CBL_1,G.I.Cable,0,-1,1
+CBL_2,G.I.Cable,0,-1,2
+CBL_2,G.I.Cable,0,-1,2
+CBL_3,G.I.Cable,0,-1,3
+CBL_3,G.I.Cable,0,-1,3
+CBL_4,G.I.Cable,0,-1,4
+CBL_4,G.I.Cable,0,-1,4
+CBL_5,G.I.Cable,0,-1,5
+CBL_5,G.I.Cable,0,-1,5
+CBL_6,G.I.Cable,0,-1,6
+CBL_6,G.I.Cable,0,-1,6
+CBL_7,G.I.Cable,0,-1,7
+CBL_7,G.I.Cable,0,-1,7
+CBL_8,G.I.Cable,0,-1,8
+CBL_8,G.I.Cable,0,-1,8
+CBL_9,G.I.Cable,0,-1,9
+CBL_9,G.I.Cable,0,-1,9
+CBL_POWER,G.I.Cable,0,-1,10
+CBL_POWER,G.I.Cable,0,-1,10
+CBL_CHAN+,G.I.Cable,0,-1,11
+CBL_CHAN+,G.I.Cable,0,-1,11
+CBL_CHAN-,G.I.Cable,0,-1,12
+CBL_CHAN-,G.I.Cable,0,-1,12
+CBL_VOL+,G.I.Cable,0,-1,13
+CBL_VOL+,G.I.Cable,0,-1,13
+CBL_VOL-,G.I.Cable,0,-1,14
+CBL_VOL-,G.I.Cable,0,-1,14
+CBL_MUTE,G.I.Cable,0,-1,15
+CBL_MUTE,G.I.Cable,0,-1,15
+CBL_MUSIC,G.I.Cable,0,-1,16
+CBL_MUSIC,G.I.Cable,0,-1,16
+CBL_OK,G.I.Cable,0,-1,17
+CBL_OK,G.I.Cable,0,-1,17
+KEY_EXIT,G.I.Cable,0,-1,18
+KEY_EXIT,G.I.Cable,0,-1,18
+CBL_LAST,G.I.Cable,0,-1,19
+CBL_LAST,G.I.Cable,0,-1,19
+CBL_BYPASS,G.I.Cable,0,-1,20
+CBL_BYPASS,G.I.Cable,0,-1,20
+CBL_FAV,G.I.Cable,0,-1,21
+CBL_FAV,G.I.Cable,0,-1,21
+CBL_LOCK,G.I.Cable,0,-1,22
+CBL_LOCK,G.I.Cable,0,-1,22
+CBL_A,G.I.Cable,0,-1,23
+CBL_A,G.I.Cable,0,-1,23
+CBL_MENU,G.I.Cable,0,-1,25
+CBL_MENU,G.I.Cable,0,-1,25
+CBL_FF,G.I.Cable,0,-1,29
+CBL_FF,G.I.Cable,0,-1,29
+CBL_REW,G.I.Cable,0,-1,30
+CBL_REW,G.I.Cable,0,-1,30
+CBL_PAUSE,G.I.Cable,0,-1,31
+CBL_PAUSE,G.I.Cable,0,-1,31
+CBL_B,G.I.Cable,0,-1,39
+CBL_B,G.I.Cable,0,-1,39
+CBL_C,G.I.Cable,0,-1,40
+CBL_C,G.I.Cable,0,-1,40
+CBL_GUIDE,G.I.Cable,0,-1,48
+CBL_GUIDE,G.I.Cable,0,-1,48
+CBL_REC,G.I.Cable,0,-1,49
+CBL_REC,G.I.Cable,0,-1,49
+CBL_HELP,G.I.Cable,0,-1,50
+CBL_HELP,G.I.Cable,0,-1,50
+CBL_INFO,G.I.Cable,0,-1,51
+CBL_INFO,G.I.Cable,0,-1,51
+CBL_UP,G.I.Cable,0,-1,52
+CBL_UP,G.I.Cable,0,-1,52
+CBL_DOWN,G.I.Cable,0,-1,53
+CBL_DOWN,G.I.Cable,0,-1,53
+CBL_LEFT,G.I.Cable,0,-1,54
+CBL_LEFT,G.I.Cable,0,-1,54
+CBL_RIGHT,G.I.Cable,0,-1,55
+CBL_RIGHT,G.I.Cable,0,-1,55
+CBL_PLAY,G.I.Cable,0,-1,56
+CBL_PLAY,G.I.Cable,0,-1,56
+CBL_STOP,G.I.Cable,0,-1,57
+CBL_STOP,G.I.Cable,0,-1,57
+CBL_PAGE+,G.I.Cable,0,-1,58
+CBL_PAGE+,G.I.Cable,0,-1,58
+CBL_PAGE-,G.I.Cable,0,-1,59
+CBL_PAGE-,G.I.Cable,0,-1,59

--- a/codes/Jerrold/Cable Box/0,-1.csv
+++ b/codes/Jerrold/Cable Box/0,-1.csv
@@ -1,57 +1,57 @@
 functionname,protocol,device,subdevice,function
-CATV 0,G.I. Cable,0,-1,0
-0,G.I. Cable,0,-1,0
-CATV 1,G.I. Cable,0,-1,1
-1,G.I. Cable,0,-1,1
-CATV 2,G.I. Cable,0,-1,2
-2,G.I. Cable,0,-1,2
-CATV 3,G.I. Cable,0,-1,3
-3,G.I. Cable,0,-1,3
-CATV 4,G.I. Cable,0,-1,4
-4,G.I. Cable,0,-1,4
-CATV 5,G.I. Cable,0,-1,5
-5,G.I. Cable,0,-1,5
-CATV 6,G.I. Cable,0,-1,6
-6,G.I. Cable,0,-1,6
-CATV 7,G.I. Cable,0,-1,7
-7,G.I. Cable,0,-1,7
-CATV 8,G.I. Cable,0,-1,8
-8,G.I. Cable,0,-1,8
-CATV 9,G.I. Cable,0,-1,9
-9,G.I. Cable,0,-1,9
-CATV CATV POWER,G.I. Cable,0,-1,10
-CATV,G.I. Cable,0,-1,10
-POWER,G.I. Cable,0,-1,10
-CATV CH +,G.I. Cable,0,-1,11
-CHANNEL +,G.I. Cable,0,-1,11
-CATV CH -,G.I. Cable,0,-1,12
-CHANNEL -,G.I. Cable,0,-1,12
-CATV VOL +,G.I. Cable,0,-1,13
-VOLUME +,G.I. Cable,0,-1,13
-CATV VOL -,G.I. Cable,0,-1,14
-VOLUME -,G.I. Cable,0,-1,14
-CATV MUTE,G.I. Cable,0,-1,15
-MUTE,G.I. Cable,0,-1,15
-CATV ENTER,G.I. Cable,0,-1,16
-ENTER,G.I. Cable,0,-1,16
-CATV SELECT,G.I. Cable,0,-1,17
-SELECT,G.I. Cable,0,-1,17
-CATV DISP,G.I. Cable,0,-1,18
-DISPLAY,G.I. Cable,0,-1,18
-CATV <CH,G.I. Cable,0,-1,19
-<CH,G.I. Cable,0,-1,19
-CHANNEL <,G.I. Cable,0,-1,19
-CATV <A B>,G.I. Cable,0,-1,20
-A/B,G.I. Cable,0,-1,20
-CATV FAV,G.I. Cable,0,-1,21
-FAV.,G.I. Cable,0,-1,21
-FAV,G.I. Cable,0,-1,21
-CATV PROG,G.I. Cable,0,-1,22
-PROG.,G.I. Cable,0,-1,22
-PROGRAM,G.I. Cable,0,-1,22
-CATV DELETE,G.I. Cable,0,-1,23
-DELETE,G.I. Cable,0,-1,23
-CATV F,G.I. Cable,0,-1,24
-F,G.I. Cable,0,-1,24
-CATV MENU,G.I. Cable,0,-1,25
-MENU,G.I. Cable,0,-1,25
+CATV 0,G.I.Cable,0,-1,0
+0,G.I.Cable,0,-1,0
+CATV 1,G.I.Cable,0,-1,1
+1,G.I.Cable,0,-1,1
+CATV 2,G.I.Cable,0,-1,2
+2,G.I.Cable,0,-1,2
+CATV 3,G.I.Cable,0,-1,3
+3,G.I.Cable,0,-1,3
+CATV 4,G.I.Cable,0,-1,4
+4,G.I.Cable,0,-1,4
+CATV 5,G.I.Cable,0,-1,5
+5,G.I.Cable,0,-1,5
+CATV 6,G.I.Cable,0,-1,6
+6,G.I.Cable,0,-1,6
+CATV 7,G.I.Cable,0,-1,7
+7,G.I.Cable,0,-1,7
+CATV 8,G.I.Cable,0,-1,8
+8,G.I.Cable,0,-1,8
+CATV 9,G.I.Cable,0,-1,9
+9,G.I.Cable,0,-1,9
+CATV CATV POWER,G.I.Cable,0,-1,10
+CATV,G.I.Cable,0,-1,10
+POWER,G.I.Cable,0,-1,10
+CATV CH +,G.I.Cable,0,-1,11
+CHANNEL +,G.I.Cable,0,-1,11
+CATV CH -,G.I.Cable,0,-1,12
+CHANNEL -,G.I.Cable,0,-1,12
+CATV VOL +,G.I.Cable,0,-1,13
+VOLUME +,G.I.Cable,0,-1,13
+CATV VOL -,G.I.Cable,0,-1,14
+VOLUME -,G.I.Cable,0,-1,14
+CATV MUTE,G.I.Cable,0,-1,15
+MUTE,G.I.Cable,0,-1,15
+CATV ENTER,G.I.Cable,0,-1,16
+ENTER,G.I.Cable,0,-1,16
+CATV SELECT,G.I.Cable,0,-1,17
+SELECT,G.I.Cable,0,-1,17
+CATV DISP,G.I.Cable,0,-1,18
+DISPLAY,G.I.Cable,0,-1,18
+CATV <CH,G.I.Cable,0,-1,19
+<CH,G.I.Cable,0,-1,19
+CHANNEL <,G.I.Cable,0,-1,19
+CATV <A B>,G.I.Cable,0,-1,20
+A/B,G.I.Cable,0,-1,20
+CATV FAV,G.I.Cable,0,-1,21
+FAV.,G.I.Cable,0,-1,21
+FAV,G.I.Cable,0,-1,21
+CATV PROG,G.I.Cable,0,-1,22
+PROG.,G.I.Cable,0,-1,22
+PROGRAM,G.I.Cable,0,-1,22
+CATV DELETE,G.I.Cable,0,-1,23
+DELETE,G.I.Cable,0,-1,23
+CATV F,G.I.Cable,0,-1,24
+F,G.I.Cable,0,-1,24
+CATV MENU,G.I.Cable,0,-1,25
+MENU,G.I.Cable,0,-1,25

--- a/codes/Jerrold/Unknown_550-osd/0,-1.csv
+++ b/codes/Jerrold/Unknown_550-osd/0,-1.csv
@@ -1,28 +1,28 @@
 functionname,protocol,device,subdevice,function
-KEY_0,G.I. Cable{1},0,-1,0
-KEY_1,G.I. Cable{1},0,-1,1
-KEY_2,G.I. Cable{1},0,-1,2
-KEY_3,G.I. Cable{1},0,-1,3
-KEY_4,G.I. Cable{1},0,-1,4
-KEY_5,G.I. Cable{1},0,-1,5
-KEY_6,G.I. Cable{1},0,-1,6
-KEY_7,G.I. Cable{1},0,-1,7
-KEY_8,G.I. Cable{1},0,-1,8
-KEY_9,G.I. Cable{1},0,-1,9
-KEY_POWER,G.I. Cable{1},0,-1,10
-KEY_CHANNELUP,G.I. Cable{1},0,-1,11
-KEY_CHANNELDOWN,G.I. Cable{1},0,-1,12
-KEY_VOLUMEUP,G.I. Cable{1},0,-1,13
-KEY_VOLUMEDOWN,G.I. Cable{1},0,-1,14
-KEY_MUTE,G.I. Cable{1},0,-1,15
-KEY_ENTER,G.I. Cable{1},0,-1,16
-KEY_SELECT,G.I. Cable{1},0,-1,17
-tcp,G.I. Cable{1},0,-1,18
-lc,G.I. Cable{1},0,-1,19
-ab,G.I. Cable{1},0,-1,20
-fc,G.I. Cable{1},0,-1,21
-prgm,G.I. Cable{1},0,-1,22
-KEY_DELETE,G.I. Cable{1},0,-1,23
-KEY_F,G.I. Cable{1},0,-1,24
-learn,G.I. Cable{1},0,-1,25
-pcpm,G.I. Cable{1},0,-1,50
+KEY_0,G.I.Cable,0,-1,0
+KEY_1,G.I.Cable,0,-1,1
+KEY_2,G.I.Cable,0,-1,2
+KEY_3,G.I.Cable,0,-1,3
+KEY_4,G.I.Cable,0,-1,4
+KEY_5,G.I.Cable,0,-1,5
+KEY_6,G.I.Cable,0,-1,6
+KEY_7,G.I.Cable,0,-1,7
+KEY_8,G.I.Cable,0,-1,8
+KEY_9,G.I.Cable,0,-1,9
+KEY_POWER,G.I.Cable,0,-1,10
+KEY_CHANNELUP,G.I.Cable,0,-1,11
+KEY_CHANNELDOWN,G.I.Cable,0,-1,12
+KEY_VOLUMEUP,G.I.Cable,0,-1,13
+KEY_VOLUMEDOWN,G.I.Cable,0,-1,14
+KEY_MUTE,G.I.Cable,0,-1,15
+KEY_ENTER,G.I.Cable,0,-1,16
+KEY_SELECT,G.I.Cable,0,-1,17
+tcp,G.I.Cable,0,-1,18
+lc,G.I.Cable,0,-1,19
+ab,G.I.Cable,0,-1,20
+fc,G.I.Cable,0,-1,21
+prgm,G.I.Cable,0,-1,22
+KEY_DELETE,G.I.Cable,0,-1,23
+KEY_F,G.I.Cable,0,-1,24
+learn,G.I.Cable,0,-1,25
+pcpm,G.I.Cable,0,-1,50

--- a/codes/Jerrold/Unknown_CFT2000/0,-1.csv
+++ b/codes/Jerrold/Unknown_CFT2000/0,-1.csv
@@ -1,16 +1,16 @@
 functionname,protocol,device,subdevice,function
-KEY_0,G.I. Cable{1},0,-1,0
-KEY_1,G.I. Cable{1},0,-1,1
-KEY_2,G.I. Cable{1},0,-1,2
-KEY_3,G.I. Cable{1},0,-1,3
-KEY_4,G.I. Cable{1},0,-1,4
-KEY_5,G.I. Cable{1},0,-1,5
-KEY_6,G.I. Cable{1},0,-1,6
-KEY_7,G.I. Cable{1},0,-1,7
-KEY_8,G.I. Cable{1},0,-1,8
-KEY_9,G.I. Cable{1},0,-1,9
-KEY_CHANNELUP,G.I. Cable{1},0,-1,11
-KEY_CHANNELDOWN,G.I. Cable{1},0,-1,12
-KEY_A,G.I. Cable{1},0,-1,23
-KEY_B,G.I. Cable{1},0,-1,39
-KEY_C,G.I. Cable{1},0,-1,40
+KEY_0,G.I.Cable,0,-1,0
+KEY_1,G.I.Cable,0,-1,1
+KEY_2,G.I.Cable,0,-1,2
+KEY_3,G.I.Cable,0,-1,3
+KEY_4,G.I.Cable,0,-1,4
+KEY_5,G.I.Cable,0,-1,5
+KEY_6,G.I.Cable,0,-1,6
+KEY_7,G.I.Cable,0,-1,7
+KEY_8,G.I.Cable,0,-1,8
+KEY_9,G.I.Cable,0,-1,9
+KEY_CHANNELUP,G.I.Cable,0,-1,11
+KEY_CHANNELDOWN,G.I.Cable,0,-1,12
+KEY_A,G.I.Cable,0,-1,23
+KEY_B,G.I.Cable,0,-1,39
+KEY_C,G.I.Cable,0,-1,40

--- a/codes/Jerrold/Unknown_RC-OSD/0,-1.csv
+++ b/codes/Jerrold/Unknown_RC-OSD/0,-1.csv
@@ -1,27 +1,27 @@
 functionname,protocol,device,subdevice,function
-KEY_0,G.I. Cable{1},0,-1,0
-KEY_1,G.I. Cable{1},0,-1,1
-KEY_2,G.I. Cable{1},0,-1,2
-KEY_3,G.I. Cable{1},0,-1,3
-KEY_4,G.I. Cable{1},0,-1,4
-KEY_5,G.I. Cable{1},0,-1,5
-KEY_6,G.I. Cable{1},0,-1,6
-KEY_7,G.I. Cable{1},0,-1,7
-KEY_8,G.I. Cable{1},0,-1,8
-KEY_9,G.I. Cable{1},0,-1,9
-CATV,G.I. Cable{1},0,-1,10
-KEY_CHANNELUP,G.I. Cable{1},0,-1,11
-KEY_CHANNELDOWN,G.I. Cable{1},0,-1,12
-KEY_VOLUMEUP,G.I. Cable{1},0,-1,13
-KEY_VOLUMEDOWN,G.I. Cable{1},0,-1,14
-KEY_MUTE,G.I. Cable{1},0,-1,15
-KEY_ENTER,G.I. Cable{1},0,-1,16
-KEY_SELECT,G.I. Cable{1},0,-1,17
-DISPLAY,G.I. Cable{1},0,-1,18
-CH,G.I. Cable{1},0,-1,19
-AB,G.I. Cable{1},0,-1,20
-KEY_FAVORITES,G.I. Cable{1},0,-1,21
-PROG,G.I. Cable{1},0,-1,22
-KEY_DELETE,G.I. Cable{1},0,-1,23
-KEY_F,G.I. Cable{1},0,-1,24
-KEY_MENU,G.I. Cable{1},0,-1,25
+KEY_0,G.I.Cable,0,-1,0
+KEY_1,G.I.Cable,0,-1,1
+KEY_2,G.I.Cable,0,-1,2
+KEY_3,G.I.Cable,0,-1,3
+KEY_4,G.I.Cable,0,-1,4
+KEY_5,G.I.Cable,0,-1,5
+KEY_6,G.I.Cable,0,-1,6
+KEY_7,G.I.Cable,0,-1,7
+KEY_8,G.I.Cable,0,-1,8
+KEY_9,G.I.Cable,0,-1,9
+CATV,G.I.Cable,0,-1,10
+KEY_CHANNELUP,G.I.Cable,0,-1,11
+KEY_CHANNELDOWN,G.I.Cable,0,-1,12
+KEY_VOLUMEUP,G.I.Cable,0,-1,13
+KEY_VOLUMEDOWN,G.I.Cable,0,-1,14
+KEY_MUTE,G.I.Cable,0,-1,15
+KEY_ENTER,G.I.Cable,0,-1,16
+KEY_SELECT,G.I.Cable,0,-1,17
+DISPLAY,G.I.Cable,0,-1,18
+CH,G.I.Cable,0,-1,19
+AB,G.I.Cable,0,-1,20
+KEY_FAVORITES,G.I.Cable,0,-1,21
+PROG,G.I.Cable,0,-1,22
+KEY_DELETE,G.I.Cable,0,-1,23
+KEY_F,G.I.Cable,0,-1,24
+KEY_MENU,G.I.Cable,0,-1,25

--- a/codes/Marantz/TV/0,-1.csv
+++ b/codes/Marantz/TV/0,-1.csv
@@ -1,7 +1,7 @@
 functionname,protocol,device,subdevice,function
-POWER ON/OFF,G.I. Cable,0,-1,10
-CHANNEL +,G.I. Cable,0,-1,11
-CHANNEL -,G.I. Cable,0,-1,12
+POWER ON/OFF,G.I.Cable,0,-1,10
+CHANNEL +,G.I.Cable,0,-1,11
+CHANNEL -,G.I.Cable,0,-1,12
 POWER OFF,RC5,0,-1,12
 ,RC5,0,-1,12
 VOLUME +,RC5,0,-1,16

--- a/codes/Mitsubishi/Cable Box/0,-1.csv
+++ b/codes/Mitsubishi/Cable Box/0,-1.csv
@@ -1,36 +1,36 @@
 functionname,protocol,device,subdevice,function
-0,G.I. Cable,0,-1,0
-1,G.I. Cable,0,-1,1
-2,G.I. Cable,0,-1,2
-3,G.I. Cable,0,-1,3
-4,G.I. Cable,0,-1,4
-5,G.I. Cable,0,-1,5
-6,G.I. Cable,0,-1,6
-7,G.I. Cable,0,-1,7
-8,G.I. Cable,0,-1,8
-9,G.I. Cable,0,-1,9
-POWER,G.I. Cable,0,-1,10
-CHANNEL +,G.I. Cable,0,-1,11
-CHANNEL -,G.I. Cable,0,-1,12
-VOLUME +,G.I. Cable,0,-1,13
-VOLUME -,G.I. Cable,0,-1,14
-MUTE,G.I. Cable,0,-1,15
-MUSIC,G.I. Cable,0,-1,16
-ENTER,G.I. Cable,0,-1,17
-EXIT,G.I. Cable,0,-1,18
-LAST,G.I. Cable,0,-1,19
-BYPASS,G.I. Cable,0,-1,20
-FAVORITE,G.I. Cable,0,-1,21
-A,G.I. Cable,0,-1,23
-HELP,G.I. Cable,0,-1,24
-MENU,G.I. Cable,0,-1,25
-B,G.I. Cable,0,-1,39
-C,G.I. Cable,0,-1,40
-GUIDE,G.I. Cable,0,-1,48
-INFO,G.I. Cable,0,-1,51
-CURSER UP,G.I. Cable,0,-1,52
-PAGE UP,G.I. Cable,0,-1,52
-CURSER DOWN,G.I. Cable,0,-1,53
-PAGE DOWN,G.I. Cable,0,-1,53
-CURSER LEFT,G.I. Cable,0,-1,54
-CURSER RIGHT,G.I. Cable,0,-1,55
+0,G.I.Cable,0,-1,0
+1,G.I.Cable,0,-1,1
+2,G.I.Cable,0,-1,2
+3,G.I.Cable,0,-1,3
+4,G.I.Cable,0,-1,4
+5,G.I.Cable,0,-1,5
+6,G.I.Cable,0,-1,6
+7,G.I.Cable,0,-1,7
+8,G.I.Cable,0,-1,8
+9,G.I.Cable,0,-1,9
+POWER,G.I.Cable,0,-1,10
+CHANNEL +,G.I.Cable,0,-1,11
+CHANNEL -,G.I.Cable,0,-1,12
+VOLUME +,G.I.Cable,0,-1,13
+VOLUME -,G.I.Cable,0,-1,14
+MUTE,G.I.Cable,0,-1,15
+MUSIC,G.I.Cable,0,-1,16
+ENTER,G.I.Cable,0,-1,17
+EXIT,G.I.Cable,0,-1,18
+LAST,G.I.Cable,0,-1,19
+BYPASS,G.I.Cable,0,-1,20
+FAVORITE,G.I.Cable,0,-1,21
+A,G.I.Cable,0,-1,23
+HELP,G.I.Cable,0,-1,24
+MENU,G.I.Cable,0,-1,25
+B,G.I.Cable,0,-1,39
+C,G.I.Cable,0,-1,40
+GUIDE,G.I.Cable,0,-1,48
+INFO,G.I.Cable,0,-1,51
+CURSER UP,G.I.Cable,0,-1,52
+PAGE UP,G.I.Cable,0,-1,52
+CURSER DOWN,G.I.Cable,0,-1,53
+PAGE DOWN,G.I.Cable,0,-1,53
+CURSER LEFT,G.I.Cable,0,-1,54
+CURSER RIGHT,G.I.Cable,0,-1,55

--- a/codes/Motorola/Cable Box/0,-1.csv
+++ b/codes/Motorola/Cable Box/0,-1.csv
@@ -1,264 +1,264 @@
 functionname,protocol,device,subdevice,function
-0,G.I. Cable,0,-1,0
-,G.I. Cable,0,-1,0
-ON DEMAND,G.I. Cable,0,-1,0
-1,G.I. Cable,0,-1,1
-ON DEMAND,G.I. Cable,0,-1,1
-2,G.I. Cable,0,-1,2
-C/PPV,G.I. Cable,0,-1,2
-C,G.I. Cable,0,-1,2
-B,G.I. Cable,0,-1,2
-PPV / C,G.I. Cable,0,-1,2
-3,G.I. Cable,0,-1,3
-4,G.I. Cable,0,-1,4
-4,G.I. Cable{1},0,-1,4
-5,G.I. Cable,0,-1,5
-5,G.I. Cable{1},0,-1,5
-6,G.I. Cable,0,-1,6
-6,G.I. Cable{1},0,-1,6
-7,G.I. Cable,0,-1,7
-7,G.I. Cable{1},0,-1,7
-8,G.I. Cable,0,-1,8
-8,G.I. Cable{1},0,-1,8
-9,G.I. Cable,0,-1,9
-9,G.I. Cable{1},0,-1,9
-ON DEMAND,G.I. Cable,0,-1,9
-CABLE,G.I. Cable,0,-1,10
-VCR/DVD/VOD,G.I. Cable{1},0,-1,10
-POWER,G.I. Cable,0,-1,10
-ALL ON,G.I. Cable,0,-1,10
-CODE1 POWER OFF,G.I. Cable,0,-1,10
-CODE1 POWER ON,G.I. Cable,0,-1,10
-CODE3 POWER OFF,G.I. Cable,0,-1,10
-CODE3 POWER ON,G.I. Cable,0,-1,10
-CODE4 POWER OFF,G.I. Cable,0,-1,10
-CODE4 POWER ON,G.I. Cable,0,-1,10
-MUSIC,G.I. Cable,0,-1,10
-POWER,G.I. Cable{1},0,-1,10
-CHANNEL +,G.I. Cable,0,-1,11
-CHANNEL +,G.I. Cable{1},0,-1,11
-NEW CODE,G.I. Cable,0,-1,11
-CHANNEL UP,G.I. Cable,0,-1,11
-CHAN UP,G.I. Cable,0,-1,11
-CH+,G.I. Cable,0,-1,11
-CHANNEL -,G.I. Cable,0,-1,12
-CHANNEL -,G.I. Cable{1},0,-1,12
-CHANNEL DOWN,G.I. Cable,0,-1,12
-CHAN DOWN,G.I. Cable,0,-1,12
-CH-,G.I. Cable,0,-1,12
+0,G.I.Cable,0,-1,0
+,G.I.Cable,0,-1,0
+ON DEMAND,G.I.Cable,0,-1,0
+1,G.I.Cable,0,-1,1
+ON DEMAND,G.I.Cable,0,-1,1
+2,G.I.Cable,0,-1,2
+C/PPV,G.I.Cable,0,-1,2
+C,G.I.Cable,0,-1,2
+B,G.I.Cable,0,-1,2
+PPV / C,G.I.Cable,0,-1,2
+3,G.I.Cable,0,-1,3
+4,G.I.Cable,0,-1,4
+4,G.I.Cable,0,-1,4
+5,G.I.Cable,0,-1,5
+5,G.I.Cable,0,-1,5
+6,G.I.Cable,0,-1,6
+6,G.I.Cable,0,-1,6
+7,G.I.Cable,0,-1,7
+7,G.I.Cable,0,-1,7
+8,G.I.Cable,0,-1,8
+8,G.I.Cable,0,-1,8
+9,G.I.Cable,0,-1,9
+9,G.I.Cable,0,-1,9
+ON DEMAND,G.I.Cable,0,-1,9
+CABLE,G.I.Cable,0,-1,10
+VCR/DVD/VOD,G.I.Cable,0,-1,10
+POWER,G.I.Cable,0,-1,10
+ALL ON,G.I.Cable,0,-1,10
+CODE1 POWER OFF,G.I.Cable,0,-1,10
+CODE1 POWER ON,G.I.Cable,0,-1,10
+CODE3 POWER OFF,G.I.Cable,0,-1,10
+CODE3 POWER ON,G.I.Cable,0,-1,10
+CODE4 POWER OFF,G.I.Cable,0,-1,10
+CODE4 POWER ON,G.I.Cable,0,-1,10
+MUSIC,G.I.Cable,0,-1,10
+POWER,G.I.Cable,0,-1,10
+CHANNEL +,G.I.Cable,0,-1,11
+CHANNEL +,G.I.Cable,0,-1,11
+NEW CODE,G.I.Cable,0,-1,11
+CHANNEL UP,G.I.Cable,0,-1,11
+CHAN UP,G.I.Cable,0,-1,11
+CH+,G.I.Cable,0,-1,11
+CHANNEL -,G.I.Cable,0,-1,12
+CHANNEL -,G.I.Cable,0,-1,12
+CHANNEL DOWN,G.I.Cable,0,-1,12
+CHAN DOWN,G.I.Cable,0,-1,12
+CH-,G.I.Cable,0,-1,12
 MUTE,RC5,0,-1,13
-VOLUME +,G.I. Cable,0,-1,13
-VOLUME -,G.I. Cable,0,-1,14
-MUTE,G.I. Cable,0,-1,15
-ENTER,G.I. Cable,0,-1,16
-ENTER/MUSIC,G.I. Cable,0,-1,16
+VOLUME +,G.I.Cable,0,-1,13
+VOLUME -,G.I.Cable,0,-1,14
+MUTE,G.I.Cable,0,-1,15
+ENTER,G.I.Cable,0,-1,16
+ENTER/MUSIC,G.I.Cable,0,-1,16
 VOLUME +,RC5,0,-1,16
-#/ENTER,G.I. Cable,0,-1,16
-MUSIC,G.I. Cable,0,-1,16
-OK/SELECT,G.I. Cable,0,-1,17
-MENU ENTER,G.I. Cable,0,-1,17
-,G.I. Cable,0,-1,17
-OK SELECT,G.I. Cable,0,-1,17
+#/ENTER,G.I.Cable,0,-1,16
+MUSIC,G.I.Cable,0,-1,16
+OK/SELECT,G.I.Cable,0,-1,17
+MENU ENTER,G.I.Cable,0,-1,17
+,G.I.Cable,0,-1,17
+OK SELECT,G.I.Cable,0,-1,17
 VOLUME -,RC5,0,-1,17
-CURSOR ENTER,G.I. Cable,0,-1,17
-ENTER,G.I. Cable,0,-1,17
-SELECT,G.I. Cable,0,-1,17
-OK,G.I. Cable,0,-1,17
-/ENTER,G.I. Cable,0,-1,17
-C OK,G.I. Cable,0,-1,17
-MENU-SELECT/OK,G.I. Cable,0,-1,17
-CURSOR SELECT OK,G.I. Cable,0,-1,17
-CURSER OK,G.I. Cable,0,-1,17
-EXIT,G.I. Cable,0,-1,18
-RETURN,G.I. Cable,0,-1,18
-LAST,G.I. Cable,0,-1,19
-LAST CH.,G.I. Cable,0,-1,19
-LAST CH,G.I. Cable,0,-1,19
-LAST/PREVIOUS,G.I. Cable,0,-1,19
-PREVIOUS CHANNEL,G.I. Cable,0,-1,19
-LAST CHANNEL,G.I. Cable,0,-1,19
-PREV CHANNEL,G.I. Cable,0,-1,19
-BYPASS- TV/VCR,G.I. Cable,0,-1,20
-INPUT,G.I. Cable,0,-1,20
-TV/VCR INPUT,G.I. Cable,0,-1,20
-TV/VCR,G.I. Cable,0,-1,20
-BYPASS,G.I. Cable,0,-1,20
-FAV,G.I. Cable,0,-1,21
-FAV,G.I. Cable{1},0,-1,21
-FAVORITES,G.I. Cable,0,-1,21
-FAVORITE CHANNEL,G.I. Cable,0,-1,21
-FAVORITE,G.I. Cable,0,-1,21
-LOCK,G.I. Cable,0,-1,22
-A/LOCK,G.I. Cable,0,-1,22
-A,G.I. Cable,0,-1,22
-A LOCK,G.I. Cable,0,-1,22
-A (LOCK),G.I. Cable,0,-1,22
-LOCKOUT,G.I. Cable,0,-1,22
-LOCK / A,G.I. Cable,0,-1,22
-A,G.I. Cable,0,-1,23
-PPV,G.I. Cable,0,-1,24
-ON DEMAND,G.I. Cable,0,-1,24
-P-CHANNEL-,G.I. Cable,0,-1,24
-VOD,G.I. Cable,0,-1,24
-MENU,G.I. Cable,0,-1,25
-SETTINGS,G.I. Cable,0,-1,25
-VOD,G.I. Cable,0,-1,26
-VOD2,G.I. Cable,0,-1,26
-ON DEMAND,G.I. Cable,0,-1,26
-P-CHANNEL+,G.I. Cable,0,-1,26
-ONDEMAND,G.I. Cable,0,-1,26
-PLAY,G.I. Cable,0,-1,27
-STOP,G.I. Cable,0,-1,28
-FAST FOWARD,G.I. Cable,0,-1,29
-FF,G.I. Cable,0,-1,29
-FAST FORWARD,G.I. Cable,0,-1,29
-FWD,G.I. Cable,0,-1,29
->>,G.I. Cable,0,-1,29
-FAST-FORWARD,G.I. Cable,0,-1,29
-FAST FWD,G.I. Cable,0,-1,29
-FFWD,G.I. Cable,0,-1,29
-FORWARD,G.I. Cable,0,-1,29
-SHUTTLE FORWARD,G.I. Cable,0,-1,29
-FWD >>,G.I. Cable,0,-1,29
-FFD,G.I. Cable,0,-1,29
-REWIND,G.I. Cable,0,-1,30
-REW,G.I. Cable,0,-1,30
-REVERSE,G.I. Cable,0,-1,30
-<<,G.I. Cable,0,-1,30
-REV,G.I. Cable,0,-1,30
-SHUTTLE REVERSE,G.I. Cable,0,-1,30
-BACK <<,G.I. Cable,0,-1,30
-REW,G.I. Cable{1},0,-1,30
-PAUSE,G.I. Cable,0,-1,31
-PAUSE ,G.I. Cable,0,-1,31
-PIP ON/OFF,G.I. Cable,0,-1,34
-SWAP,G.I. Cable,0,-1,35
-PIP SWAP,G.I. Cable,0,-1,35
-MOVE,G.I. Cable,0,-1,36
-PIP MOVE,G.I. Cable,0,-1,36
-PIP CH+,G.I. Cable,0,-1,37
-PIP +,G.I. Cable,0,-1,37
-PIP CH-,G.I. Cable,0,-1,38
-PIP -,G.I. Cable,0,-1,38
-B,G.I. Cable,0,-1,39
-C,G.I. Cable,0,-1,40
-C,G.I. Cable{1},0,-1,40
-EXIT,G.I. Cable,0,-1,40
-D,G.I. Cable,0,-1,41
-GUIDE,G.I. Cable,0,-1,48
-TV GUIDE,G.I. Cable,0,-1,48
-RECORD,G.I. Cable,0,-1,49
-REC,G.I. Cable,0,-1,49
-HELP,G.I. Cable,0,-1,50
-INFO,G.I. Cable,0,-1,51
-ARROW UP,G.I. Cable,0,-1,52
-MENU UP,G.I. Cable,0,-1,52
-CURSOR UP,G.I. Cable,0,-1,52
-UP ARROW,G.I. Cable,0,-1,52
-C UP,G.I. Cable{1},0,-1,52
-UP,G.I. Cable,0,-1,52
-C UP,G.I. Cable,0,-1,52
-MENU-UP,G.I. Cable,0,-1,52
-CURSER UP,G.I. Cable{1},0,-1,52
-ARROW DOWN,G.I. Cable,0,-1,53
-MENU DOWN,G.I. Cable,0,-1,53
-CURSOR DOWN,G.I. Cable,0,-1,53
-CURSOR DN,G.I. Cable,0,-1,53
-DOWN ARROW,G.I. Cable,0,-1,53
-C DOWN,G.I. Cable,0,-1,53
-ARROWN DOWN,G.I. Cable,0,-1,53
-DOWN,G.I. Cable,0,-1,53
-MENU-DOWN,G.I. Cable,0,-1,53
-CURSER DOWN,G.I. Cable{1},0,-1,53
-DN,G.I. Cable,0,-1,53
-ARROW LEFT,G.I. Cable,0,-1,54
-MENU LEFT,G.I. Cable,0,-1,54
-CURSOR LEFT,G.I. Cable,0,-1,54
-CURSOR LF,G.I. Cable,0,-1,54
-LEFT ARROW,G.I. Cable,0,-1,54
-C LEFT,G.I. Cable,0,-1,54
-LEFT,G.I. Cable,0,-1,54
-MENU-LEFT,G.I. Cable,0,-1,54
-CURSER LEFT,G.I. Cable,0,-1,54
-<,G.I. Cable,0,-1,54
-ARROW RIGHT,G.I. Cable,0,-1,55
-MENU RIGHT,G.I. Cable,0,-1,55
-CURSOR RIGHT,G.I. Cable,0,-1,55
-CURSOR RT,G.I. Cable,0,-1,55
-RIGHT ARROW,G.I. Cable,0,-1,55
-C RIGHT,G.I. Cable{1},0,-1,55
-RIGHT,G.I. Cable,0,-1,55
-C RIGHT,G.I. Cable,0,-1,55
-MENU-RIGHT,G.I. Cable,0,-1,55
-CURSER RIGHT,G.I. Cable,0,-1,55
->,G.I. Cable,0,-1,55
-DAY -,G.I. Cable,0,-1,56
-PLAY,G.I. Cable,0,-1,56
-DAY +,G.I. Cable,0,-1,56
->,G.I. Cable,0,-1,56
-DAY+,G.I. Cable,0,-1,56
-C,G.I. Cable,0,-1,56
-C DAY +,G.I. Cable,0,-1,56
-C (DAY +),G.I. Cable,0,-1,56
-DAY UP,G.I. Cable,0,-1,56
-DAY>,G.I. Cable,0,-1,56
-DAY FOR,G.I. Cable,0,-1,56
-DAY +,G.I. Cable,0,-1,57
-STOP,G.I. Cable,0,-1,57
-DAY -,G.I. Cable,0,-1,57
-DAY-,G.I. Cable,0,-1,57
-DAY =,G.I. Cable,0,-1,57
-B,G.I. Cable,0,-1,57
-B DAY -,G.I. Cable,0,-1,57
-B (DAY -),G.I. Cable,0,-1,57
-DAY DOWN,G.I. Cable,0,-1,57
-<DAY,G.I. Cable,0,-1,57
-DAT REV,G.I. Cable,0,-1,57
-PAGE +,G.I. Cable,0,-1,58
-PAGE /\,G.I. Cable,0,-1,58
-PAGE UP,G.I. Cable,0,-1,58
-PAGE+,G.I. Cable,0,-1,58
-PAGE -,G.I. Cable,0,-1,58
-PG UP,G.I. Cable,0,-1,58
-PAGE -,G.I. Cable,0,-1,59
-PAGE \/,G.I. Cable,0,-1,59
-PAGE --,G.I. Cable,0,-1,59
-PAGE DN,G.I. Cable,0,-1,59
-PAGE-,G.I. Cable,0,-1,59
-PAGE +,G.I. Cable,0,-1,59
-PAGE DOWN,G.I. Cable,0,-1,59
-PG DOWN,G.I. Cable,0,-1,59
-REPLAY,G.I. Cable,0,-1,60
-RE-PLAY,G.I. Cable,0,-1,60
-BACKUP,G.I. Cable,0,-1,60
-JUMP,G.I. Cable,0,-1,60
-BACK,G.I. Cable,0,-1,60
-INSTANT REPLAY,G.I. Cable,0,-1,60
-MUSIC,G.I. Cable,0,-1,60
-PIPTG,G.I. Cable,0,-1,60
-PPV,G.I. Cable,0,-1,60
-PREVIOUS,G.I. Cable,0,-1,60
-RETURN,G.I. Cable,0,-1,60
-LIST,G.I. Cable,0,-1,61
-MY DVR,G.I. Cable,0,-1,61
-P-SWP,G.I. Cable,0,-1,61
-DVR,G.I. Cable,0,-1,61
-DVR LIST,G.I. Cable,0,-1,61
-LIVE TV,G.I. Cable,0,-1,62
-LIVE,G.I. Cable,0,-1,62
-LOCKOUT,G.I. Cable,0,-1,62
-LV-TV,G.I. Cable,0,-1,62
-P-MOVE,G.I. Cable,0,-1,62
-FIOS TV,G.I. Cable,0,-1,62
-SKIP30,G.I. Cable,0,-1,63
-30 SECOND SKIP,G.I. Cable,0,-1,63
-SKIP FORWARD,G.I. Cable,0,-1,63
-NEXT,G.I. Cable,0,-1,63
-ASPECT,G.I. Cable,0,-1,64
-ENTER,G.I. Cable,0,-1,64
-HD ZOOM,G.I. Cable,0,-1,64
-*,G.I. Cable,0,-1,64
-HD ZOOM ENTER,G.I. Cable,0,-1,64
-OPTIONS,G.I. Cable,0,-1,66
-WIDGETS,G.I. Cable,0,-1,67
+CURSOR ENTER,G.I.Cable,0,-1,17
+ENTER,G.I.Cable,0,-1,17
+SELECT,G.I.Cable,0,-1,17
+OK,G.I.Cable,0,-1,17
+/ENTER,G.I.Cable,0,-1,17
+C OK,G.I.Cable,0,-1,17
+MENU-SELECT/OK,G.I.Cable,0,-1,17
+CURSOR SELECT OK,G.I.Cable,0,-1,17
+CURSER OK,G.I.Cable,0,-1,17
+EXIT,G.I.Cable,0,-1,18
+RETURN,G.I.Cable,0,-1,18
+LAST,G.I.Cable,0,-1,19
+LAST CH.,G.I.Cable,0,-1,19
+LAST CH,G.I.Cable,0,-1,19
+LAST/PREVIOUS,G.I.Cable,0,-1,19
+PREVIOUS CHANNEL,G.I.Cable,0,-1,19
+LAST CHANNEL,G.I.Cable,0,-1,19
+PREV CHANNEL,G.I.Cable,0,-1,19
+BYPASS- TV/VCR,G.I.Cable,0,-1,20
+INPUT,G.I.Cable,0,-1,20
+TV/VCR INPUT,G.I.Cable,0,-1,20
+TV/VCR,G.I.Cable,0,-1,20
+BYPASS,G.I.Cable,0,-1,20
+FAV,G.I.Cable,0,-1,21
+FAV,G.I.Cable,0,-1,21
+FAVORITES,G.I.Cable,0,-1,21
+FAVORITE CHANNEL,G.I.Cable,0,-1,21
+FAVORITE,G.I.Cable,0,-1,21
+LOCK,G.I.Cable,0,-1,22
+A/LOCK,G.I.Cable,0,-1,22
+A,G.I.Cable,0,-1,22
+A LOCK,G.I.Cable,0,-1,22
+A (LOCK),G.I.Cable,0,-1,22
+LOCKOUT,G.I.Cable,0,-1,22
+LOCK / A,G.I.Cable,0,-1,22
+A,G.I.Cable,0,-1,23
+PPV,G.I.Cable,0,-1,24
+ON DEMAND,G.I.Cable,0,-1,24
+P-CHANNEL-,G.I.Cable,0,-1,24
+VOD,G.I.Cable,0,-1,24
+MENU,G.I.Cable,0,-1,25
+SETTINGS,G.I.Cable,0,-1,25
+VOD,G.I.Cable,0,-1,26
+VOD2,G.I.Cable,0,-1,26
+ON DEMAND,G.I.Cable,0,-1,26
+P-CHANNEL+,G.I.Cable,0,-1,26
+ONDEMAND,G.I.Cable,0,-1,26
+PLAY,G.I.Cable,0,-1,27
+STOP,G.I.Cable,0,-1,28
+FAST FOWARD,G.I.Cable,0,-1,29
+FF,G.I.Cable,0,-1,29
+FAST FORWARD,G.I.Cable,0,-1,29
+FWD,G.I.Cable,0,-1,29
+>>,G.I.Cable,0,-1,29
+FAST-FORWARD,G.I.Cable,0,-1,29
+FAST FWD,G.I.Cable,0,-1,29
+FFWD,G.I.Cable,0,-1,29
+FORWARD,G.I.Cable,0,-1,29
+SHUTTLE FORWARD,G.I.Cable,0,-1,29
+FWD >>,G.I.Cable,0,-1,29
+FFD,G.I.Cable,0,-1,29
+REWIND,G.I.Cable,0,-1,30
+REW,G.I.Cable,0,-1,30
+REVERSE,G.I.Cable,0,-1,30
+<<,G.I.Cable,0,-1,30
+REV,G.I.Cable,0,-1,30
+SHUTTLE REVERSE,G.I.Cable,0,-1,30
+BACK <<,G.I.Cable,0,-1,30
+REW,G.I.Cable,0,-1,30
+PAUSE,G.I.Cable,0,-1,31
+PAUSE ,G.I.Cable,0,-1,31
+PIP ON/OFF,G.I.Cable,0,-1,34
+SWAP,G.I.Cable,0,-1,35
+PIP SWAP,G.I.Cable,0,-1,35
+MOVE,G.I.Cable,0,-1,36
+PIP MOVE,G.I.Cable,0,-1,36
+PIP CH+,G.I.Cable,0,-1,37
+PIP +,G.I.Cable,0,-1,37
+PIP CH-,G.I.Cable,0,-1,38
+PIP -,G.I.Cable,0,-1,38
+B,G.I.Cable,0,-1,39
+C,G.I.Cable,0,-1,40
+C,G.I.Cable,0,-1,40
+EXIT,G.I.Cable,0,-1,40
+D,G.I.Cable,0,-1,41
+GUIDE,G.I.Cable,0,-1,48
+TV GUIDE,G.I.Cable,0,-1,48
+RECORD,G.I.Cable,0,-1,49
+REC,G.I.Cable,0,-1,49
+HELP,G.I.Cable,0,-1,50
+INFO,G.I.Cable,0,-1,51
+ARROW UP,G.I.Cable,0,-1,52
+MENU UP,G.I.Cable,0,-1,52
+CURSOR UP,G.I.Cable,0,-1,52
+UP ARROW,G.I.Cable,0,-1,52
+C UP,G.I.Cable,0,-1,52
+UP,G.I.Cable,0,-1,52
+C UP,G.I.Cable,0,-1,52
+MENU-UP,G.I.Cable,0,-1,52
+CURSER UP,G.I.Cable,0,-1,52
+ARROW DOWN,G.I.Cable,0,-1,53
+MENU DOWN,G.I.Cable,0,-1,53
+CURSOR DOWN,G.I.Cable,0,-1,53
+CURSOR DN,G.I.Cable,0,-1,53
+DOWN ARROW,G.I.Cable,0,-1,53
+C DOWN,G.I.Cable,0,-1,53
+ARROWN DOWN,G.I.Cable,0,-1,53
+DOWN,G.I.Cable,0,-1,53
+MENU-DOWN,G.I.Cable,0,-1,53
+CURSER DOWN,G.I.Cable,0,-1,53
+DN,G.I.Cable,0,-1,53
+ARROW LEFT,G.I.Cable,0,-1,54
+MENU LEFT,G.I.Cable,0,-1,54
+CURSOR LEFT,G.I.Cable,0,-1,54
+CURSOR LF,G.I.Cable,0,-1,54
+LEFT ARROW,G.I.Cable,0,-1,54
+C LEFT,G.I.Cable,0,-1,54
+LEFT,G.I.Cable,0,-1,54
+MENU-LEFT,G.I.Cable,0,-1,54
+CURSER LEFT,G.I.Cable,0,-1,54
+<,G.I.Cable,0,-1,54
+ARROW RIGHT,G.I.Cable,0,-1,55
+MENU RIGHT,G.I.Cable,0,-1,55
+CURSOR RIGHT,G.I.Cable,0,-1,55
+CURSOR RT,G.I.Cable,0,-1,55
+RIGHT ARROW,G.I.Cable,0,-1,55
+C RIGHT,G.I.Cable,0,-1,55
+RIGHT,G.I.Cable,0,-1,55
+C RIGHT,G.I.Cable,0,-1,55
+MENU-RIGHT,G.I.Cable,0,-1,55
+CURSER RIGHT,G.I.Cable,0,-1,55
+>,G.I.Cable,0,-1,55
+DAY -,G.I.Cable,0,-1,56
+PLAY,G.I.Cable,0,-1,56
+DAY +,G.I.Cable,0,-1,56
+>,G.I.Cable,0,-1,56
+DAY+,G.I.Cable,0,-1,56
+C,G.I.Cable,0,-1,56
+C DAY +,G.I.Cable,0,-1,56
+C (DAY +),G.I.Cable,0,-1,56
+DAY UP,G.I.Cable,0,-1,56
+DAY>,G.I.Cable,0,-1,56
+DAY FOR,G.I.Cable,0,-1,56
+DAY +,G.I.Cable,0,-1,57
+STOP,G.I.Cable,0,-1,57
+DAY -,G.I.Cable,0,-1,57
+DAY-,G.I.Cable,0,-1,57
+DAY =,G.I.Cable,0,-1,57
+B,G.I.Cable,0,-1,57
+B DAY -,G.I.Cable,0,-1,57
+B (DAY -),G.I.Cable,0,-1,57
+DAY DOWN,G.I.Cable,0,-1,57
+<DAY,G.I.Cable,0,-1,57
+DAT REV,G.I.Cable,0,-1,57
+PAGE +,G.I.Cable,0,-1,58
+PAGE /\,G.I.Cable,0,-1,58
+PAGE UP,G.I.Cable,0,-1,58
+PAGE+,G.I.Cable,0,-1,58
+PAGE -,G.I.Cable,0,-1,58
+PG UP,G.I.Cable,0,-1,58
+PAGE -,G.I.Cable,0,-1,59
+PAGE \/,G.I.Cable,0,-1,59
+PAGE --,G.I.Cable,0,-1,59
+PAGE DN,G.I.Cable,0,-1,59
+PAGE-,G.I.Cable,0,-1,59
+PAGE +,G.I.Cable,0,-1,59
+PAGE DOWN,G.I.Cable,0,-1,59
+PG DOWN,G.I.Cable,0,-1,59
+REPLAY,G.I.Cable,0,-1,60
+RE-PLAY,G.I.Cable,0,-1,60
+BACKUP,G.I.Cable,0,-1,60
+JUMP,G.I.Cable,0,-1,60
+BACK,G.I.Cable,0,-1,60
+INSTANT REPLAY,G.I.Cable,0,-1,60
+MUSIC,G.I.Cable,0,-1,60
+PIPTG,G.I.Cable,0,-1,60
+PPV,G.I.Cable,0,-1,60
+PREVIOUS,G.I.Cable,0,-1,60
+RETURN,G.I.Cable,0,-1,60
+LIST,G.I.Cable,0,-1,61
+MY DVR,G.I.Cable,0,-1,61
+P-SWP,G.I.Cable,0,-1,61
+DVR,G.I.Cable,0,-1,61
+DVR LIST,G.I.Cable,0,-1,61
+LIVE TV,G.I.Cable,0,-1,62
+LIVE,G.I.Cable,0,-1,62
+LOCKOUT,G.I.Cable,0,-1,62
+LV-TV,G.I.Cable,0,-1,62
+P-MOVE,G.I.Cable,0,-1,62
+FIOS TV,G.I.Cable,0,-1,62
+SKIP30,G.I.Cable,0,-1,63
+30 SECOND SKIP,G.I.Cable,0,-1,63
+SKIP FORWARD,G.I.Cable,0,-1,63
+NEXT,G.I.Cable,0,-1,63
+ASPECT,G.I.Cable,0,-1,64
+ENTER,G.I.Cable,0,-1,64
+HD ZOOM,G.I.Cable,0,-1,64
+*,G.I.Cable,0,-1,64
+HD ZOOM ENTER,G.I.Cable,0,-1,64
+OPTIONS,G.I.Cable,0,-1,66
+WIDGETS,G.I.Cable,0,-1,67
 DVD,NEC1,0,-1,79

--- a/codes/Motorola/Cox/0,-1.csv
+++ b/codes/Motorola/Cox/0,-1.csv
@@ -1,57 +1,57 @@
 functionname,protocol,device,subdevice,function
-0,G.I. Cable,0,-1,0
-1,G.I. Cable,0,-1,1
-2,G.I. Cable,0,-1,2
-3,G.I. Cable,0,-1,3
-4,G.I. Cable,0,-1,4
-5,G.I. Cable,0,-1,5
-6,G.I. Cable,0,-1,6
-7,G.I. Cable,0,-1,7
-8,G.I. Cable,0,-1,8
-9,G.I. Cable,0,-1,9
-POWER,G.I. Cable,0,-1,10
-CHANNEL +,G.I. Cable,0,-1,11
-CHANNEL -,G.I. Cable,0,-1,12
-#/ENTER,G.I. Cable,0,-1,16
-ENTER,G.I. Cable,0,-1,16
-ENTER,G.I. Cable,0,-1,17
-SELECT,G.I. Cable,0,-1,17
-CURSOR ENTER,G.I. Cable,0,-1,17
-EXIT,G.I. Cable,0,-1,18
-LAST,G.I. Cable,0,-1,19
-LAST CH.,G.I. Cable,0,-1,19
-A,G.I. Cable,0,-1,23
-MENU,G.I. Cable,0,-1,25
-SETTINGS,G.I. Cable,0,-1,25
-PLAY,G.I. Cable,0,-1,27
-STOP,G.I. Cable,0,-1,28
-FAST FWD,G.I. Cable,0,-1,29
-FAST-FORWARD,G.I. Cable,0,-1,29
-REWIND,G.I. Cable,0,-1,30
-PAUSE,G.I. Cable,0,-1,31
-B,G.I. Cable,0,-1,39
-C,G.I. Cable,0,-1,40
-GUIDE,G.I. Cable,0,-1,48
-RECORD,G.I. Cable,0,-1,49
-INFO,G.I. Cable,0,-1,51
-MENU UP,G.I. Cable,0,-1,52
-CURSOR UP,G.I. Cable,0,-1,52
-MENU DOWN,G.I. Cable,0,-1,53
-CURSOR DOWN,G.I. Cable,0,-1,53
-MENU LEFT,G.I. Cable,0,-1,54
-CURSOR LEFT,G.I. Cable,0,-1,54
-MENU RIGHT,G.I. Cable,0,-1,55
-CURSOR RIGHT,G.I. Cable,0,-1,55
-PLAY,G.I. Cable,0,-1,56
-DAY+,G.I. Cable,0,-1,56
-STOP,G.I. Cable,0,-1,57
-DAY-,G.I. Cable,0,-1,57
-PAGE +,G.I. Cable,0,-1,58
-PAGE+,G.I. Cable,0,-1,58
-PAGE -,G.I. Cable,0,-1,59
-PAGE-,G.I. Cable,0,-1,59
-REPLAY,G.I. Cable,0,-1,60
-RE-PLAY,G.I. Cable,0,-1,60
-LIST,G.I. Cable,0,-1,61
-LIVE TV,G.I. Cable,0,-1,62
-*,G.I. Cable,0,-1,64
+0,G.I.Cable,0,-1,0
+1,G.I.Cable,0,-1,1
+2,G.I.Cable,0,-1,2
+3,G.I.Cable,0,-1,3
+4,G.I.Cable,0,-1,4
+5,G.I.Cable,0,-1,5
+6,G.I.Cable,0,-1,6
+7,G.I.Cable,0,-1,7
+8,G.I.Cable,0,-1,8
+9,G.I.Cable,0,-1,9
+POWER,G.I.Cable,0,-1,10
+CHANNEL +,G.I.Cable,0,-1,11
+CHANNEL -,G.I.Cable,0,-1,12
+#/ENTER,G.I.Cable,0,-1,16
+ENTER,G.I.Cable,0,-1,16
+ENTER,G.I.Cable,0,-1,17
+SELECT,G.I.Cable,0,-1,17
+CURSOR ENTER,G.I.Cable,0,-1,17
+EXIT,G.I.Cable,0,-1,18
+LAST,G.I.Cable,0,-1,19
+LAST CH.,G.I.Cable,0,-1,19
+A,G.I.Cable,0,-1,23
+MENU,G.I.Cable,0,-1,25
+SETTINGS,G.I.Cable,0,-1,25
+PLAY,G.I.Cable,0,-1,27
+STOP,G.I.Cable,0,-1,28
+FAST FWD,G.I.Cable,0,-1,29
+FAST-FORWARD,G.I.Cable,0,-1,29
+REWIND,G.I.Cable,0,-1,30
+PAUSE,G.I.Cable,0,-1,31
+B,G.I.Cable,0,-1,39
+C,G.I.Cable,0,-1,40
+GUIDE,G.I.Cable,0,-1,48
+RECORD,G.I.Cable,0,-1,49
+INFO,G.I.Cable,0,-1,51
+MENU UP,G.I.Cable,0,-1,52
+CURSOR UP,G.I.Cable,0,-1,52
+MENU DOWN,G.I.Cable,0,-1,53
+CURSOR DOWN,G.I.Cable,0,-1,53
+MENU LEFT,G.I.Cable,0,-1,54
+CURSOR LEFT,G.I.Cable,0,-1,54
+MENU RIGHT,G.I.Cable,0,-1,55
+CURSOR RIGHT,G.I.Cable,0,-1,55
+PLAY,G.I.Cable,0,-1,56
+DAY+,G.I.Cable,0,-1,56
+STOP,G.I.Cable,0,-1,57
+DAY-,G.I.Cable,0,-1,57
+PAGE +,G.I.Cable,0,-1,58
+PAGE+,G.I.Cable,0,-1,58
+PAGE -,G.I.Cable,0,-1,59
+PAGE-,G.I.Cable,0,-1,59
+REPLAY,G.I.Cable,0,-1,60
+RE-PLAY,G.I.Cable,0,-1,60
+LIST,G.I.Cable,0,-1,61
+LIVE TV,G.I.Cable,0,-1,62
+*,G.I.Cable,0,-1,64

--- a/codes/Motorola/DVR/0,-1.csv
+++ b/codes/Motorola/DVR/0,-1.csv
@@ -1,47 +1,47 @@
 functionname,protocol,device,subdevice,function
-0,G.I. Cable,0,-1,0
-1,G.I. Cable,0,-1,1
-2,G.I. Cable,0,-1,2
-3,G.I. Cable,0,-1,3
-4,G.I. Cable,0,-1,4
-5,G.I. Cable,0,-1,5
-6,G.I. Cable,0,-1,6
-7,G.I. Cable,0,-1,7
-8,G.I. Cable,0,-1,8
-9,G.I. Cable,0,-1,9
-POWER,G.I. Cable,0,-1,10
-CHANNEL +,G.I. Cable,0,-1,11
-,G.I. Cable,0,-1,12
-CHANNEL -,G.I. Cable,0,-1,12
-ENTER,G.I. Cable,0,-1,17
-SELECT,G.I. Cable,0,-1,17
-EXIT,G.I. Cable,0,-1,18
-LAST,G.I. Cable,0,-1,19
-FAV,G.I. Cable,0,-1,21
-A,G.I. Cable,0,-1,23
-ON DEMAND,G.I. Cable,0,-1,26
-FFW,G.I. Cable,0,-1,29
-REW,G.I. Cable,0,-1,30
-PAUSE,G.I. Cable,0,-1,31
-B,G.I. Cable,0,-1,39
-C,G.I. Cable,0,-1,40
-GUIDE,G.I. Cable,0,-1,48
-RECALL,G.I. Cable,0,-1,49
-RECORD,G.I. Cable,0,-1,49
-SETTING,G.I. Cable,0,-1,50
-SETTINGS,G.I. Cable,0,-1,50
-INFO,G.I. Cable,0,-1,51
-UP,G.I. Cable,0,-1,52
-DOWN,G.I. Cable,0,-1,53
-LEFT,G.I. Cable,0,-1,54
-RIGHT,G.I. Cable,0,-1,55
-PLAY,G.I. Cable,0,-1,56
-NEW CODE,G.I. Cable,0,-1,57
-STOP,G.I. Cable,0,-1,57
-PAGE +,G.I. Cable,0,-1,58
-PAGE -,G.I. Cable,0,-1,59
-QUICK REWIND,G.I. Cable,0,-1,60
-DVR LIST,G.I. Cable,0,-1,61
-LIST,G.I. Cable,0,-1,61
-LIVE,G.I. Cable,0,-1,62
-HD ZOOM,G.I. Cable,0,-1,64
+0,G.I.Cable,0,-1,0
+1,G.I.Cable,0,-1,1
+2,G.I.Cable,0,-1,2
+3,G.I.Cable,0,-1,3
+4,G.I.Cable,0,-1,4
+5,G.I.Cable,0,-1,5
+6,G.I.Cable,0,-1,6
+7,G.I.Cable,0,-1,7
+8,G.I.Cable,0,-1,8
+9,G.I.Cable,0,-1,9
+POWER,G.I.Cable,0,-1,10
+CHANNEL +,G.I.Cable,0,-1,11
+,G.I.Cable,0,-1,12
+CHANNEL -,G.I.Cable,0,-1,12
+ENTER,G.I.Cable,0,-1,17
+SELECT,G.I.Cable,0,-1,17
+EXIT,G.I.Cable,0,-1,18
+LAST,G.I.Cable,0,-1,19
+FAV,G.I.Cable,0,-1,21
+A,G.I.Cable,0,-1,23
+ON DEMAND,G.I.Cable,0,-1,26
+FFW,G.I.Cable,0,-1,29
+REW,G.I.Cable,0,-1,30
+PAUSE,G.I.Cable,0,-1,31
+B,G.I.Cable,0,-1,39
+C,G.I.Cable,0,-1,40
+GUIDE,G.I.Cable,0,-1,48
+RECALL,G.I.Cable,0,-1,49
+RECORD,G.I.Cable,0,-1,49
+SETTING,G.I.Cable,0,-1,50
+SETTINGS,G.I.Cable,0,-1,50
+INFO,G.I.Cable,0,-1,51
+UP,G.I.Cable,0,-1,52
+DOWN,G.I.Cable,0,-1,53
+LEFT,G.I.Cable,0,-1,54
+RIGHT,G.I.Cable,0,-1,55
+PLAY,G.I.Cable,0,-1,56
+NEW CODE,G.I.Cable,0,-1,57
+STOP,G.I.Cable,0,-1,57
+PAGE +,G.I.Cable,0,-1,58
+PAGE -,G.I.Cable,0,-1,59
+QUICK REWIND,G.I.Cable,0,-1,60
+DVR LIST,G.I.Cable,0,-1,61
+LIST,G.I.Cable,0,-1,61
+LIVE,G.I.Cable,0,-1,62
+HD ZOOM,G.I.Cable,0,-1,64

--- a/codes/Motorola/Remote/0,-1.csv
+++ b/codes/Motorola/Remote/0,-1.csv
@@ -1,54 +1,54 @@
 functionname,protocol,device,subdevice,function
-0,G.I. Cable,0,-1,0
-1,G.I. Cable,0,-1,1
-2,G.I. Cable,0,-1,2
-3,G.I. Cable,0,-1,3
-4,G.I. Cable,0,-1,4
-5,G.I. Cable,0,-1,5
-6,G.I. Cable,0,-1,6
-7,G.I. Cable,0,-1,7
-8,G.I. Cable,0,-1,8
-9,G.I. Cable,0,-1,9
-MUSIC,G.I. Cable,0,-1,10
-POWER,G.I. Cable{1},0,-1,10
-CHANNEL +,G.I. Cable,0,-1,11
-CHANNEL -,G.I. Cable,0,-1,12
-ENTER,G.I. Cable,0,-1,16
-OK,G.I. Cable,0,-1,17
-LAST,G.I. Cable,0,-1,19
-INPUT,G.I. Cable,0,-1,20
-FAV,G.I. Cable,0,-1,21
-A,G.I. Cable,0,-1,23
-PPV,G.I. Cable,0,-1,24
-MENU,G.I. Cable,0,-1,25
-VOD,G.I. Cable,0,-1,26
-PLAY,G.I. Cable,0,-1,27
-STOP,G.I. Cable,0,-1,28
-FAST FOWARD,G.I. Cable,0,-1,29
-REWIND,G.I. Cable,0,-1,30
-PAUSE,G.I. Cable,0,-1,31
-PIP ON/OFF,G.I. Cable,0,-1,34
-PIP SWAP,G.I. Cable,0,-1,35
-PIP MOVE,G.I. Cable,0,-1,36
-PIP +,G.I. Cable,0,-1,37
-PIP -,G.I. Cable,0,-1,38
-B,G.I. Cable,0,-1,39
-C,G.I. Cable,0,-1,40
-EXIT,G.I. Cable,0,-1,40
-GUIDE,G.I. Cable,0,-1,48
-TV GUIDE,G.I. Cable,0,-1,48
-RECORD,G.I. Cable,0,-1,49
-HELP,G.I. Cable,0,-1,50
-INFO,G.I. Cable,0,-1,51
-UP,G.I. Cable,0,-1,52
-DOWN,G.I. Cable,0,-1,53
-LEFT,G.I. Cable,0,-1,54
-RIGHT,G.I. Cable,0,-1,55
-DAY -,G.I. Cable,0,-1,56
-DAY +,G.I. Cable,0,-1,57
-PAGE +,G.I. Cable,0,-1,58
-PAGE -,G.I. Cable,0,-1,59
-REPLAY,G.I. Cable,0,-1,60
-DVR LIST,G.I. Cable,0,-1,61
-LIVE TV,G.I. Cable,0,-1,62
-ASPECT,G.I. Cable,0,-1,64
+0,G.I.Cable,0,-1,0
+1,G.I.Cable,0,-1,1
+2,G.I.Cable,0,-1,2
+3,G.I.Cable,0,-1,3
+4,G.I.Cable,0,-1,4
+5,G.I.Cable,0,-1,5
+6,G.I.Cable,0,-1,6
+7,G.I.Cable,0,-1,7
+8,G.I.Cable,0,-1,8
+9,G.I.Cable,0,-1,9
+MUSIC,G.I.Cable,0,-1,10
+POWER,G.I.Cable,0,-1,10
+CHANNEL +,G.I.Cable,0,-1,11
+CHANNEL -,G.I.Cable,0,-1,12
+ENTER,G.I.Cable,0,-1,16
+OK,G.I.Cable,0,-1,17
+LAST,G.I.Cable,0,-1,19
+INPUT,G.I.Cable,0,-1,20
+FAV,G.I.Cable,0,-1,21
+A,G.I.Cable,0,-1,23
+PPV,G.I.Cable,0,-1,24
+MENU,G.I.Cable,0,-1,25
+VOD,G.I.Cable,0,-1,26
+PLAY,G.I.Cable,0,-1,27
+STOP,G.I.Cable,0,-1,28
+FAST FOWARD,G.I.Cable,0,-1,29
+REWIND,G.I.Cable,0,-1,30
+PAUSE,G.I.Cable,0,-1,31
+PIP ON/OFF,G.I.Cable,0,-1,34
+PIP SWAP,G.I.Cable,0,-1,35
+PIP MOVE,G.I.Cable,0,-1,36
+PIP +,G.I.Cable,0,-1,37
+PIP -,G.I.Cable,0,-1,38
+B,G.I.Cable,0,-1,39
+C,G.I.Cable,0,-1,40
+EXIT,G.I.Cable,0,-1,40
+GUIDE,G.I.Cable,0,-1,48
+TV GUIDE,G.I.Cable,0,-1,48
+RECORD,G.I.Cable,0,-1,49
+HELP,G.I.Cable,0,-1,50
+INFO,G.I.Cable,0,-1,51
+UP,G.I.Cable,0,-1,52
+DOWN,G.I.Cable,0,-1,53
+LEFT,G.I.Cable,0,-1,54
+RIGHT,G.I.Cable,0,-1,55
+DAY -,G.I.Cable,0,-1,56
+DAY +,G.I.Cable,0,-1,57
+PAGE +,G.I.Cable,0,-1,58
+PAGE -,G.I.Cable,0,-1,59
+REPLAY,G.I.Cable,0,-1,60
+DVR LIST,G.I.Cable,0,-1,61
+LIVE TV,G.I.Cable,0,-1,62
+ASPECT,G.I.Cable,0,-1,64

--- a/codes/Motorola/Unknown_Cable/0,-1.csv
+++ b/codes/Motorola/Unknown_Cable/0,-1.csv
@@ -1,37 +1,37 @@
 functionname,protocol,device,subdevice,function
-KEY_0,G.I. Cable{1},0,-1,0
-KEY_1,G.I. Cable{1},0,-1,1
-KEY_2,G.I. Cable{1},0,-1,2
-KEY_3,G.I. Cable{1},0,-1,3
-KEY_4,G.I. Cable{1},0,-1,4
-KEY_5,G.I. Cable{1},0,-1,5
-KEY_6,G.I. Cable{1},0,-1,6
-KEY_7,G.I. Cable{1},0,-1,7
-KEY_8,G.I. Cable{1},0,-1,8
-KEY_9,G.I. Cable{1},0,-1,9
-KEY_POWER,G.I. Cable{1},0,-1,10
-KEY_CHANNELUP,G.I. Cable{1},0,-1,11
-CHNDN,G.I. Cable{1},0,-1,12
-KEY_VOLUMEUP,G.I. Cable{1},0,-1,13
-KEY_VOLUMEDOWN,G.I. Cable{1},0,-1,14
-KEY_MUTE,G.I. Cable{1},0,-1,15
-KEY_AUDIO,G.I. Cable{1},0,-1,16
-KEY_EXIT,G.I. Cable{1},0,-1,18
-KEY_LAST,G.I. Cable{1},0,-1,19
-BYPASS,G.I. Cable{1},0,-1,20
-KEY_FAVORITES,G.I. Cable{1},0,-1,21
-PPV,G.I. Cable{1},0,-1,22
-THEME,G.I. Cable{1},0,-1,23
-KEY_MENU,G.I. Cable{1},0,-1,25
-KEY_LIST,G.I. Cable{1},0,-1,39
-KEY_CANCEL,G.I. Cable{1},0,-1,40
-KEY_INFO,G.I. Cable{1},0,-1,48
-KEY_INFO,G.I. Cable{1},0,-1,51
-KEY_UP,G.I. Cable{1},0,-1,52
-KEY_DOWN,G.I. Cable{1},0,-1,53
-KEY_LEFT,G.I. Cable{1},0,-1,54
-KEY_RIGHT,G.I. Cable{1},0,-1,55
-DAY+,G.I. Cable{1},0,-1,56
-DAY-,G.I. Cable{1},0,-1,57
-KEY_PAGEUP,G.I. Cable{1},0,-1,58
-PGDN,G.I. Cable{1},0,-1,59
+KEY_0,G.I.Cable,0,-1,0
+KEY_1,G.I.Cable,0,-1,1
+KEY_2,G.I.Cable,0,-1,2
+KEY_3,G.I.Cable,0,-1,3
+KEY_4,G.I.Cable,0,-1,4
+KEY_5,G.I.Cable,0,-1,5
+KEY_6,G.I.Cable,0,-1,6
+KEY_7,G.I.Cable,0,-1,7
+KEY_8,G.I.Cable,0,-1,8
+KEY_9,G.I.Cable,0,-1,9
+KEY_POWER,G.I.Cable,0,-1,10
+KEY_CHANNELUP,G.I.Cable,0,-1,11
+CHNDN,G.I.Cable,0,-1,12
+KEY_VOLUMEUP,G.I.Cable,0,-1,13
+KEY_VOLUMEDOWN,G.I.Cable,0,-1,14
+KEY_MUTE,G.I.Cable,0,-1,15
+KEY_AUDIO,G.I.Cable,0,-1,16
+KEY_EXIT,G.I.Cable,0,-1,18
+KEY_LAST,G.I.Cable,0,-1,19
+BYPASS,G.I.Cable,0,-1,20
+KEY_FAVORITES,G.I.Cable,0,-1,21
+PPV,G.I.Cable,0,-1,22
+THEME,G.I.Cable,0,-1,23
+KEY_MENU,G.I.Cable,0,-1,25
+KEY_LIST,G.I.Cable,0,-1,39
+KEY_CANCEL,G.I.Cable,0,-1,40
+KEY_INFO,G.I.Cable,0,-1,48
+KEY_INFO,G.I.Cable,0,-1,51
+KEY_UP,G.I.Cable,0,-1,52
+KEY_DOWN,G.I.Cable,0,-1,53
+KEY_LEFT,G.I.Cable,0,-1,54
+KEY_RIGHT,G.I.Cable,0,-1,55
+DAY+,G.I.Cable,0,-1,56
+DAY-,G.I.Cable,0,-1,57
+KEY_PAGEUP,G.I.Cable,0,-1,58
+PGDN,G.I.Cable,0,-1,59

--- a/codes/Motorola/Unknown_DCH3416/0,-1.csv
+++ b/codes/Motorola/Unknown_DCH3416/0,-1.csv
@@ -1,35 +1,35 @@
 functionname,protocol,device,subdevice,function
-KEY_0,G.I. Cable{1},0,-1,0
-KEY_1,G.I. Cable{1},0,-1,1
-KEY_2,G.I. Cable{1},0,-1,2
-KEY_3,G.I. Cable{1},0,-1,3
-KEY_4,G.I. Cable{1},0,-1,4
-KEY_5,G.I. Cable{1},0,-1,5
-KEY_6,G.I. Cable{1},0,-1,6
-KEY_7,G.I. Cable{1},0,-1,7
-KEY_8,G.I. Cable{1},0,-1,8
-KEY_9,G.I. Cable{1},0,-1,9
-KEY_POWER,G.I. Cable{1},0,-1,10
-KEY_CHANNELUP,G.I. Cable{1},0,-1,11
-KEY_CHANNELDOWN,G.I. Cable{1},0,-1,12
-OK/Select,G.I. Cable{1},0,-1,17
-KEY_EXIT,G.I. Cable{1},0,-1,18
-KEY_LAST,G.I. Cable{1},0,-1,19
-KEY_FAVORITES,G.I. Cable{1},0,-1,21
-KEY_MENU,G.I. Cable{1},0,-1,25
-KEY_POWER,G.I. Cable{1},0,-1,26
-KEY_PLAY,G.I. Cable{1},0,-1,27
-KEY_STOP,G.I. Cable{1},0,-1,28
-KEY_FASTFORWARD,G.I. Cable{1},0,-1,29
-KEY_REWIND,G.I. Cable{1},0,-1,30
-KEY_PAUSE,G.I. Cable{1},0,-1,31
-KEY_INFO,G.I. Cable{1},0,-1,48
-KEY_RECORD,G.I. Cable{1},0,-1,49
-KEY_INFO,G.I. Cable{1},0,-1,51
-KEY_UP,G.I. Cable{1},0,-1,52
-KEY_DOWN,G.I. Cable{1},0,-1,53
-KEY_LEFT,G.I. Cable{1},0,-1,54
-KEY_RIGHT,G.I. Cable{1},0,-1,55
-KEY_PAGEUP,G.I. Cable{1},0,-1,58
-KEY_PAGEDOWN,G.I. Cable{1},0,-1,59
-MYDVR,G.I. Cable{1},0,-1,61
+KEY_0,G.I.Cable,0,-1,0
+KEY_1,G.I.Cable,0,-1,1
+KEY_2,G.I.Cable,0,-1,2
+KEY_3,G.I.Cable,0,-1,3
+KEY_4,G.I.Cable,0,-1,4
+KEY_5,G.I.Cable,0,-1,5
+KEY_6,G.I.Cable,0,-1,6
+KEY_7,G.I.Cable,0,-1,7
+KEY_8,G.I.Cable,0,-1,8
+KEY_9,G.I.Cable,0,-1,9
+KEY_POWER,G.I.Cable,0,-1,10
+KEY_CHANNELUP,G.I.Cable,0,-1,11
+KEY_CHANNELDOWN,G.I.Cable,0,-1,12
+OK/Select,G.I.Cable,0,-1,17
+KEY_EXIT,G.I.Cable,0,-1,18
+KEY_LAST,G.I.Cable,0,-1,19
+KEY_FAVORITES,G.I.Cable,0,-1,21
+KEY_MENU,G.I.Cable,0,-1,25
+KEY_POWER,G.I.Cable,0,-1,26
+KEY_PLAY,G.I.Cable,0,-1,27
+KEY_STOP,G.I.Cable,0,-1,28
+KEY_FASTFORWARD,G.I.Cable,0,-1,29
+KEY_REWIND,G.I.Cable,0,-1,30
+KEY_PAUSE,G.I.Cable,0,-1,31
+KEY_INFO,G.I.Cable,0,-1,48
+KEY_RECORD,G.I.Cable,0,-1,49
+KEY_INFO,G.I.Cable,0,-1,51
+KEY_UP,G.I.Cable,0,-1,52
+KEY_DOWN,G.I.Cable,0,-1,53
+KEY_LEFT,G.I.Cable,0,-1,54
+KEY_RIGHT,G.I.Cable,0,-1,55
+KEY_PAGEUP,G.I.Cable,0,-1,58
+KEY_PAGEDOWN,G.I.Cable,0,-1,59
+MYDVR,G.I.Cable,0,-1,61

--- a/codes/Motorola/Unknown_DCT2000/0,-1.csv
+++ b/codes/Motorola/Unknown_DCT2000/0,-1.csv
@@ -1,42 +1,42 @@
 functionname,protocol,device,subdevice,function
-KEY_0,G.I. Cable{1},0,-1,0
-KEY_1,G.I. Cable{1},0,-1,1
-KEY_2,G.I. Cable{1},0,-1,2
-KEY_3,G.I. Cable{1},0,-1,3
-KEY_4,G.I. Cable{1},0,-1,4
-KEY_5,G.I. Cable{1},0,-1,5
-KEY_6,G.I. Cable{1},0,-1,6
-KEY_7,G.I. Cable{1},0,-1,7
-KEY_8,G.I. Cable{1},0,-1,8
-KEY_9,G.I. Cable{1},0,-1,9
-KEY_POWER,G.I. Cable{1},0,-1,10
-KEY_CHANNELUP,G.I. Cable{1},0,-1,11
-KEY_CHANNELDOWN,G.I. Cable{1},0,-1,12
-KEY_VOLUMEUP,G.I. Cable{1},0,-1,13
-KEY_VOLUMEDOWN,G.I. Cable{1},0,-1,14
-KEY_MUTE,G.I. Cable{1},0,-1,15
-KEY_AUDIO,G.I. Cable{1},0,-1,16
-KEY_OK,G.I. Cable{1},0,-1,17
-KEY_EXIT,G.I. Cable{1},0,-1,18
-KEY_LAST,G.I. Cable{1},0,-1,19
-BYPASS,G.I. Cable{1},0,-1,20
-KEY_FAVORITES,G.I. Cable{1},0,-1,21
-LOCK,G.I. Cable{1},0,-1,22
-KEY_A,G.I. Cable{1},0,-1,23
-KEY_MENU,G.I. Cable{1},0,-1,25
-KEY_FASTFORWARD,G.I. Cable{1},0,-1,29
-KEY_REWIND,G.I. Cable{1},0,-1,30
-KEY_PAUSE,G.I. Cable{1},0,-1,31
-KEY_B,G.I. Cable{1},0,-1,39
-KEY_C,G.I. Cable{1},0,-1,40
-KEY_INFO,G.I. Cable{1},0,-1,48
-KEY_RECORD,G.I. Cable{1},0,-1,49
-KEY_HELP,G.I. Cable{1},0,-1,50
-AUP,G.I. Cable{1},0,-1,52
-ADOWN,G.I. Cable{1},0,-1,53
-ALEFT,G.I. Cable{1},0,-1,54
-ARIGHT,G.I. Cable{1},0,-1,55
-KEY_PLAY,G.I. Cable{1},0,-1,56
-KEY_STOP,G.I. Cable{1},0,-1,57
-KEY_PAGEUP,G.I. Cable{1},0,-1,58
-KEY_PAGEDOWN,G.I. Cable{1},0,-1,59
+KEY_0,G.I.Cable,0,-1,0
+KEY_1,G.I.Cable,0,-1,1
+KEY_2,G.I.Cable,0,-1,2
+KEY_3,G.I.Cable,0,-1,3
+KEY_4,G.I.Cable,0,-1,4
+KEY_5,G.I.Cable,0,-1,5
+KEY_6,G.I.Cable,0,-1,6
+KEY_7,G.I.Cable,0,-1,7
+KEY_8,G.I.Cable,0,-1,8
+KEY_9,G.I.Cable,0,-1,9
+KEY_POWER,G.I.Cable,0,-1,10
+KEY_CHANNELUP,G.I.Cable,0,-1,11
+KEY_CHANNELDOWN,G.I.Cable,0,-1,12
+KEY_VOLUMEUP,G.I.Cable,0,-1,13
+KEY_VOLUMEDOWN,G.I.Cable,0,-1,14
+KEY_MUTE,G.I.Cable,0,-1,15
+KEY_AUDIO,G.I.Cable,0,-1,16
+KEY_OK,G.I.Cable,0,-1,17
+KEY_EXIT,G.I.Cable,0,-1,18
+KEY_LAST,G.I.Cable,0,-1,19
+BYPASS,G.I.Cable,0,-1,20
+KEY_FAVORITES,G.I.Cable,0,-1,21
+LOCK,G.I.Cable,0,-1,22
+KEY_A,G.I.Cable,0,-1,23
+KEY_MENU,G.I.Cable,0,-1,25
+KEY_FASTFORWARD,G.I.Cable,0,-1,29
+KEY_REWIND,G.I.Cable,0,-1,30
+KEY_PAUSE,G.I.Cable,0,-1,31
+KEY_B,G.I.Cable,0,-1,39
+KEY_C,G.I.Cable,0,-1,40
+KEY_INFO,G.I.Cable,0,-1,48
+KEY_RECORD,G.I.Cable,0,-1,49
+KEY_HELP,G.I.Cable,0,-1,50
+AUP,G.I.Cable,0,-1,52
+ADOWN,G.I.Cable,0,-1,53
+ALEFT,G.I.Cable,0,-1,54
+ARIGHT,G.I.Cable,0,-1,55
+KEY_PLAY,G.I.Cable,0,-1,56
+KEY_STOP,G.I.Cable,0,-1,57
+KEY_PAGEUP,G.I.Cable,0,-1,58
+KEY_PAGEDOWN,G.I.Cable,0,-1,59

--- a/codes/Motorola/Unknown_DCT2244/0,-1.csv
+++ b/codes/Motorola/Unknown_DCT2244/0,-1.csv
@@ -1,11 +1,11 @@
 functionname,protocol,device,subdevice,function
-KEY_0,G.I. Cable{1},0,-1,0
-KEY_1,G.I. Cable{1},0,-1,1
-KEY_2,G.I. Cable{1},0,-1,2
-KEY_3,G.I. Cable{1},0,-1,3
-KEY_4,G.I. Cable{1},0,-1,4
-KEY_5,G.I. Cable{1},0,-1,5
-KEY_6,G.I. Cable{1},0,-1,6
-KEY_7,G.I. Cable{1},0,-1,7
-KEY_8,G.I. Cable{1},0,-1,8
-KEY_9,G.I. Cable{1},0,-1,9
+KEY_0,G.I.Cable,0,-1,0
+KEY_1,G.I.Cable,0,-1,1
+KEY_2,G.I.Cable,0,-1,2
+KEY_3,G.I.Cable,0,-1,3
+KEY_4,G.I.Cable,0,-1,4
+KEY_5,G.I.Cable,0,-1,5
+KEY_6,G.I.Cable,0,-1,6
+KEY_7,G.I.Cable,0,-1,7
+KEY_8,G.I.Cable,0,-1,8
+KEY_9,G.I.Cable,0,-1,9

--- a/codes/Motorola/Unknown_DCT2524/0,-1.csv
+++ b/codes/Motorola/Unknown_DCT2524/0,-1.csv
@@ -1,46 +1,46 @@
 functionname,protocol,device,subdevice,function
-KEY_0,G.I. Cable{1},0,-1,0
-KEY_1,G.I. Cable{1},0,-1,1
-KEY_2,G.I. Cable{1},0,-1,2
-KEY_3,G.I. Cable{1},0,-1,3
-KEY_4,G.I. Cable{1},0,-1,4
-KEY_5,G.I. Cable{1},0,-1,5
-KEY_6,G.I. Cable{1},0,-1,6
-KEY_7,G.I. Cable{1},0,-1,7
-KEY_8,G.I. Cable{1},0,-1,8
-KEY_9,G.I. Cable{1},0,-1,9
-KEY_POWER,G.I. Cable{1},0,-1,10
-KEY_CHANNELUP,G.I. Cable{1},0,-1,11
-KEY_CHANNELDOWN,G.I. Cable{1},0,-1,12
-KEY_VOLUMEUP,G.I. Cable{1},0,-1,13
-KEY_VOLUMEDOWN,G.I. Cable{1},0,-1,14
-KEY_MUTE,G.I. Cable{1},0,-1,15
-ok/select,G.I. Cable{1},0,-1,17
-KEY_EXIT,G.I. Cable{1},0,-1,18
-KEY_LAST,G.I. Cable{1},0,-1,19
-tv/vcr_input,G.I. Cable{1},0,-1,20
-KEY_FAVORITES,G.I. Cable{1},0,-1,21
-a_lock,G.I. Cable{1},0,-1,22
-KEY_MENU,G.I. Cable{1},0,-1,25
-KEY_PLAY,G.I. Cable{1},0,-1,27
-KEY_STOP,G.I. Cable{1},0,-1,28
-KEY_FASTFORWARD,G.I. Cable{1},0,-1,29
-KEY_REWIND,G.I. Cable{1},0,-1,30
-KEY_PAUSE,G.I. Cable{1},0,-1,31
-pnp-swap,G.I. Cable{1},0,-1,35
-KEY_INFO,G.I. Cable{1},0,-1,48
-KEY_RECORD,G.I. Cable{1},0,-1,49
-KEY_HELP,G.I. Cable{1},0,-1,50
-KEY_INFO,G.I. Cable{1},0,-1,51
-KEY_UP,G.I. Cable{1},0,-1,52
-KEY_DOWN,G.I. Cable{1},0,-1,53
-KEY_LEFT,G.I. Cable{1},0,-1,54
-KEY_RIGHT,G.I. Cable{1},0,-1,55
-c_day+,G.I. Cable{1},0,-1,56
-b_day-,G.I. Cable{1},0,-1,57
-KEY_PAGEUP,G.I. Cable{1},0,-1,58
-KEY_PAGEDOWN,G.I. Cable{1},0,-1,59
-KEY_REWIND,G.I. Cable{1},0,-1,60
-mydvr,G.I. Cable{1},0,-1,61
-live,G.I. Cable{1},0,-1,62
-hdzoom_enter,G.I. Cable{1},0,-1,64
+KEY_0,G.I.Cable,0,-1,0
+KEY_1,G.I.Cable,0,-1,1
+KEY_2,G.I.Cable,0,-1,2
+KEY_3,G.I.Cable,0,-1,3
+KEY_4,G.I.Cable,0,-1,4
+KEY_5,G.I.Cable,0,-1,5
+KEY_6,G.I.Cable,0,-1,6
+KEY_7,G.I.Cable,0,-1,7
+KEY_8,G.I.Cable,0,-1,8
+KEY_9,G.I.Cable,0,-1,9
+KEY_POWER,G.I.Cable,0,-1,10
+KEY_CHANNELUP,G.I.Cable,0,-1,11
+KEY_CHANNELDOWN,G.I.Cable,0,-1,12
+KEY_VOLUMEUP,G.I.Cable,0,-1,13
+KEY_VOLUMEDOWN,G.I.Cable,0,-1,14
+KEY_MUTE,G.I.Cable,0,-1,15
+ok/select,G.I.Cable,0,-1,17
+KEY_EXIT,G.I.Cable,0,-1,18
+KEY_LAST,G.I.Cable,0,-1,19
+tv/vcr_input,G.I.Cable,0,-1,20
+KEY_FAVORITES,G.I.Cable,0,-1,21
+a_lock,G.I.Cable,0,-1,22
+KEY_MENU,G.I.Cable,0,-1,25
+KEY_PLAY,G.I.Cable,0,-1,27
+KEY_STOP,G.I.Cable,0,-1,28
+KEY_FASTFORWARD,G.I.Cable,0,-1,29
+KEY_REWIND,G.I.Cable,0,-1,30
+KEY_PAUSE,G.I.Cable,0,-1,31
+pnp-swap,G.I.Cable,0,-1,35
+KEY_INFO,G.I.Cable,0,-1,48
+KEY_RECORD,G.I.Cable,0,-1,49
+KEY_HELP,G.I.Cable,0,-1,50
+KEY_INFO,G.I.Cable,0,-1,51
+KEY_UP,G.I.Cable,0,-1,52
+KEY_DOWN,G.I.Cable,0,-1,53
+KEY_LEFT,G.I.Cable,0,-1,54
+KEY_RIGHT,G.I.Cable,0,-1,55
+c_day+,G.I.Cable,0,-1,56
+b_day-,G.I.Cable,0,-1,57
+KEY_PAGEUP,G.I.Cable,0,-1,58
+KEY_PAGEDOWN,G.I.Cable,0,-1,59
+KEY_REWIND,G.I.Cable,0,-1,60
+mydvr,G.I.Cable,0,-1,61
+live,G.I.Cable,0,-1,62
+hdzoom_enter,G.I.Cable,0,-1,64

--- a/codes/Motorola/Unknown_DRC800/0,-1.csv
+++ b/codes/Motorola/Unknown_DRC800/0,-1.csv
@@ -1,54 +1,54 @@
 functionname,protocol,device,subdevice,function
-KEY_0,G.I. Cable{1},0,-1,0
-KEY_1,G.I. Cable{1},0,-1,1
-KEY_2,G.I. Cable{1},0,-1,2
-KEY_3,G.I. Cable{1},0,-1,3
-KEY_4,G.I. Cable{1},0,-1,4
-KEY_5,G.I. Cable{1},0,-1,5
-KEY_6,G.I. Cable{1},0,-1,6
-KEY_7,G.I. Cable{1},0,-1,7
-KEY_8,G.I. Cable{1},0,-1,8
-KEY_9,G.I. Cable{1},0,-1,9
-KEY_POWER,G.I. Cable{1},0,-1,10
-KEY_CHANNELUP,G.I. Cable{1},0,-1,11
-KEY_CHANNELDOWN,G.I. Cable{1},0,-1,12
-KEY_VOLUMEUP,G.I. Cable{1},0,-1,13
-KEY_VOLUMEDOWN,G.I. Cable{1},0,-1,14
-KEY_MUTE,G.I. Cable{1},0,-1,15
-KEY_OK,G.I. Cable{1},0,-1,17
-KEY_EXIT,G.I. Cable{1},0,-1,18
-KEY_LAST,G.I. Cable{1},0,-1,19
-input,G.I. Cable{1},0,-1,20
-KEY_FAVORITES,G.I. Cable{1},0,-1,21
-KEY_A,G.I. Cable{1},0,-1,23
-ppv,G.I. Cable{1},0,-1,24
-KEY_MENU,G.I. Cable{1},0,-1,25
-vod,G.I. Cable{1},0,-1,26
-KEY_PLAY,G.I. Cable{1},0,-1,27
-KEY_STOP,G.I. Cable{1},0,-1,28
-KEY_FORWARD,G.I. Cable{1},0,-1,29
-KEY_REWIND,G.I. Cable{1},0,-1,30
-KEY_PAUSE,G.I. Cable{1},0,-1,31
-pip_onoff,G.I. Cable{1},0,-1,34
-pip_swap,G.I. Cable{1},0,-1,35
-pip_move,G.I. Cable{1},0,-1,36
-pip_chan_up,G.I. Cable{1},0,-1,37
-pip_chan_down,G.I. Cable{1},0,-1,38
-KEY_B,G.I. Cable{1},0,-1,39
-KEY_C,G.I. Cable{1},0,-1,40
-KEY_INFO,G.I. Cable{1},0,-1,48
-KEY_RECORD,G.I. Cable{1},0,-1,49
-KEY_HELP,G.I. Cable{1},0,-1,50
-KEY_INFO,G.I. Cable{1},0,-1,51
-KEY_UP,G.I. Cable{1},0,-1,52
-KEY_DOWN,G.I. Cable{1},0,-1,53
-KEY_LEFT,G.I. Cable{1},0,-1,54
-KEY_RIGHT,G.I. Cable{1},0,-1,55
-day-plus,G.I. Cable{1},0,-1,56
-day-minus,G.I. Cable{1},0,-1,57
-KEY_PAGEUP,G.I. Cable{1},0,-1,58
-KEY_PAGEDOWN,G.I. Cable{1},0,-1,59
-KEY_AGAIN,G.I. Cable{1},0,-1,60
-KEY_LIST,G.I. Cable{1},0,-1,61
-KEY_TV,G.I. Cable{1},0,-1,62
-aspect,G.I. Cable{1},0,-1,64
+KEY_0,G.I.Cable,0,-1,0
+KEY_1,G.I.Cable,0,-1,1
+KEY_2,G.I.Cable,0,-1,2
+KEY_3,G.I.Cable,0,-1,3
+KEY_4,G.I.Cable,0,-1,4
+KEY_5,G.I.Cable,0,-1,5
+KEY_6,G.I.Cable,0,-1,6
+KEY_7,G.I.Cable,0,-1,7
+KEY_8,G.I.Cable,0,-1,8
+KEY_9,G.I.Cable,0,-1,9
+KEY_POWER,G.I.Cable,0,-1,10
+KEY_CHANNELUP,G.I.Cable,0,-1,11
+KEY_CHANNELDOWN,G.I.Cable,0,-1,12
+KEY_VOLUMEUP,G.I.Cable,0,-1,13
+KEY_VOLUMEDOWN,G.I.Cable,0,-1,14
+KEY_MUTE,G.I.Cable,0,-1,15
+KEY_OK,G.I.Cable,0,-1,17
+KEY_EXIT,G.I.Cable,0,-1,18
+KEY_LAST,G.I.Cable,0,-1,19
+input,G.I.Cable,0,-1,20
+KEY_FAVORITES,G.I.Cable,0,-1,21
+KEY_A,G.I.Cable,0,-1,23
+ppv,G.I.Cable,0,-1,24
+KEY_MENU,G.I.Cable,0,-1,25
+vod,G.I.Cable,0,-1,26
+KEY_PLAY,G.I.Cable,0,-1,27
+KEY_STOP,G.I.Cable,0,-1,28
+KEY_FORWARD,G.I.Cable,0,-1,29
+KEY_REWIND,G.I.Cable,0,-1,30
+KEY_PAUSE,G.I.Cable,0,-1,31
+pip_onoff,G.I.Cable,0,-1,34
+pip_swap,G.I.Cable,0,-1,35
+pip_move,G.I.Cable,0,-1,36
+pip_chan_up,G.I.Cable,0,-1,37
+pip_chan_down,G.I.Cable,0,-1,38
+KEY_B,G.I.Cable,0,-1,39
+KEY_C,G.I.Cable,0,-1,40
+KEY_INFO,G.I.Cable,0,-1,48
+KEY_RECORD,G.I.Cable,0,-1,49
+KEY_HELP,G.I.Cable,0,-1,50
+KEY_INFO,G.I.Cable,0,-1,51
+KEY_UP,G.I.Cable,0,-1,52
+KEY_DOWN,G.I.Cable,0,-1,53
+KEY_LEFT,G.I.Cable,0,-1,54
+KEY_RIGHT,G.I.Cable,0,-1,55
+day-plus,G.I.Cable,0,-1,56
+day-minus,G.I.Cable,0,-1,57
+KEY_PAGEUP,G.I.Cable,0,-1,58
+KEY_PAGEDOWN,G.I.Cable,0,-1,59
+KEY_AGAIN,G.I.Cable,0,-1,60
+KEY_LIST,G.I.Cable,0,-1,61
+KEY_TV,G.I.Cable,0,-1,62
+aspect,G.I.Cable,0,-1,64

--- a/codes/Motorola/Unknown_DVi2030/0,-1.csv
+++ b/codes/Motorola/Unknown_DVi2030/0,-1.csv
@@ -1,34 +1,34 @@
 functionname,protocol,device,subdevice,function
-KEY_0,G.I. Cable{1},0,-1,0
-KEY_1,G.I. Cable{1},0,-1,1
-KEY_2,G.I. Cable{1},0,-1,2
-KEY_3,G.I. Cable{1},0,-1,3
-KEY_4,G.I. Cable{1},0,-1,4
-KEY_5,G.I. Cable{1},0,-1,5
-KEY_6,G.I. Cable{1},0,-1,6
-KEY_7,G.I. Cable{1},0,-1,7
-KEY_8,G.I. Cable{1},0,-1,8
-KEY_9,G.I. Cable{1},0,-1,9
-KEY_POWER,G.I. Cable{1},0,-1,10
-KEY_CHANNELUP,G.I. Cable{1},0,-1,11
-KEY_CHANNELDOWN,G.I. Cable{1},0,-1,12
-KEY_VOLUMEUP,G.I. Cable{1},0,-1,13
-KEY_VOLUMEDOWN,G.I. Cable{1},0,-1,14
-KEY_MUTE,G.I. Cable{1},0,-1,15
-KEY_OK,G.I. Cable{1},0,-1,17
-KEY_BACK,G.I. Cable{1},0,-1,19
-KEY_LANGUAGE,G.I. Cable{1},0,-1,23
-KEY_POWER,G.I. Cable{1},0,-1,25
-KEY_HELP,G.I. Cable{1},0,-1,50
-KEY_INFO,G.I. Cable{1},0,-1,51
-KEY_UP,G.I. Cable{1},0,-1,52
-KEY_DOWN,G.I. Cable{1},0,-1,53
-KEY_LEFT,G.I. Cable{1},0,-1,54
-KEY_RIGHT,G.I. Cable{1},0,-1,55
-KEY_RED,G.I. Cable{1},0,-1,110
-KEY_GREEN,G.I. Cable{1},0,-1,111
-yelow,G.I. Cable{1},0,-1,112
-KEY_BLUE,G.I. Cable{1},0,-1,113
-grey,G.I. Cable{1},0,-1,114
-ojo,G.I. Cable{1},0,-1,216
-KEY_EXIT,G.I. Cable{1},0,-1,251
+KEY_0,G.I.Cable,0,-1,0
+KEY_1,G.I.Cable,0,-1,1
+KEY_2,G.I.Cable,0,-1,2
+KEY_3,G.I.Cable,0,-1,3
+KEY_4,G.I.Cable,0,-1,4
+KEY_5,G.I.Cable,0,-1,5
+KEY_6,G.I.Cable,0,-1,6
+KEY_7,G.I.Cable,0,-1,7
+KEY_8,G.I.Cable,0,-1,8
+KEY_9,G.I.Cable,0,-1,9
+KEY_POWER,G.I.Cable,0,-1,10
+KEY_CHANNELUP,G.I.Cable,0,-1,11
+KEY_CHANNELDOWN,G.I.Cable,0,-1,12
+KEY_VOLUMEUP,G.I.Cable,0,-1,13
+KEY_VOLUMEDOWN,G.I.Cable,0,-1,14
+KEY_MUTE,G.I.Cable,0,-1,15
+KEY_OK,G.I.Cable,0,-1,17
+KEY_BACK,G.I.Cable,0,-1,19
+KEY_LANGUAGE,G.I.Cable,0,-1,23
+KEY_POWER,G.I.Cable,0,-1,25
+KEY_HELP,G.I.Cable,0,-1,50
+KEY_INFO,G.I.Cable,0,-1,51
+KEY_UP,G.I.Cable,0,-1,52
+KEY_DOWN,G.I.Cable,0,-1,53
+KEY_LEFT,G.I.Cable,0,-1,54
+KEY_RIGHT,G.I.Cable,0,-1,55
+KEY_RED,G.I.Cable,0,-1,110
+KEY_GREEN,G.I.Cable,0,-1,111
+yelow,G.I.Cable,0,-1,112
+KEY_BLUE,G.I.Cable,0,-1,113
+grey,G.I.Cable,0,-1,114
+ojo,G.I.Cable,0,-1,216
+KEY_EXIT,G.I.Cable,0,-1,251

--- a/codes/Motorola/Unknown_MOTOROLA/0,-1.csv
+++ b/codes/Motorola/Unknown_MOTOROLA/0,-1.csv
@@ -1,45 +1,45 @@
 functionname,protocol,device,subdevice,function
-KEY_0,G.I. Cable{1},0,-1,0
-KEY_1,G.I. Cable{1},0,-1,1
-KEY_2,G.I. Cable{1},0,-1,2
-KEY_3,G.I. Cable{1},0,-1,3
-KEY_4,G.I. Cable{1},0,-1,4
-KEY_5,G.I. Cable{1},0,-1,5
-KEY_6,G.I. Cable{1},0,-1,6
-KEY_7,G.I. Cable{1},0,-1,7
-KEY_8,G.I. Cable{1},0,-1,8
-KEY_9,G.I. Cable{1},0,-1,9
-KEY_POWER,G.I. Cable{1},0,-1,10
-KEY_CHANNELUP,G.I. Cable{1},0,-1,11
-KEY_CHANNELDOWN,G.I. Cable{1},0,-1,12
-KEY_VOLUMEUP,G.I. Cable{1},0,-1,13
-KEY_VOLUMEDOWN,G.I. Cable{1},0,-1,14
-KEY_MUTE,G.I. Cable{1},0,-1,15
-KEY_ENTER,G.I. Cable{1},0,-1,16
-KEY_OK,G.I. Cable{1},0,-1,17
-KEY_EXIT,G.I. Cable{1},0,-1,18
-KEY_LAST,G.I. Cable{1},0,-1,19
-bypass,G.I. Cable{1},0,-1,20
-KEY_FAVORITES,G.I. Cable{1},0,-1,21
-lock,G.I. Cable{1},0,-1,22
-KEY_A,G.I. Cable{1},0,-1,23
-KEY_MENU,G.I. Cable{1},0,-1,25
-KEY_FASTFORWARD,G.I. Cable{1},0,-1,29
-KEY_REWIND,G.I. Cable{1},0,-1,30
-KEY_PAUSE,G.I. Cable{1},0,-1,31
-KEY_B,G.I. Cable{1},0,-1,39
-KEY_C,G.I. Cable{1},0,-1,40
-KEY_INFO,G.I. Cable{1},0,-1,48
-KEY_RECORD,G.I. Cable{1},0,-1,49
-KEY_HELP,G.I. Cable{1},0,-1,50
-KEY_INFO,G.I. Cable{1},0,-1,51
-KEY_UP,G.I. Cable{1},0,-1,52
-KEY_DOWN,G.I. Cable{1},0,-1,53
-KEY_LEFT,G.I. Cable{1},0,-1,54
-KEY_RIGHT,G.I. Cable{1},0,-1,55
-KEY_PLAY,G.I. Cable{1},0,-1,56
-day+,G.I. Cable{1},0,-1,56
-KEY_STOP,G.I. Cable{1},0,-1,57
-day-,G.I. Cable{1},0,-1,57
-KEY_PAGEUP,G.I. Cable{1},0,-1,58
-KEY_PAGEDOWN,G.I. Cable{1},0,-1,59
+KEY_0,G.I.Cable,0,-1,0
+KEY_1,G.I.Cable,0,-1,1
+KEY_2,G.I.Cable,0,-1,2
+KEY_3,G.I.Cable,0,-1,3
+KEY_4,G.I.Cable,0,-1,4
+KEY_5,G.I.Cable,0,-1,5
+KEY_6,G.I.Cable,0,-1,6
+KEY_7,G.I.Cable,0,-1,7
+KEY_8,G.I.Cable,0,-1,8
+KEY_9,G.I.Cable,0,-1,9
+KEY_POWER,G.I.Cable,0,-1,10
+KEY_CHANNELUP,G.I.Cable,0,-1,11
+KEY_CHANNELDOWN,G.I.Cable,0,-1,12
+KEY_VOLUMEUP,G.I.Cable,0,-1,13
+KEY_VOLUMEDOWN,G.I.Cable,0,-1,14
+KEY_MUTE,G.I.Cable,0,-1,15
+KEY_ENTER,G.I.Cable,0,-1,16
+KEY_OK,G.I.Cable,0,-1,17
+KEY_EXIT,G.I.Cable,0,-1,18
+KEY_LAST,G.I.Cable,0,-1,19
+bypass,G.I.Cable,0,-1,20
+KEY_FAVORITES,G.I.Cable,0,-1,21
+lock,G.I.Cable,0,-1,22
+KEY_A,G.I.Cable,0,-1,23
+KEY_MENU,G.I.Cable,0,-1,25
+KEY_FASTFORWARD,G.I.Cable,0,-1,29
+KEY_REWIND,G.I.Cable,0,-1,30
+KEY_PAUSE,G.I.Cable,0,-1,31
+KEY_B,G.I.Cable,0,-1,39
+KEY_C,G.I.Cable,0,-1,40
+KEY_INFO,G.I.Cable,0,-1,48
+KEY_RECORD,G.I.Cable,0,-1,49
+KEY_HELP,G.I.Cable,0,-1,50
+KEY_INFO,G.I.Cable,0,-1,51
+KEY_UP,G.I.Cable,0,-1,52
+KEY_DOWN,G.I.Cable,0,-1,53
+KEY_LEFT,G.I.Cable,0,-1,54
+KEY_RIGHT,G.I.Cable,0,-1,55
+KEY_PLAY,G.I.Cable,0,-1,56
+day+,G.I.Cable,0,-1,56
+KEY_STOP,G.I.Cable,0,-1,57
+day-,G.I.Cable,0,-1,57
+KEY_PAGEUP,G.I.Cable,0,-1,58
+KEY_PAGEDOWN,G.I.Cable,0,-1,59

--- a/codes/Motorola/Unknown_QIP2500/0,-1.csv
+++ b/codes/Motorola/Unknown_QIP2500/0,-1.csv
@@ -1,57 +1,57 @@
 functionname,protocol,device,subdevice,function
-KEY_0,G.I. Cable{1},0,-1,0
-KEY_1,G.I. Cable{1},0,-1,1
-KEY_2,G.I. Cable{1},0,-1,2
-KEY_3,G.I. Cable{1},0,-1,3
-KEY_4,G.I. Cable{1},0,-1,4
-KEY_5,G.I. Cable{1},0,-1,5
-KEY_6,G.I. Cable{1},0,-1,6
-KEY_7,G.I. Cable{1},0,-1,7
-KEY_8,G.I. Cable{1},0,-1,8
-KEY_9,G.I. Cable{1},0,-1,9
-KEY_POWER,G.I. Cable{1},0,-1,10
-KEY_CHANNELUP,G.I. Cable{1},0,-1,11
-KEY_CHANNELDOWN,G.I. Cable{1},0,-1,12
-KEY_VOLUMEUP,G.I. Cable{1},0,-1,13
-KEY_VOLUMEDOWN,G.I. Cable{1},0,-1,14
-KEY_MUTE,G.I. Cable{1},0,-1,15
-KEY_OK,G.I. Cable{1},0,-1,17
-KEY_EXIT,G.I. Cable{1},0,-1,18
-KEY_LAST,G.I. Cable{1},0,-1,19
-input,G.I. Cable{1},0,-1,20
-KEY_FAVORITES,G.I. Cable{1},0,-1,21
-function-a,G.I. Cable{1},0,-1,23
-function-a_triangle,G.I. Cable{1},0,-1,23
-ppv,G.I. Cable{1},0,-1,24
-KEY_MENU,G.I. Cable{1},0,-1,25
-vod,G.I. Cable{1},0,-1,26
-dvr_play,G.I. Cable{1},0,-1,27
-dvr_stop,G.I. Cable{1},0,-1,28
-dvr_fastforward,G.I. Cable{1},0,-1,29
-dvr_rewind,G.I. Cable{1},0,-1,30
-dvr_pause,G.I. Cable{1},0,-1,31
-pip_on-off,G.I. Cable{1},0,-1,34
-pip_swap,G.I. Cable{1},0,-1,35
-pip_move,G.I. Cable{1},0,-1,36
-pip_ch-plus,G.I. Cable{1},0,-1,37
-pip_ch-minus,G.I. Cable{1},0,-1,38
-function-b,G.I. Cable{1},0,-1,39
-function-b_square,G.I. Cable{1},0,-1,39
-function-c,G.I. Cable{1},0,-1,40
-function-c_circle,G.I. Cable{1},0,-1,40
-KEY_INFO,G.I. Cable{1},0,-1,48
-dvr_record,G.I. Cable{1},0,-1,49
-KEY_HELP,G.I. Cable{1},0,-1,50
-KEY_INFO,G.I. Cable{1},0,-1,51
-arrow_up,G.I. Cable{1},0,-1,52
-arrow_down,G.I. Cable{1},0,-1,53
-arrow_left,G.I. Cable{1},0,-1,54
-arrow_right,G.I. Cable{1},0,-1,55
-day_plus,G.I. Cable{1},0,-1,56
-day_minus,G.I. Cable{1},0,-1,57
-KEY_PAGEUP,G.I. Cable{1},0,-1,58
-KEY_PAGEDOWN,G.I. Cable{1},0,-1,59
-dvr_replay,G.I. Cable{1},0,-1,60
-dvr_list,G.I. Cable{1},0,-1,61
-dvr_livetv,G.I. Cable{1},0,-1,62
-aspect,G.I. Cable{1},0,-1,64
+KEY_0,G.I.Cable,0,-1,0
+KEY_1,G.I.Cable,0,-1,1
+KEY_2,G.I.Cable,0,-1,2
+KEY_3,G.I.Cable,0,-1,3
+KEY_4,G.I.Cable,0,-1,4
+KEY_5,G.I.Cable,0,-1,5
+KEY_6,G.I.Cable,0,-1,6
+KEY_7,G.I.Cable,0,-1,7
+KEY_8,G.I.Cable,0,-1,8
+KEY_9,G.I.Cable,0,-1,9
+KEY_POWER,G.I.Cable,0,-1,10
+KEY_CHANNELUP,G.I.Cable,0,-1,11
+KEY_CHANNELDOWN,G.I.Cable,0,-1,12
+KEY_VOLUMEUP,G.I.Cable,0,-1,13
+KEY_VOLUMEDOWN,G.I.Cable,0,-1,14
+KEY_MUTE,G.I.Cable,0,-1,15
+KEY_OK,G.I.Cable,0,-1,17
+KEY_EXIT,G.I.Cable,0,-1,18
+KEY_LAST,G.I.Cable,0,-1,19
+input,G.I.Cable,0,-1,20
+KEY_FAVORITES,G.I.Cable,0,-1,21
+function-a,G.I.Cable,0,-1,23
+function-a_triangle,G.I.Cable,0,-1,23
+ppv,G.I.Cable,0,-1,24
+KEY_MENU,G.I.Cable,0,-1,25
+vod,G.I.Cable,0,-1,26
+dvr_play,G.I.Cable,0,-1,27
+dvr_stop,G.I.Cable,0,-1,28
+dvr_fastforward,G.I.Cable,0,-1,29
+dvr_rewind,G.I.Cable,0,-1,30
+dvr_pause,G.I.Cable,0,-1,31
+pip_on-off,G.I.Cable,0,-1,34
+pip_swap,G.I.Cable,0,-1,35
+pip_move,G.I.Cable,0,-1,36
+pip_ch-plus,G.I.Cable,0,-1,37
+pip_ch-minus,G.I.Cable,0,-1,38
+function-b,G.I.Cable,0,-1,39
+function-b_square,G.I.Cable,0,-1,39
+function-c,G.I.Cable,0,-1,40
+function-c_circle,G.I.Cable,0,-1,40
+KEY_INFO,G.I.Cable,0,-1,48
+dvr_record,G.I.Cable,0,-1,49
+KEY_HELP,G.I.Cable,0,-1,50
+KEY_INFO,G.I.Cable,0,-1,51
+arrow_up,G.I.Cable,0,-1,52
+arrow_down,G.I.Cable,0,-1,53
+arrow_left,G.I.Cable,0,-1,54
+arrow_right,G.I.Cable,0,-1,55
+day_plus,G.I.Cable,0,-1,56
+day_minus,G.I.Cable,0,-1,57
+KEY_PAGEUP,G.I.Cable,0,-1,58
+KEY_PAGEDOWN,G.I.Cable,0,-1,59
+dvr_replay,G.I.Cable,0,-1,60
+dvr_list,G.I.Cable,0,-1,61
+dvr_livetv,G.I.Cable,0,-1,62
+aspect,G.I.Cable,0,-1,64

--- a/codes/Motorola/Unknown_RC1445302-00B-REV2/0,-1.csv
+++ b/codes/Motorola/Unknown_RC1445302-00B-REV2/0,-1.csv
@@ -1,73 +1,73 @@
 functionname,protocol,device,subdevice,function
-KEY_0,G.I. Cable{1},0,-1,0
-KEY_1,G.I. Cable{1},0,-1,1
-KEY_1_symbols,G.I. Cable{1},0,-1,1
-KEY_2,G.I. Cable{1},0,-1,2
-KEY_2_abc,G.I. Cable{1},0,-1,2
-KEY_3,G.I. Cable{1},0,-1,3
-KEY_3_def,G.I. Cable{1},0,-1,3
-KEY_4,G.I. Cable{1},0,-1,4
-KEY_4_ghi,G.I. Cable{1},0,-1,4
-KEY_5,G.I. Cable{1},0,-1,5
-KEY_5_jkl,G.I. Cable{1},0,-1,5
-KEY_6,G.I. Cable{1},0,-1,6
-KEY_6_mno,G.I. Cable{1},0,-1,6
-KEY_7,G.I. Cable{1},0,-1,7
-KEY_7_pqrs,G.I. Cable{1},0,-1,7
-KEY_8,G.I. Cable{1},0,-1,8
-KEY_8_tuv,G.I. Cable{1},0,-1,8
-KEY_9,G.I. Cable{1},0,-1,9
-KEY_9_wxyz,G.I. Cable{1},0,-1,9
-KEY_POWER,G.I. Cable{1},0,-1,10
-KEY_CHANNELUP,G.I. Cable{1},0,-1,11
-KEY_PAGEUP,G.I. Cable{1},0,-1,11
-KEY_CHANNELDOWN,G.I. Cable{1},0,-1,12
-KEY_PAGEDOWN,G.I. Cable{1},0,-1,12
-KEY_VOLUMEUP,G.I. Cable{1},0,-1,13
-KEY_VOLUMEDOWN,G.I. Cable{1},0,-1,14
-KEY_MUTE,G.I. Cable{1},0,-1,15
-KEY_OK,G.I. Cable{1},0,-1,17
-KEY_EXIT,G.I. Cable{1},0,-1,18
-KEY_LAST,G.I. Cable{1},0,-1,19
-input_a-v,G.I. Cable{1},0,-1,20
-heart,G.I. Cable{1},0,-1,21
-heart_favorites,G.I. Cable{1},0,-1,21
-KEY_FAVORITES,G.I. Cable{1},0,-1,21
-function-a,G.I. Cable{1},0,-1,23
-function-a_yellow_triangle,G.I. Cable{1},0,-1,23
-KEY_MENU,G.I. Cable{1},0,-1,25
-KEY_NUMERIC_STAR,G.I. Cable{1},0,-1,26
-star_ondemand,G.I. Cable{1},0,-1,26
-KEY_POWER,G.I. Cable{1},0,-1,26
-dvr_play,G.I. Cable{1},0,-1,27
-dvr_stop,G.I. Cable{1},0,-1,28
-dvr_fastforward,G.I. Cable{1},0,-1,29
-dvr_rewind,G.I. Cable{1},0,-1,30
-dvr_pause,G.I. Cable{1},0,-1,31
-pip,G.I. Cable{1},0,-1,34
-change,G.I. Cable{1},0,-1,35
-function-b,G.I. Cable{1},0,-1,39
-function-b_blue_square,G.I. Cable{1},0,-1,39
-function-c,G.I. Cable{1},0,-1,40
-function-c_red_circle,G.I. Cable{1},0,-1,40
-function-d,G.I. Cable{1},0,-1,41
-function-d_green_diamond,G.I. Cable{1},0,-1,41
-KEY_INFO,G.I. Cable{1},0,-1,48
-dvr_record,G.I. Cable{1},0,-1,49
-KEY_INFO,G.I. Cable{1},0,-1,51
-arrow_up,G.I. Cable{1},0,-1,52
-arrow_down,G.I. Cable{1},0,-1,53
-arrow_left,G.I. Cable{1},0,-1,54
-arrow_right,G.I. Cable{1},0,-1,55
-dvr_previous,G.I. Cable{1},0,-1,60
-dvr,G.I. Cable{1},0,-1,61
-fiostv,G.I. Cable{1},0,-1,62
-dvr_next,G.I. Cable{1},0,-1,63
-pound,G.I. Cable{1},0,-1,64
-pound_aspect,G.I. Cable{1},0,-1,64
-KEY_OPTION,G.I. Cable{1},0,-1,66
-KEY_KPPLUS,G.I. Cable{1},0,-1,67
-plus_widgets,G.I. Cable{1},0,-1,67
-widgets,G.I. Cable{1},0,-1,67
-KEY_KPASTERISK,G.I. Cable{1},0,-1,68
-asterisk_cc,G.I. Cable{1},0,-1,68
+KEY_0,G.I.Cable,0,-1,0
+KEY_1,G.I.Cable,0,-1,1
+KEY_1_symbols,G.I.Cable,0,-1,1
+KEY_2,G.I.Cable,0,-1,2
+KEY_2_abc,G.I.Cable,0,-1,2
+KEY_3,G.I.Cable,0,-1,3
+KEY_3_def,G.I.Cable,0,-1,3
+KEY_4,G.I.Cable,0,-1,4
+KEY_4_ghi,G.I.Cable,0,-1,4
+KEY_5,G.I.Cable,0,-1,5
+KEY_5_jkl,G.I.Cable,0,-1,5
+KEY_6,G.I.Cable,0,-1,6
+KEY_6_mno,G.I.Cable,0,-1,6
+KEY_7,G.I.Cable,0,-1,7
+KEY_7_pqrs,G.I.Cable,0,-1,7
+KEY_8,G.I.Cable,0,-1,8
+KEY_8_tuv,G.I.Cable,0,-1,8
+KEY_9,G.I.Cable,0,-1,9
+KEY_9_wxyz,G.I.Cable,0,-1,9
+KEY_POWER,G.I.Cable,0,-1,10
+KEY_CHANNELUP,G.I.Cable,0,-1,11
+KEY_PAGEUP,G.I.Cable,0,-1,11
+KEY_CHANNELDOWN,G.I.Cable,0,-1,12
+KEY_PAGEDOWN,G.I.Cable,0,-1,12
+KEY_VOLUMEUP,G.I.Cable,0,-1,13
+KEY_VOLUMEDOWN,G.I.Cable,0,-1,14
+KEY_MUTE,G.I.Cable,0,-1,15
+KEY_OK,G.I.Cable,0,-1,17
+KEY_EXIT,G.I.Cable,0,-1,18
+KEY_LAST,G.I.Cable,0,-1,19
+input_a-v,G.I.Cable,0,-1,20
+heart,G.I.Cable,0,-1,21
+heart_favorites,G.I.Cable,0,-1,21
+KEY_FAVORITES,G.I.Cable,0,-1,21
+function-a,G.I.Cable,0,-1,23
+function-a_yellow_triangle,G.I.Cable,0,-1,23
+KEY_MENU,G.I.Cable,0,-1,25
+KEY_NUMERIC_STAR,G.I.Cable,0,-1,26
+star_ondemand,G.I.Cable,0,-1,26
+KEY_POWER,G.I.Cable,0,-1,26
+dvr_play,G.I.Cable,0,-1,27
+dvr_stop,G.I.Cable,0,-1,28
+dvr_fastforward,G.I.Cable,0,-1,29
+dvr_rewind,G.I.Cable,0,-1,30
+dvr_pause,G.I.Cable,0,-1,31
+pip,G.I.Cable,0,-1,34
+change,G.I.Cable,0,-1,35
+function-b,G.I.Cable,0,-1,39
+function-b_blue_square,G.I.Cable,0,-1,39
+function-c,G.I.Cable,0,-1,40
+function-c_red_circle,G.I.Cable,0,-1,40
+function-d,G.I.Cable,0,-1,41
+function-d_green_diamond,G.I.Cable,0,-1,41
+KEY_INFO,G.I.Cable,0,-1,48
+dvr_record,G.I.Cable,0,-1,49
+KEY_INFO,G.I.Cable,0,-1,51
+arrow_up,G.I.Cable,0,-1,52
+arrow_down,G.I.Cable,0,-1,53
+arrow_left,G.I.Cable,0,-1,54
+arrow_right,G.I.Cable,0,-1,55
+dvr_previous,G.I.Cable,0,-1,60
+dvr,G.I.Cable,0,-1,61
+fiostv,G.I.Cable,0,-1,62
+dvr_next,G.I.Cable,0,-1,63
+pound,G.I.Cable,0,-1,64
+pound_aspect,G.I.Cable,0,-1,64
+KEY_OPTION,G.I.Cable,0,-1,66
+KEY_KPPLUS,G.I.Cable,0,-1,67
+plus_widgets,G.I.Cable,0,-1,67
+widgets,G.I.Cable,0,-1,67
+KEY_KPASTERISK,G.I.Cable,0,-1,68
+asterisk_cc,G.I.Cable,0,-1,68

--- a/codes/One For All/Unknown_For/0,-1.csv
+++ b/codes/One For All/Unknown_For/0,-1.csv
@@ -1,39 +1,39 @@
 functionname,protocol,device,subdevice,function
-KEY_0,G.I. Cable{1},0,-1,0
-KEY_1,G.I. Cable{1},0,-1,1
-KEY_2,G.I. Cable{1},0,-1,2
-KEY_3,G.I. Cable{1},0,-1,3
-KEY_4,G.I. Cable{1},0,-1,4
-KEY_5,G.I. Cable{1},0,-1,5
-KEY_6,G.I. Cable{1},0,-1,6
-KEY_7,G.I. Cable{1},0,-1,7
-KEY_8,G.I. Cable{1},0,-1,8
-KEY_9,G.I. Cable{1},0,-1,9
-KEY_POWER,G.I. Cable{1},0,-1,10
-KEY_CHANNELUP,G.I. Cable{1},0,-1,11
-KEY_CHANNELDOWN,G.I. Cable{1},0,-1,12
-KEY_VOLUMEUP,G.I. Cable{1},0,-1,13
-KEY_VOLUMEDOWN,G.I. Cable{1},0,-1,14
-KEY_MUTE,G.I. Cable{1},0,-1,15
-KEY_ENTER,G.I. Cable{1},0,-1,16
-KEY_OK,G.I. Cable{1},0,-1,17
-KEY_EXIT,G.I. Cable{1},0,-1,18
-KEY_PREVIOUS,G.I. Cable{1},0,-1,19
-input,G.I. Cable{1},0,-1,20
-KEY_MENU,G.I. Cable{1},0,-1,25
-KEY_PLAY,G.I. Cable{1},0,-1,27
-KEY_STOP,G.I. Cable{1},0,-1,28
-KEY_FORWARD,G.I. Cable{1},0,-1,29
-KEY_REWIND,G.I. Cable{1},0,-1,30
-KEY_PAUSE,G.I. Cable{1},0,-1,31
-KEY_INFO,G.I. Cable{1},0,-1,48
-KEY_RECORD,G.I. Cable{1},0,-1,49
-KEY_INFO,G.I. Cable{1},0,-1,51
-KEY_UP,G.I. Cable{1},0,-1,52
-KEY_DOWN,G.I. Cable{1},0,-1,53
-KEY_LEFT,G.I. Cable{1},0,-1,54
-KEY_RIGHT,G.I. Cable{1},0,-1,55
-f.rew,G.I. Cable{1},0,-1,60
-cc,G.I. Cable{1},0,-1,61
-format,G.I. Cable{1},0,-1,62
-f.fwd,G.I. Cable{1},0,-1,63
+KEY_0,G.I.Cable,0,-1,0
+KEY_1,G.I.Cable,0,-1,1
+KEY_2,G.I.Cable,0,-1,2
+KEY_3,G.I.Cable,0,-1,3
+KEY_4,G.I.Cable,0,-1,4
+KEY_5,G.I.Cable,0,-1,5
+KEY_6,G.I.Cable,0,-1,6
+KEY_7,G.I.Cable,0,-1,7
+KEY_8,G.I.Cable,0,-1,8
+KEY_9,G.I.Cable,0,-1,9
+KEY_POWER,G.I.Cable,0,-1,10
+KEY_CHANNELUP,G.I.Cable,0,-1,11
+KEY_CHANNELDOWN,G.I.Cable,0,-1,12
+KEY_VOLUMEUP,G.I.Cable,0,-1,13
+KEY_VOLUMEDOWN,G.I.Cable,0,-1,14
+KEY_MUTE,G.I.Cable,0,-1,15
+KEY_ENTER,G.I.Cable,0,-1,16
+KEY_OK,G.I.Cable,0,-1,17
+KEY_EXIT,G.I.Cable,0,-1,18
+KEY_PREVIOUS,G.I.Cable,0,-1,19
+input,G.I.Cable,0,-1,20
+KEY_MENU,G.I.Cable,0,-1,25
+KEY_PLAY,G.I.Cable,0,-1,27
+KEY_STOP,G.I.Cable,0,-1,28
+KEY_FORWARD,G.I.Cable,0,-1,29
+KEY_REWIND,G.I.Cable,0,-1,30
+KEY_PAUSE,G.I.Cable,0,-1,31
+KEY_INFO,G.I.Cable,0,-1,48
+KEY_RECORD,G.I.Cable,0,-1,49
+KEY_INFO,G.I.Cable,0,-1,51
+KEY_UP,G.I.Cable,0,-1,52
+KEY_DOWN,G.I.Cable,0,-1,53
+KEY_LEFT,G.I.Cable,0,-1,54
+KEY_RIGHT,G.I.Cable,0,-1,55
+f.rew,G.I.Cable,0,-1,60
+cc,G.I.Cable,0,-1,61
+format,G.I.Cable,0,-1,62
+f.fwd,G.I.Cable,0,-1,63

--- a/codes/US Electronics/Cable Box/0,-1.csv
+++ b/codes/US Electronics/Cable Box/0,-1.csv
@@ -1,38 +1,38 @@
 functionname,protocol,device,subdevice,function
-0,G.I. Cable,0,-1,0
-1,G.I. Cable,0,-1,1
-2,G.I. Cable,0,-1,2
-3,G.I. Cable,0,-1,3
-4,G.I. Cable,0,-1,4
-5,G.I. Cable,0,-1,5
-6,G.I. Cable,0,-1,6
-7,G.I. Cable,0,-1,7
-8,G.I. Cable,0,-1,8
-9,G.I. Cable,0,-1,9
-POWER,G.I. Cable,0,-1,10
-CHANNEL +,G.I. Cable,0,-1,11
-CHANNEL -,G.I. Cable,0,-1,12
+0,G.I.Cable,0,-1,0
+1,G.I.Cable,0,-1,1
+2,G.I.Cable,0,-1,2
+3,G.I.Cable,0,-1,3
+4,G.I.Cable,0,-1,4
+5,G.I.Cable,0,-1,5
+6,G.I.Cable,0,-1,6
+7,G.I.Cable,0,-1,7
+8,G.I.Cable,0,-1,8
+9,G.I.Cable,0,-1,9
+POWER,G.I.Cable,0,-1,10
+CHANNEL +,G.I.Cable,0,-1,11
+CHANNEL -,G.I.Cable,0,-1,12
 MUTE,RC5,0,-1,13
-MUSIC/ENTER,G.I. Cable,0,-1,16
+MUSIC/ENTER,G.I.Cable,0,-1,16
 VOLUME +,RC5,0,-1,16
-OK,G.I. Cable,0,-1,17
+OK,G.I.Cable,0,-1,17
 VOLUME -,RC5,0,-1,17
-EXIT,G.I. Cable,0,-1,18
-LAST,G.I. Cable,0,-1,19
-FAV,G.I. Cable,0,-1,21
-LOCK,G.I. Cable,0,-1,22
-A,G.I. Cable,0,-1,23
-MENU,G.I. Cable,0,-1,25
-B,G.I. Cable,0,-1,39
-C,G.I. Cable,0,-1,40
-GUIDE,G.I. Cable,0,-1,48
-HELP,G.I. Cable,0,-1,50
-INFO,G.I. Cable,0,-1,51
-CURSOR UP,G.I. Cable,0,-1,52
-CURSOR DOWN,G.I. Cable,0,-1,53
-CURSOR LEFT,G.I. Cable,0,-1,54
-CURSOR RIGHT,G.I. Cable,0,-1,55
-DAY +,G.I. Cable,0,-1,56
-DAY -,G.I. Cable,0,-1,57
-PAGE -,G.I. Cable,0,-1,58
-PAGE +,G.I. Cable,0,-1,59
+EXIT,G.I.Cable,0,-1,18
+LAST,G.I.Cable,0,-1,19
+FAV,G.I.Cable,0,-1,21
+LOCK,G.I.Cable,0,-1,22
+A,G.I.Cable,0,-1,23
+MENU,G.I.Cable,0,-1,25
+B,G.I.Cable,0,-1,39
+C,G.I.Cable,0,-1,40
+GUIDE,G.I.Cable,0,-1,48
+HELP,G.I.Cable,0,-1,50
+INFO,G.I.Cable,0,-1,51
+CURSOR UP,G.I.Cable,0,-1,52
+CURSOR DOWN,G.I.Cable,0,-1,53
+CURSOR LEFT,G.I.Cable,0,-1,54
+CURSOR RIGHT,G.I.Cable,0,-1,55
+DAY +,G.I.Cable,0,-1,56
+DAY -,G.I.Cable,0,-1,57
+PAGE -,G.I.Cable,0,-1,58
+PAGE +,G.I.Cable,0,-1,59


### PR DESCRIPTION
"G.I. Cable" was probably generated by DecodeIR, is not renderable; "G.I.Cable" (i.e. without the space) is.

"G.I. Cable{1}" denotes an incomplete learn of DecodeIR.

In some cases (like Marantz TV), these commands are intermixed with RC5 commands, which suggests that some may be erroneous... 