### PR TITLE
Create CD63SE

### DIFF
--- a/codes/Marantz/CD Player/CD63SE
+++ b/codes/Marantz/CD Player/CD63SE
@@ -1,0 +1,31 @@
+functionname	protocol	device	subdevice	function
+0	RC5	20	-1	0
+1	RC5	20	-1	1
+2	RC5	20	-1	2
+3	RC5	20	-1	3
+4	RC5	20	-1	4
+5	RC5	20	-1	5
+6	RC5	20	-1	6
+7	RC5	20	-1	7
+8	RC5	20	-1	8
+9	RC5	20	-1	9
+Time	RC5	20	-1	11
+Recall	RC5	20	-1	15
+Volume Up	RC5	20	-1	16
+Volume Down	RC5	20	-1	17
+Random	RC5	20	-1	28
+Repeat	RC5	20	-1	29
+Skip Forward	RC5	20	-1	32
+Skip Back	RC5	20	-1	33
+Prog	RC5	20	-1	41
+AMS	RC5	20	-1	43
+Open / Close	RC5	20	-1	45
+Pause	RC5	20	-1	48
+Cancel	RC5	20	-1	49
+RewindFast Backward	RC5	20	-1	50
+Fast Forward	RC5	20	-1	52
+Play	RC5	20	-1	53
+Stop	RC5	20	-1	54
+A-B	RC5	20	-1	59
+Dimmer	RC5	20	-1	71
+Edit	RC5	20	-1	104


### PR DESCRIPTION
Marantz CD Player 63SE probably compatible with other 90s Marantz CD players. Captured in Irscrutinizer