### PR TITLE
Add LG SP7R soundbar IR codes (Model: AKB76038001)

### DIFF
--- a/codes/LG/Soundbar/SP7R.csv
+++ b/codes/LG/Soundbar/SP7R.csv
@@ -1,0 +1,16 @@
+functionname,protocol,device,subdevice,function
+Power,NEC1,44,-1,30
+Mute,NEC1,44,-1,31
+Input,NEC1,44,-1,138
+Volume Up,NEC1,44,-1,23
+Volume Down,NEC1,44,-1,22
+EQ Setting,NEC1,44,-1,47
+Bluetooth,NEC1,44,-1,76
+Menu,NEC1,44,-1,163
+Speaker Level,NEC1,44,-1,152
+Settings,NEC1,44,-1,165
+Up,NEC1,44,-1,167
+Down,NEC1,44,-1,166
+Left,NEC1,44,-1,168
+Right,NEC1,44,-1,169
+Enter,NEC1,44,-1,170


### PR DESCRIPTION
Adding IR codes for LG SP7R 7.1 channel soundbar
Remote Model: AKB76038001
Protocol: NEC
Address: 0x2C (44 decimal)

All 15 buttons captured and tested working.
Includes: Power, Mute, Input, Volume±, EQ, Bluetooth, Menu, Speaker Level, Settings, Navigation (Up/Down/Left/Right/Enter)