### PR TITLE
Add Ezcoo EZ-MX42HAS-EARC HDMI Matrix Switch

### DIFF
--- a/codes/Ezcoo/HDMI Matrix Switch 4x2 ARC/128,-1.csv
+++ b/codes/Ezcoo/HDMI Matrix Switch 4x2 ARC/128,-1.csv
@@ -1,0 +1,12 @@
+function,protocol,device,subdevice,function
+   OUT1_IN1,nec1,128,-1,1
+   OUT1_IN2,nec1,128,-1,4
+   OUT1_IN3,nec1,128,-1,2
+   OUT1_IN4,nec1,128,-1,13
+   OUT1_CYCLE,nec1,128,-1,26
+   OUT2_IN1,nec1,128,-1,10
+   OUT2_IN2,nec1,128,-1,0
+   OUT2_IN3,nec1,128,-1,27
+   OUT2_IN4,nec1,128,-1,5
+   OUT2_CYCLE,nec1,128,-1,31
+   POWER_TOGGLE,nec1,128,-1,3


### PR DESCRIPTION
- Model: EZ-MX42HAS-EARC
   - Type: 4x2 HDMI Matrix Switch
   - Protocol: NEC (nec1)
   - Device: 128 (0x80)
   - Codes: 11 functions verified
   - Firmware: v1.04
   - Verified: 100% tested with serial monitoring