### PR TITLE
Added A010 (unknown brand) IR RGB Controller

### DIFF
--- a/codes/General/Unknown IR RGB Controller A010/0,-1.csv.csv
+++ b/codes/General/Unknown IR RGB Controller A010/0,-1.csv.csv
@@ -1,0 +1,25 @@
+functionname,protocol,device,subdevice,function
+Brighter,NEC1,0,-1,5
+Darker,NEC1,0,-1,4
+Off,NEC1,0,-1,6
+On,NEC1,0,-1,7
+White,NEC1,0,-1,11
+Flash,NEC1,0,-1,15
+Strobe,NEC1,0,-1,23
+Fade,NEC1,0,-1,27
+Smooth,NEC1,0,-1,19
+Red,NEC1,0,-1,9
+Green,NEC1,0,-1,8
+Blue,NEC1,0,-1,10
+Orange,NEC1,0,-1,13
+Mint,NEC1,0,-1,12
+Saphire,NEC1,0,-1,14
+Mango,NEC1,0,-1,21
+Middle blue,NEC1,0,-1,20
+Violet,NEC1,0,-1,22
+Tangerine,NEC1,0,-1,25
+Picton blue,NEC1,0,-1,24
+Rose Quartz,NEC1,0,-1,26
+Yellow,NEC1,0,-1,17
+Cyan,NEC1,0,-1,16
+Pink,NEC1,0,-1,18


### PR DESCRIPTION
This PR adds IR codes for the A010 IR RGB controller that is sold all over the place under different names (if at all).

![image](https://github.com/user-attachments/assets/069b0a01-295b-4108-aa91-12b619ab3483)

* [Amazon](https://www.amazon.com/GALYGG-Controller-Wireless-Flexible-Lighting/dp/B06Y3Y1HTT/ref=sxin_16_pa_sp_search_thematic_sspa)
* [Amazon](https://www.amazon.com/SUPERNIGHT-Remote-Controller-Dimmer-Lights/dp/B08SHFJ94V/ref=sr_1_11)
* [Amazon](https://www.amazon.com/Yiliaw-Controller-Wireless-Rectifier-Flexible/dp/B08978NS3N/ref=sr_1_22)
* [LedStripKoning (dutch)](https://www.ledstripkoning.nl/accessoires/rgb-afstandsbedieningen/24-knops-afstandsbediening-ir)
* [AliExpress](https://nl.aliexpress.com/item/1005006661409487.html)
* [GreenIce](https://greenice.com/nl/controllers-voor-led-strips/1784-brico-ip20-serie-rgb-afstandsbedieningcontroller-pl219000rgb-8435402513940.html)
* [LightInTheBox](https://www.lightinthebox.com/p/led-strip-lights-diy-controller-24-keys-ir-rgb-control-box-receiver-ir-remote-dimmer-dc12v-6a-for-rgb-2835-3528-5050-beads_p7282169.htm)
* [ABC LED (dutch)](https://www.abc-led.nl/webshop/led-aansluitmateriaal--benodigdheden/rgb-led-controllers--dimmers/detail/81/24-key-led-ir-controller-rgb.html)
* [Diamant LED (dutch)](https://diamantled.nl/led-rgb-strip-24-knops-afstandsbediening-ir-2-uitgangen.html)
* [BOL (dutch)](https://www.bol.com/nl/nl/p/led-rgb-strip-24-knops-afstandsbediening-ir/9300000075006847/)

Edit: Oh, crap, just noticed I was on an old branch. Shouldn't matter.