### PR TITLE
Added Sharp LC-20SH1E

### DIFF
--- a/codes/Sharp/TV/LC-20SH1E/1,-1.csv
+++ b/codes/Sharp/TV/LC-20SH1E/1,-1.csv
@@ -27,10 +27,10 @@ Menu,Sharp,17,-1,198
 8,Sharp,1,-1,8
 9,Sharp,1,-1,9
 0,Sharp,1,-1,10
-Red, Picture Menu,Sharp,1,-1,72
-Green, Sound Menu,Sharp,1,-1,73
+Red - Picture Menu,Sharp,1,-1,72
+Green - Sound Menu,Sharp,1,-1,73
 Yellow,Sharp,1,-1,74
-Blue, Status Display,Sharp,1,-1,75
+Blue - Status Display,Sharp,1,-1,75
 Flashback,Sharp,1,-1,39
 Subpage,Sharp,30,-1,205
 Teletext,Sharp,1,-1,52

--- a/codes/Sharp/TV/LC-20SH1E/1,-1.csv
+++ b/codes/Sharp/TV/LC-20SH1E/1,-1.csv
@@ -1,0 +1,39 @@
+functionname,protocol,device,subdevice,function
+Power,Sharp,1,-1,22
+I / II / I + II / CD,Sharp,1,-1,24
+Backlight,Sharp,30,-1,139
+Rotate,Sharp,30,-1,140
+Input Up,Sharp,1,-1,19
+Input Down,Sharp,17,-1,115
+Volume Up,Sharp,1,-1,20
+Volume Down,Sharp,1,-1,21
+Mute,Sharp,1,-1,23
+Channel Up,Sharp,1,-1,17
+Channel Down,Sharp,1,-1,18
+Up,Sharp,1,-1,87
+Left,Sharp,1,-1,215
+Right,Sharp,1,-1,216
+Down,Sharp,1,-1,32
+Ok,Sharp,1,-1,82
+End,Sharp,1,-1,245
+Menu,Sharp,17,-1,198
+1,Sharp,1,-1,1
+2,Sharp,1,-1,2
+3,Sharp,1,-1,3
+4,Sharp,1,-1,4
+5,Sharp,1,-1,5
+6,Sharp,1,-1,6
+7,Sharp,1,-1,7
+8,Sharp,1,-1,8
+9,Sharp,1,-1,9
+0,Sharp,1,-1,10
+Red, Picture Menu,Sharp,1,-1,72
+Green, Sound Menu,Sharp,1,-1,73
+Yellow,Sharp,1,-1,74
+Blue, Status Display,Sharp,1,-1,75
+Flashback,Sharp,1,-1,39
+Subpage,Sharp,30,-1,205
+Teletext,Sharp,1,-1,52
+Reveal,Sharp,1,-1,56
+Hold,Sharp,1,-1,51
+Subtitle,Sharp,30,-1,159


### PR DESCRIPTION
I'm not quite sure if this needs to be `Sharp` or `Sharp{1}`; most buttons detect both ways, sometimes it's the first, sometimes the latter. However, the press duration doesn't seem to always matter...

Remote: `GA339WJSA`

![GA339WJSA](https://github.com/user-attachments/assets/e06c8e10-f390-41cf-86c1-65a5c18f0d0b)
